### PR TITLE
Update README.md

### DIFF
--- a/python/agents/data-science/README.md
+++ b/python/agents/data-science/README.md
@@ -122,7 +122,7 @@ The key features of the Data Science Multi-Agent include:
     *   You will find the datasets inside 'data-science/data_science/utils/data/'.
         Make sure you are still in the working directory (`agents/data-science`). To load the test and train tables into BigQuery, run the following commands:
         ```bash
-        python3 data_science/utils/create_bq_table.py
+        poetry run python data_science/utils/create_bq_table.py
         ```
 
 
@@ -136,7 +136,7 @@ The key features of the Data Science Multi-Agent include:
     `data-science/data_science/utils/reference_guide_RAG.py` by running the below command from the working directory:
 
     ```bash
-    python3 data_science/utils/reference_guide_RAG.py
+    poetry run python data_science/utils/reference_guide_RAG.py
     ```
 
 


### PR DESCRIPTION
Problem: On some POSIX environments, multiple python versions or conflicting environments may be present. When this happens, invoking python directly may result in not using the version from poetry.

Solution: Ensure python is being ran from poetry environment by explicitly calling it from the active poetry environment.