### PR TITLE
Fixed Required packages for FOMC Agent example

### DIFF
--- a/agents/fomc-research/README.md
+++ b/agents/fomc-research/README.md
@@ -94,7 +94,7 @@ to implement this workflow.
 
     Install the FOMC Research agent requirements:
     ```bash
-    poetry install
+    pip install poetry pdfplumber diff_match_patch
     ```
 
     This will also install the released version of 'google-adk', the Google Agent Development Kit.


### PR DESCRIPTION
There were 2 more packages missing to run this agent and they were not mentioned in the readme file, so added there