### PR TITLE
Fix typos in agents readme files

### DIFF
--- a/agents/RAG/README.md
+++ b/agents/RAG/README.md
@@ -233,7 +233,7 @@ After deploying the agent, you'll be able to read the following INFO log message
 Deployed agent to Vertex AI Agent Engine successfully, resource name: projects/<PROJECT_NUMBER>/locations/us-central1/reasoningEngines/<AGENT_ENGINE_ID>
 ```
 
-Please note your Agent Engine resource name and update `.env` file accordingly as this is crutial for testing the remote agent.
+Please note your Agent Engine resource name and update `.env` file accordingly as this is crucial for testing the remote agent.
 
 You may also modify the deployment script for your use cases.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -8,7 +8,7 @@ Each folder in this directory contains a different agent sample.
 
 1.  **Prerequisites:**
 
-    *   "Ensure you have installed and configured the Agent Development Kit (ADK). See the [ADK Quickstart Guide](https://google.github.io/adk-docs/get-started/quickstart/).
+    *   "Ensure you have installed and configured the Agent Development Kit (ADK). See the [ADK Quickstart Guide](https://google.github.io/adk-docs/get-started/quickstart/)."
     *   "Python 3.9+ and [Poetry](https://python-poetry.org/docs/#installation) installed."
     *   "Access to Google Cloud (Vertex AI) and/or a Gemini API Key (depending on the agent - see individual agent READMEs)."
 

--- a/agents/customer-service/README.md
+++ b/agents/customer-service/README.md
@@ -26,7 +26,7 @@ The agent is built using a multi-modal architecture, combining text and video in
 
 It is important to notice that this agent is not integrated to an actual backend and the behaviour is based on mocked tools. If you would like to implement this agent with actual backend integration you will need to edit [customer_service/tools.py](./customer_service/tools/tools.py)
 
-Because the tools are mocked you might notice that some reuqested changes will not be applied. For instance newly added item to cart will not show if later a user asks the agent to list all items.
+Because the tools are mocked you might notice that some requested changes will not be applied. For instance newly added item to cart will not show if later a user asks the agent to list all items.
 
 ### Key Features
 
@@ -137,7 +137,7 @@ The agent has access to the following tools:
     - Set the `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` environment variables. You can set them in your `.env` file (modify and rename .env_sample file to .env) or directly in your shell. Alternatively you can edit [customer_service/config.py](./customer_service/config.py)
 
     ```bash
-    export GOOGLE_CLOUD_PROJECT=YOUR_ROJECT_NAME_HERE
+    export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_NAME_HERE
     export GOOGLE_GENAI_USE_VERTEXAI=1
     export GOOGLE_CLOUD_LOCATION=us-central1
     ```
@@ -242,7 +242,7 @@ In order to inherit all dependencies of your agent you can build the wheel file 
     ```
 
 1.  **Deploy the agent to agents engine**
-    It is importand to run deploy.py from withing deployment folder so paths are correct
+    It is important to run deploy.py from within deployment folder so paths are correct
 
     ```bash
     cd deployment
@@ -267,7 +267,7 @@ vertexai.init(
 )
 
 # get the agent based on resource id
-agent_engine = vertexai.agent_engines.get('DEPLOYMENT_RESOURSE_NAME') # looks like this projects/PROJECT_ID/locations/LOCATION/reasoningEngines/REASONING_ENGINE_ID
+agent_engine = vertexai.agent_engines.get('DEPLOYMENT_RESOURCE_NAME') # looks like this projects/PROJECT_ID/locations/LOCATION/reasoningEngines/REASONING_ENGINE_ID
 
 for event in remote_agent.stream_query(
     user_id=USER_ID,

--- a/agents/data-science/README.md
+++ b/agents/data-science/README.md
@@ -100,7 +100,7 @@ The key features of the Data Science Multi-Agent include:
 
     *   First, set the BigQuery project ID in the `.env` file. This can be the same GCP Project you use for `GOOGLE_CLOUD_PROJECT`,
         but you can use other BigQuery projects as well, as long as you have access permissions to that project.
-        If you have an existig BigQuery table you wish to connect, specify the `BQ_DATASET_ID` in the `.env` file as well.
+        If you have an existing BigQuery table you wish to connect, specify the `BQ_DATASET_ID` in the `.env` file as well.
         Make sure you leave `BQ_DATASET_ID='forecasting_sticker_sales'` if you wish to use the sample data.
 
         Alternatively, you can set the variables from your terminal:
@@ -295,7 +295,7 @@ The last sequence of digits is the AgentEngine resource ID.
 
 Once you have successfully deployed your agent, you can interact with it
 using the `test_deployment.py` script in the `deployment` directory. Store the
-agent's resource ID in an enviroment variable and run the following command:
+agent's resource ID in an environment variable and run the following command:
 
 ```bash
 export RESOURCE_ID=...

--- a/agents/fomc-research/README.md
+++ b/agents/fomc-research/README.md
@@ -236,7 +236,7 @@ The last sequence of digits is the AgentEngine resource ID.
 
 Once you have successfully deployed your agent, you can interact with it
 using the `test_deployment.py` script in the `deployment` directory. Store the
-agent's resource ID in an enviroment variable and run the following command:
+agent's resource ID in an environment variable and run the following command:
 ```bash
 export RESOURCE_ID=...
 export USER_ID=<any string>

--- a/agents/llm-auditor/README.md
+++ b/agents/llm-auditor/README.md
@@ -143,7 +143,7 @@ for event in runner.run(
         print(part.text)
 ```
 
-You may aslo utilize `google.adk.Runner` to have fine-grained control on
+You may also utilize `google.adk.Runner` to have fine-grained control on
 interaction sessions and more, or wrap the agent in a
 `vertexai.preview.reasoning_engines.AdkApp`.
 
@@ -272,7 +272,7 @@ python3 -m pytest eval
 `tests` runs the agent on a sample request, and makes sure that every component
 is functional. `eval` is a demonstration of how to evaluate the agent, using the
 `AgentEvaluator` in ADK. It sends a couple requests to the agent and expects
-that the agent's responses match a pre-defined response reasonablly well.
+that the agent's responses match a pre-defined response reasonably well.
 
 
 ## Deployment

--- a/agents/personalized-shopping/README.md
+++ b/agents/personalized-shopping/README.md
@@ -37,7 +37,7 @@ The agent’s default configuration allows you to simulate interactions with a f
 
 The key features of the personalized-shopping agent include:
 *  **Environment:** The agent can interact in a e-commerce web environment with 1.18M of products.
-*  **Memory:** The agent maintain a conversational memory with all the previous-turns information in its context window.
+*  **Memory:** The agent maintains a conversational memory with all the previous-turns information in its context window.
 *  **Tools:**
 
     _Search_: The agent has access to a search-retrieval engine, where it can perform key-word search for the related products.

--- a/agents/travel-concierge/README.md
+++ b/agents/travel-concierge/README.md
@@ -39,8 +39,8 @@ Expand on the "Key Components" from above.
     * `planning_agent` - Given a destination, start date, and duration, the planning agent helps the user select flights, seats and a hotel (mocked), then generate an itinerary containing the activities.
     * `booking_agent` - Given an itinerary, the booking agent will help process those items in the itinerary that requires payment.
     * `pre_trip_agent` - Intended to be invoked regularly before the trip starts; This agent fetches relevant trip information given its origin, destination, and the user's nationality.
-    * `in_trip_agent`- Intended to be invoked frequently during the trip. This agent provide three services: monitor any changes in bookings (mocked), acts as a informative guide, and provides transit assistance.
-    * `post_trip_agent` - In this example, the post trip agent asks the traveler about their experience and attempts to extract and store their various preferences base on the trip, so that the information could be useful in future interactions.
+    * `in_trip_agent`- Intended to be invoked frequently during the trip. This agent provide three services: monitor any changes in bookings (mocked), acts as an informative guide, and provides transit assistance.
+    * `post_trip_agent` - In this example, the post trip agent asks the traveler about their experience and attempts to extract and store their various preferences based on the trip, so that the information could be useful in future interactions.
 *   **Tools:**
     * `map_tool` - retrieves lat/long; geocoding an address with the Google Map API.
     * `memorize` - a function to memorize information from the dialog that are important to trip planning and to provide in-trip support.


### PR DESCRIPTION
This pull request fixes several typos found in the README files of some agent folders. Below is a list of original words and corrected words:
```
- crutial -> crucial
- reuqested -> requested
- YOUR_ROJECT_NAME_HERE -> YOUR_PROJECT_NAME_HERE
- DEPLOYMENT_RESOURSE_NAME -> DEPLOYMENT_RESOURCE_NAME
- importand -> important
- withing -> within
- existig -> existing
- enviroment -> environment
- aslo -> also
- reasonablly -> reasonably
- base -> based
```
Completed quotation marks in [agents/README.md](https://github.com/google/adk-samples/compare/main...yatin166:adk-samples:fix-documentation-agents-readme?expand=1#diff-80ec9f41ff856af706ce4d5c9108b82e563d1c76257e4260403dd81ee7b5efc6) under `Prerequisites` section.

Improved a grammatical issues in [travel-concierge/README.md](https://github.com/google/adk-samples/compare/main...yatin166:adk-samples:fix-documentation-agents-readme?expand=1#diff-e8d523f112ddc039a643540abbb31de8ee2f8d162247b1c37c49c88827839655) under `Component Details` section.