### PR TITLE
Implement a demo of a sub-agent that uses an MCP tool

### DIFF
--- a/agents/travel-concierge/sub-agent-mcp-demo/__init__.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/agents/travel-concierge/sub-agent-mcp-demo/agent.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/agent.py
@@ -1,0 +1,82 @@
+import os
+from fastapi import FastAPI
+from pydantic import BaseModel
+from dotenv import load_dotenv
+from google.adk.agents.llm_agent import Agent
+from google.adk.models.lite_llm import LiteLlm
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
+from google.genai import types
+from sub_agent.planning_agent import create_planning
+from sub_agent.weather_agent import create_weather
+from sub_agent.tools.weather import get_mcp_tools, close_mcp_connection
+import prompt
+
+load_dotenv()
+
+app = FastAPI()
+
+# Define the request model for user input
+class QueryRequest(BaseModel):
+    query: str
+
+
+session_service = InMemorySessionService()
+artifacts_service = InMemoryArtifactService()
+
+# init the root agent
+root_agent = Agent(
+    model=LiteLlm(
+        model="azure/gpt-4o",
+        api_key=os.getenv("AZURE_API_KEY"),
+        api_base=os.getenv("AZURE_API_ENDPOINT"),
+        api_version=os.getenv("AZURE_API_VERSION")
+    ),
+    name="root_agent",
+    description="Travel concierge services using multiple sub-agents",
+    instruction=prompt.ROOT_AGENT_INSTR,
+    sub_agents=[
+        create_planning,
+        create_weather
+    ]
+)
+
+# On app startup: load MCP tools and assign to the weather agent
+@app.on_event("startup")
+async def init_weather_tool():
+    tools = await get_mcp_tools()
+    create_weather.tools = tools
+
+# On app shutdown: cleanly close the MCP tool connection
+@app.on_event("shutdown")
+async def shutdown_cleanup():
+    await close_mcp_connection()
+
+@app.post("/ask")
+async def ask_agent(request: QueryRequest):
+    session = session_service.create_session(
+        state={}, app_name="mcp_app", user_id="user"
+    )
+
+    content = types.Content(role="user", parts=[types.Part(text=request.query)])
+
+    runner = Runner(
+        app_name="mcp_app",
+        agent=root_agent,
+        artifact_service=artifacts_service,
+        session_service=session_service,
+    )
+
+    events_async = runner.run_async(
+        session_id=session.id, user_id="user", new_message=content
+    )
+
+    response = []
+    async for event in events_async:
+        if event.content:
+            for part in event.content.parts:
+                if part.text:
+                    response.append(part.text)
+
+    return {"response": "\n".join(response)}

--- a/agents/travel-concierge/sub-agent-mcp-demo/prompt.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/prompt.py
@@ -1,0 +1,15 @@
+ROOT_AGENT_INSTR = """
+- You are a dedicated itinerary planning agent
+- You help users discover local attractions, plan their trips, and check weather information
+- You want to gather minimal information to assist the user effectively
+- After every tool call, pretend you're showing the result to the user and keep your response limited to a phrase
+- Please use only the agents and tools to fulfill all user requests
+
+- If the user asks about things to do or places to visit, transfer to the agent `planning_agent`
+- If the user asks about weather conditions, transfer to the agent `weather_agent`
+
+- When returning information to the user, format the results as bullet points (list-style) to ensure clarity and readability.
+
+Once the trip phase is known, delegate control of the dialog to the appropriate agent:
+pre_trip, in_trip, post_trip.
+"""

--- a/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/planning_agent.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/planning_agent.py
@@ -1,0 +1,28 @@
+from . import prompt
+import os
+
+from google.adk.agents import Agent
+from google.genai import types
+from google.adk.models.lite_llm import LiteLlm
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+load_dotenv()
+
+create_planning = Agent(
+    model=LiteLlm(
+        model="azure/gpt-4o",
+        api_key=os.getenv("AZURE_API_KEY"),
+        api_base=os.getenv("AZURE_API_ENDPOINT"),
+        api_version=os.getenv("AZURE_API_VERSION")
+    ),
+    name="planning_agent",
+    description="""
+     Responsible for planning and creating transportation or travel reservations
+     (such as flights, high-speed rail, or shuttle services) based on the user's 
+     itinerary and preferences, ensuring the user arrives at the destination smoothly and on time.
+     """,
+    instruction=prompt.PLANNING_INSTR_TEMPLATE,
+    output_key="place",
+)
+

--- a/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/prompt.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/prompt.py
@@ -1,0 +1,21 @@
+WEATHER_INSTR_TEMPLATE = """
+You are a weather agent.
+
+Your job is to retrieve weather details, including temperature and conditions, for a specified location.
+
+When the user asks about the weather:
+- Use the MCP tools provided via `get_tools_async` to retrieve weather information.
+
+Arguments:
+- location (str): The city or location to retrieve the weather for.
+
+Keep responses concise and structured for easy reading.
+"""
+
+
+PLANNING_INSTR_TEMPLATE = """
+You are responsible for making suggestions on vacation inspirations and recommendations based on the user's query. Limit the choices to 3 results.
+Each place must have a name, its country, a URL to an image of it, a brief descriptive highlight, and a rating which rates from 1 to 5, incremented in 1/10th points.
+
+Present the output in a clear, user-friendly bullet point format. Each result should be easy to read and visually separated from the others.
+"""

--- a/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/tools/weather.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/tools/weather.py
@@ -1,0 +1,16 @@
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, SseServerParams
+
+mcp_exit_stack = None
+
+# Asynchronous function to get tools from a remote MCP Agent server
+async def get_mcp_tools():
+    global mcp_exit_stack
+    tools, mcp_exit_stack = await MCPToolset.from_server(
+        connection_params=SseServerParams(url="")  # Fill in the mcp URL here
+    )
+    return tools
+
+# Asynchronous function to gracefully close the MCP connection
+async def close_mcp_connection():
+    if mcp_exit_stack:
+        await mcp_exit_stack.aclose()

--- a/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/weather_agent.py
+++ b/agents/travel-concierge/sub-agent-mcp-demo/sub_agent/weather_agent.py
@@ -1,0 +1,23 @@
+from . import prompt
+import os
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+weather_tool = []
+
+create_weather = Agent(
+    model=LiteLlm(
+        model="azure/gpt-4o",
+        api_key=os.getenv("AZURE_API_KEY"),
+        api_base=os.getenv("AZURE_API_ENDPOINT"),
+        api_version=os.getenv("AZURE_API_VERSION")
+    ),
+    name="weather_agent",
+    description="Provides weather forecasts using MCP tools.",
+    instruction=prompt.WEATHER_INSTR_TEMPLATE,
+    tools= weather_tool
+)


### PR DESCRIPTION
In file \agents\travel-concierge\sub-agent-mcp-demo
This is a travel agent with two sub-agents. One sub-agent is responsible for generating local attraction recommendations, while the other connects to our self-hosted weather MCP server. (Since the server is not publicly accessible, you may need to find another MCP server for testing purposes.)
