### PR TITLE
feat: add remote GitHub MCP server to software-bug-assistant sample

### DIFF
--- a/python/agents/software-bug-assistant/.env.example
+++ b/python/agents/software-bug-assistant/.env.example
@@ -1,7 +1,9 @@
 # Google AI Studio
 GOOGLE_API_KEY=<your-api-key>
 GOOGLE_GENAI_USE_VERTEXAI=FALSE
+GITHUB_PERSONAL_ACCESS_TOKEN=<your-personal-access-token>
 # Vertex AI (uncomment to use)
 #GOOGLE_GENAI_USE_VERTEXAI=TRUE
 #GOOGLE_CLOUD_PROJECT=<your-project-id>
 #GOOGLE_CLOUD_LOCATION=<your-location>
+#GITHUB_PERSONAL_ACCESS_TOKEN=<your-personal-access-token>

--- a/python/agents/software-bug-assistant/Dockerfile
+++ b/python/agents/software-bug-assistant/Dockerfile
@@ -11,11 +11,11 @@ ENV PYTHONUNBUFFERED=1
 ADD . /app
 
 # Install the project's dependencies using the lockfile and settings
-RUN uv sync --frozen --no-install-project --no-dev
+RUN uv sync --locked --no-install-project --no-dev
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
-RUN uv sync --frozen --no-dev
+RUN uv sync --locked --no-dev
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/python/agents/software-bug-assistant/README.md
+++ b/python/agents/software-bug-assistant/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Software Bug Assistant is a sample agent designed to help IT Support and Software Developers triage, manage, and resolve software issues. This sample agent uses ADK Python, a PostgreSQL bug ticket database, RAG, and Google Search to assist in debugging. 
+The Software Bug Assistant is a sample agent designed to help IT Support and Software Developers triage, manage, and resolve software issues. This sample agent uses ADK Python, a PostgreSQL bug ticket database (internal tickets), GitHub MCP server (external tickets), RAG, and Google Search to assist in debugging. 
 
 ![](deployment/images/google-cloud-architecture.png)
 
@@ -17,7 +17,7 @@ The key features of the Software Bug Assistant Agent include:
 | **Interaction Type** | Conversational |
 | **Complexity**       | Intermediate |
 | **Agent Type**       | Single Agent |
-| **Components**       | Tools, Database, RAG, Google Search |
+| **Components**       | Tools, Database, RAG, Google Search, GitHub MCP |
 | **Vertical**         | Horizontal / IT Support |
 
 ## Agent Architecture
@@ -28,6 +28,11 @@ The key features of the Software Bug Assistant Agent include:
 
 *   **Retrieval-Augmented Generation (RAG):** Leverages Cloud SQL's built-in [Vertex AI ML Integration](https://cloud.google.com/sql/docs/postgres/integrate-cloud-sql-with-vertex-ai) to fetch relevant/duplicate software bugs.
 *   **MCP Toolbox for Databases:** [MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox) to provide database-specific tools to our agent.
+*   **GitHub MCP Server:** Connects to [GitHub's remote MCP server](https://github.com/github/github-mcp-server?tab=readme-ov-file#remote-github-mcp-server)
+to fetch external software bugs (open issues and pull requests).
+*   **Google Search:** Leverages Google Search as a built-in tool to fetch
+relevant search results in order to ground the agent's responses with external
+up-to-date knowledge.
 
 ## Setup and Installation
 
@@ -49,7 +54,22 @@ cd adk-samples/python/agents/software-bug-assistant
 
 2. Configure environment variables (via `.env` file):
 
-There are two different ways to call Gemini models:
+#### GitHub Personal Access Token (PAT)
+
+To authenticate with the GitHub MCP server, you need a GitHub Personal Access Token.
+
+1. Go to your GitHub [Developer settings](https://github.com/settings/tokens).
+2. Click on "Personal access tokens" -> "Tokens (classic)".
+3. Click "Generate new token" -> "Generate new token (classic)".
+4. Give your token a descriptive name.
+5. Set an expiration date for your token.
+6. Important: For security, grant your token the most limited scopes necessary. For read-only access to repositories, the `repo:status`, `public_repo`, and `read:user` scopes are often sufficient. Avoid granting full repo or admin permissions unless absolutely necessary.
+7. Click "Generate token".
+8. Copy the generated token.
+
+#### Gemini API Authentication
+
+There are two different ways to authenticate with Gemini models:
 
 - Calling the Gemini API directly using an API key created via Google AI Studio.
 - Calling Gemini models through Vertex AI APIs on Google Cloud.
@@ -64,11 +84,12 @@ There are two different ways to call Gemini models:
 
 Get an API Key from Google AI Studio: https://aistudio.google.com/apikey
 
-Create a `.env` file by running the following (replace `<your_api_key_here>` with your API key):
+Create a `.env` file by running the following (replace `<your_api_key_here>` with your API key and `<your_github_pat_here>` with your GitHub Personal Access Token):
 
 ```sh
 echo "GOOGLE_API_KEY=<your_api_key_here>" >> .env \
-&& echo "GOOGLE_GENAI_USE_VERTEXAI=FALSE" >> .env
+&& echo "GOOGLE_GENAI_USE_VERTEXAI=FALSE" >> .env \
+&& echo "GITHUB_PERSONAL_ACCESS_TOKEN=<your_github_pat_here>" >> .env
 ```
 
 </details>
@@ -87,11 +108,13 @@ gcloud config set project <your_project_id>
 gcloud services enable aiplatform.googleapis.com
 ```
 
-Create a `.env` file by running the following (replace `<your_project_id>` with your project ID):
+Create a `.env` file by running the following (replace `<your_project_id>` with your project ID and `<your_github_pat_here>` with your GitHub Personal Access Token):
+
 ```sh
 echo "GOOGLE_GENAI_USE_VERTEXAI=TRUE" >> .env \
 && echo "GOOGLE_CLOUD_PROJECT=<your_project_id>" >> .env \
-&& echo "GOOGLE_CLOUD_LOCATION=us-central1" >> .env
+&& echo "GOOGLE_CLOUD_LOCATION=us-central1" >> .env \
+&& echo "GITHUB_PERSONAL_ACCESS_TOKEN=<your_github_pat_here>" >> .env
 ```
 
 </details>
@@ -321,13 +344,13 @@ gcloud services enable sqladmin.googleapis.com \
 
 ```bash
 gcloud sql instances create software-assistant \
---database-version=POSTGRES_16 \
---tier=db-custom-1-3840 \
---region=us-central1 \
---edition=ENTERPRISE \
---enable-google-ml-integration \
---database-flags cloudsql.enable_google_ml_integration=on \
---root-password=admin
+   --database-version=POSTGRES_16 \
+   --tier=db-custom-1-3840 \
+   --region=us-central1 \
+   --edition=ENTERPRISE \
+   --enable-google-ml-integration \
+   --database-flags cloudsql.enable_google_ml_integration=on \
+   --root-password=admin
 ```
 
 Once created, you can view your instance in the Cloud Console [here](https://console.cloud.google.com/sql/instances/software-assistant/overview).
@@ -551,7 +574,7 @@ gcloud builds submit --region=us-central1 --tag us-central1-docker.pkg.dev/$PROJ
 > If you are using Vertex AI instead of AI Studio for Gemini calls, you will need to replace `GOOGLE_API_KEY` with `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_GENAI_USE_VERTEXAI=TRUE` in the last line of the below `gcloud run deploy` command.
 > 
 > ```bash
-> --set-env-vars=GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GOOGLE_CLOUD_LOCATION=us-central1,GOOGLE_GENAI_USE_VERTEXAI=TRUE,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL
+> --set-env-vars=GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GOOGLE_CLOUD_LOCATION=us-central1,GOOGLE_GENAI_USE_VERTEXAI=TRUE,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL,GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN
 > ```
 
 ```bash
@@ -559,7 +582,7 @@ gcloud run deploy software-bug-assistant \
   --image=us-central1-docker.pkg.dev/$PROJECT_ID/adk-samples/software-bug-assistant:latest \
   --region=us-central1 \
   --allow-unauthenticated \
-  --set-env-vars=GOOGLE_API_KEY=$GOOGLE_API_KEY,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL 
+  --set-env-vars=GOOGLE_API_KEY=$GOOGLE_API_KEY,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL,GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN 
 ```
 
 When this runs successfully, you should see: 

--- a/python/agents/software-bug-assistant/pyproject.toml
+++ b/python/agents/software-bug-assistant/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "google-adk==1.2.1",
+    "google-adk==1.3.0",
     "python-dotenv==1.1.0",
     "toolbox-core==0.1.0",
 ]

--- a/python/agents/software-bug-assistant/software_bug_assistant/agent.py
+++ b/python/agents/software-bug-assistant/software_bug_assistant/agent.py
@@ -15,12 +15,12 @@
 from google.adk.agents import Agent
 
 from .prompt import agent_instruction
-from .tools.tools import get_current_date, search_tool, toolbox_tools
+from .tools.tools import get_current_date, mcp_tools, search_tool, toolbox_tools
 
 
 root_agent = Agent(
     model="gemini-2.0-flash",
     name="software_assistant",
     instruction=agent_instruction,
-    tools=[get_current_date, search_tool, *toolbox_tools],
+    tools=[get_current_date, search_tool, *toolbox_tools, mcp_tools],
 )

--- a/python/agents/software-bug-assistant/software_bug_assistant/tools/tools.py
+++ b/python/agents/software-bug-assistant/software_bug_assistant/tools/tools.py
@@ -19,6 +19,7 @@ import os
 from google.adk.agents import Agent
 from google.adk.tools import google_search
 from google.adk.tools.agent_tool import AgentTool
+from google.adk.tools.mcp_tool import MCPToolset, StreamableHTTPConnectionParams
 from toolbox_core import ToolboxSyncClient
 
 from dotenv import load_dotenv
@@ -55,3 +56,14 @@ TOOLBOX_URL = os.getenv("MCP_TOOLBOX_URL", "http://127.0.0.1:5000")
 toolbox = ToolboxSyncClient(TOOLBOX_URL)
 # Load all the tools from toolset
 toolbox_tools = toolbox.load_toolset("tickets_toolset")
+
+
+# ----- Example of MCP Tools (streamable-http) -----
+mcp_tools = MCPToolset(
+    connection_params=StreamableHTTPConnectionParams(
+        url="https://api.githubcopilot.com/mcp/",
+        headers={
+            "Authorization": "Bearer " + os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"),
+        }
+    )
+)

--- a/python/agents/software-bug-assistant/uv.lock
+++ b/python/agents/software-bug-assistant/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.2.1"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -630,9 +630,9 @@ dependencies = [
     { name = "tzlocal" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/3f/c17e938b53e6638c75964db92915a866dee3bca29535df2bfd89ca57c999/google_adk-1.2.1.tar.gz", hash = "sha256:7ffac56d1ee457f64b3877f81aed099171c52e03ac2ef7b42de2f7f4973995e7", size = 1104116, upload-time = "2025-06-04T23:43:25.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/7e/223f9244fcfb34042d9519ba13f8f017bdc077a628c204d3a6944682d4a6/google_adk-1.3.0.tar.gz", hash = "sha256:3be048cd40fb3a2c2f51ecb61233d78434cab2aba5a58507156c7daf2b9772fa", size = 1142535, upload-time = "2025-06-12T17:59:09.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/83/4fa0a0e765258e4f3f6cf452a28cde0d335cce27542041fcf3afe9df4cef/google_adk-1.2.1-py3-none-any.whl", hash = "sha256:93b805180caadb5b2265a9737c7ac472d10443ddec18ad83efdef8a7a6217d2a", size = 1247947, upload-time = "2025-06-04T23:43:23.737Z" },
+    { url = "https://files.pythonhosted.org/packages/51/94/1b86404b81ea0f282694257e31fd4fb954c8cdcadebf1fde02a056979609/google_adk-1.3.0-py3-none-any.whl", hash = "sha256:a57f05633bd2d9937b9a73ca4fc4a5c7d9d1e2d28390c8df2be134d7d4b1f79c", size = 1306110, upload-time = "2025-06-12T17:59:06.649Z" },
 ]
 
 [[package]]
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "google-adk", specifier = "==1.2.1" },
+    { name = "google-adk", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.1.0" },
     { name = "toolbox-core", specifier = "==0.1.0" },
 ]


### PR DESCRIPTION
Adding support for GitHub's remote MCP server to Python `software-bug-assistant` sample.

GitHub's remote MCP server was [released last week](https://github.blog/changelog/2025-06-12-remote-github-mcp-server-is-now-available-in-public-preview/), it is a good addition
to showcase MCP tools for ADK and aligns with the sample, allowing users
to query external codebases and issues.