### PR TITLE
make poetry installation instruction more clear

### DIFF
--- a/agents/fomc-research/README.md
+++ b/agents/fomc-research/README.md
@@ -90,7 +90,11 @@ to implement this workflow.
     cd adk-samples/agents/fomc-research
     ```
 
-    Install [Poetry](https://python-poetry.org).
+    Install [Poetry](https://python-poetry.org)
+    If you have not installed poetry before then run:
+    ```bash
+    pip install poetry
+    ```
 
     Install the FOMC Research agent requirements:
     ```bash

--- a/agents/fomc-research/README.md
+++ b/agents/fomc-research/README.md
@@ -91,7 +91,7 @@ to implement this workflow.
     ```
 
     Install [Poetry](https://python-poetry.org)
-    If you have not installed poetry before then run:
+    If you have not installed poetry before, you can do so by running:
     ```bash
     pip install poetry
     ```


### PR DESCRIPTION
One of the users had issues installing dependencies , upon investigation we noticed that the user missed the step for installing poetry first. We now made the instructions a bit more clear.