### PR TITLE
Fix: Use Python -m flag in deployment script to resolve module import

### DIFF
--- a/agents/brand-search-optimization/deployment/run.sh
+++ b/agents/brand-search-optimization/deployment/run.sh
@@ -30,7 +30,7 @@ install_prereqs(){
 populate_bq_data(){
     echo "--- Changing to root directory ($ROOT_DIR) to populate BigQuery data ---"
     # Execute the python script from the root directory within a subshell
-    (cd "$ROOT_DIR" && python deployment/bq_populate_data.py)
+    (cd "$ROOT_DIR" && python -m deployment.bq_populate_data)
     echo "--- BigQuery population finished ---"
 }
 


### PR DESCRIPTION
When running the deployment script directly, Python couldn't find the brand\_search\_optimization module. Using the -m flag ensures Python treats the script as a module and adds the current directory to the path.