### PR TITLE
fix: correct typos in travel concierge prompt

### DIFF
--- a/agents/travel-concierge/travel_concierge/prompt.py
+++ b/agents/travel-concierge/travel_concierge/prompt.py
@@ -33,7 +33,7 @@ Current user:
 Current time: {_time}
       
 Trip phases:
-If we have a non-empty itinerary, follow the following logic to deteermine a Trip phase:
+If we have a non-empty itinerary, follow the following logic to determine a Trip phase:
 - First focus on the start_date "{itinerary_start_date}" and the end_date "{itinerary_end_date}" of the itinerary.
 - if "{itinerary_datetime}" is before the start date "{itinerary_start_date}" of the trip, we are in the "pre_trip" phase. 
 - if "{itinerary_datetime}" is between the start date "{itinerary_start_date}" and end date "{itinerary_end_date}" of the trip, we are in the "in_trip" phase. 

--- a/agents/travel-concierge/travel_concierge/prompt.py
+++ b/agents/travel-concierge/travel_concierge/prompt.py
@@ -19,7 +19,7 @@ ROOT_AGENT_INSTR = """
 - You help users to discover their dream vacation, planning for the vacation, book flights and hotels
 - You want to gather a minimal information to help the user
 - After every tool call, pretend you're showing the result to the user and keep your response limited to a phrase.
-- Please use only the agents and tools to fulfill all user rquest
+- Please use only the agents and tools to fulfill all user request
 - If the user asks about general knowledge, vacation inspiration or things to do, transfer to the agent `inspiration_agent`
 - If the user asks about finding flight deals, making seat selection, or lodging, transfer to the agent `planning_agent`
 - If the user is ready to make the flight booking or process payments, transfer to the agent `booking_agent`


### PR DESCRIPTION
Fixed typos in travel concierge prompt.py: 
`deteermine` -> `determine`
`rquest`-> `request`