### PR TITLE
feat(rag): add multi-file upload support to corpus preparation script

### DIFF
--- a/python/agents/RAG/README.md
+++ b/python/agents/RAG/README.md
@@ -82,6 +82,17 @@ This diagram outlines the agent's workflow, designed to provide informed and con
 
 The `rag/shared_libraries/prepare_corpus_and_data.py` script helps you set up a RAG corpus and upload an initial document. By default, it downloads Alphabet's 2024 10-K PDF and uploads it to a new corpus.
 
+> **New in v0.2** – You can now upload **multiple files at once**!  The script accepts `--pdf_urls` and `--pdf_files` command-line flags, allowing you to mix remote URLs and local file paths in a single invocation.
+
+```bash
+# Example: create (or reuse) a corpus and upload three PDFs – two remote and one local.
+python rag/shared_libraries/prepare_corpus_and_data.py \
+  --pdf_urls https://example.com/handbook.pdf https://example.com/guide.pdf \
+  --pdf_files ./docs/internal_policy.pdf
+```
+
+If no files are supplied, the script defaults to the single Alphabet 10-K example for backwards-compatibility.
+
 1.  **Authenticate with your Google Cloud account:**
     ```bash
     gcloud auth application-default login
@@ -102,6 +113,13 @@ The `rag/shared_libraries/prepare_corpus_and_data.py` script helps you set up a 
         ```
         This will create a corpus named `Alphabet_10K_2024_corpus` (if it doesn't exist) and upload the PDF `goog-10-k-2024.pdf` downloaded from the URL specified in the script.
 
+        You can also pass one or more URLs directly (without editing the script):
+
+        ```bash
+        python rag/shared_libraries/prepare_corpus_and_data.py \
+          --pdf_urls "https://path/to/first.pdf" "https://path/to/second.pdf"
+        ```
+
     *   **To upload a different PDF from a URL:**
         a. Open the `rag/shared_libraries/prepare_corpus_and_data.py` file.
         b. Modify the following variables at the top of the script:
@@ -116,7 +134,7 @@ The `rag/shared_libraries/prepare_corpus_and_data.py` script helps you set up a 
            ```
         c. Run the script:
            ```bash
-           python rag/shared_libraries/prepare_corpus_and_data.py
+           python rag/shared_libraries/prepare_corpus_and_data.py --pdf_urls "https://path/to/your/document.pdf"
            ```
 
     *   **To upload a local PDF file:**
@@ -149,7 +167,7 @@ The `rag/shared_libraries/prepare_corpus_and_data.py` script helps you set up a 
            ```
         d. Run the script:
            ```bash
-           python rag/shared_libraries/prepare_corpus_and_data.py
+           python rag/shared_libraries/prepare_corpus_and_data.py --pdf_files /path/to/your/local/file.pdf /another/file.pdf
            ```
 
 More details about managing data in Vertex RAG Engine can be found in the

--- a/python/agents/RAG/rag/shared_libraries/prepare_corpus_and_data.py
+++ b/python/agents/RAG/rag/shared_libraries/prepare_corpus_and_data.py
@@ -19,6 +19,8 @@ import os
 from dotenv import load_dotenv, set_key
 import requests
 import tempfile
+import argparse
+from urllib.parse import urlparse
 
 # Load environment variables from .env file
 load_dotenv()
@@ -35,12 +37,14 @@ if not LOCATION:
     raise ValueError(
         "GOOGLE_CLOUD_LOCATION environment variable not set. Please set it in your .env file."
     )
-CORPUS_DISPLAY_NAME = "Alphabet_10K_2024_corpus"
-CORPUS_DESCRIPTION = "Corpus containing Alphabet's 10-K 2024 document"
-PDF_URL = "https://abc.xyz/assets/77/51/9841ad5c4fbe85b4440c47a4df8d/goog-10-k-2024.pdf"
-PDF_FILENAME = "goog-10-k-2024.pdf"
 ENV_FILE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".env"))
 
+# Default corpus metadata. Can be overridden via CLI.
+CORPUS_DISPLAY_NAME = "Alphabet_10K_2024_corpus"
+CORPUS_DESCRIPTION = "Corpus containing documentation files"
+
+# Default single-file example (kept for backwards compatibility).
+DEFAULT_PDF_URL = "https://abc.xyz/assets/77/51/9841ad5c4fbe85b4440c47a4df8d/goog-10-k-2024.pdf"
 
 # --- Start of the script ---
 def initialize_vertex_ai():
@@ -72,7 +76,7 @@ def create_or_get_corpus():
   return corpus
 
 
-def download_pdf_from_url(url, output_path):
+def download_pdf_from_url(url: str, output_path: str):
   """Downloads a PDF file from the specified URL."""
   print(f"Downloading PDF from {url}...")
   response = requests.get(url, stream=True)
@@ -86,7 +90,7 @@ def download_pdf_from_url(url, output_path):
   return output_path
 
 
-def upload_pdf_to_corpus(corpus_name, pdf_path, display_name, description):
+def upload_pdf_to_corpus(corpus_name: str, pdf_path: str, display_name: str, description: str):
   """Uploads a PDF file to the specified corpus."""
   print(f"Uploading {display_name} to corpus...")
   try:
@@ -117,30 +121,106 @@ def list_corpus_files(corpus_name):
   for file in files:
     print(f"File: {file.display_name} - {file.name}")
 
+def _create_temp_dir() -> tempfile.TemporaryDirectory:
+  """Creates and returns a TemporaryDirectory instance."""
+  return tempfile.TemporaryDirectory()
+
+
+def _filename_from_url(url: str) -> str:
+  """Derives a filename from the last path component of the URL."""
+  parsed = urlparse(url)
+  return os.path.basename(parsed.path) or "downloaded_file.pdf"
+
+
+# -----------------------------------------------------------------------------
+# Entry-point
+# -----------------------------------------------------------------------------
 
 def main():
+  """Entry-point for CLI/Script.
+
+  Supports uploading multiple files to an existing or newly created RAG corpus.
+  Files can be provided via URLs (they will be downloaded first) or local file
+  paths. If no files are provided, the script falls back to a default single
+  PDF example for backwards compatibility.
+  """
+
+  global CORPUS_DISPLAY_NAME, CORPUS_DESCRIPTION  # declare globals before use
+
+  parser = argparse.ArgumentParser(description="Prepare corpus and upload PDF files to Vertex AI RAG")
+  parser.add_argument(
+      "--pdf_urls",
+      nargs="*",
+      help="One or more PDF URLs to download and upload.",
+  )
+  parser.add_argument(
+      "--pdf_files",
+      nargs="*",
+      help="One or more local PDF file paths to upload.",
+  )
+  parser.add_argument(
+      "--corpus_display_name",
+      default=CORPUS_DISPLAY_NAME,
+      help=f"Display name for the corpus (default: {CORPUS_DISPLAY_NAME}).",
+  )
+  parser.add_argument(
+      "--corpus_description",
+      default=CORPUS_DESCRIPTION,
+      help="Description for the corpus.",
+  )
+
+  args = parser.parse_args()
+
+  # Update global metadata if the user provided overrides.
+  CORPUS_DISPLAY_NAME = args.corpus_display_name
+  CORPUS_DESCRIPTION = args.corpus_description
+
+  pdf_urls = args.pdf_urls or []
+  pdf_files = args.pdf_files or []
+
+  # Fallback to default example when no input is provided.
+  if not pdf_urls and not pdf_files:
+    pdf_urls.append(DEFAULT_PDF_URL)
+
   initialize_vertex_ai()
   corpus = create_or_get_corpus()
 
-  # Update the .env file with the corpus name
+  # Ensure the .env file contains the correct corpus name so the retrieval
+  # agent can reference it later.
   update_env_file(corpus.name, ENV_FILE_PATH)
-  
-  # Create a temporary directory to store the downloaded PDF
-  with tempfile.TemporaryDirectory() as temp_dir:
-    pdf_path = os.path.join(temp_dir, PDF_FILENAME)
-    
-    # Download the PDF from the URL
-    download_pdf_from_url(PDF_URL, pdf_path)
-    
-    # Upload the PDF to the corpus
-    upload_pdf_to_corpus(
-        corpus_name=corpus.name,
-        pdf_path=pdf_path,
-        display_name=PDF_FILENAME,
-        description="Alphabet's 10-K 2024 document"
-    )
-  
-  # List all files in the corpus
+
+  # Handle URL downloads inside a temporary directory to avoid cluttering the
+  # workspace.
+  with _create_temp_dir() as temp_dir:
+    # First process URLs.
+    for url in pdf_urls:
+      try:
+        filename = _filename_from_url(url)
+        pdf_path = os.path.join(temp_dir, filename)
+        download_pdf_from_url(url, pdf_path)
+        upload_pdf_to_corpus(
+            corpus_name=corpus.name,
+            pdf_path=pdf_path,
+            display_name=filename,
+            description=f"Uploaded from URL: {url}",
+        )
+      except Exception as exc:
+        print(f"❌ Skipped {url}: {exc}")
+
+    # Next process local files.
+    for file_path in pdf_files:
+      if not os.path.isfile(file_path):
+        print(f"❌ File not found: {file_path}. Skipping.")
+        continue
+      filename = os.path.basename(file_path)
+      upload_pdf_to_corpus(
+          corpus_name=corpus.name,
+          pdf_path=file_path,
+          display_name=filename,
+          description="Uploaded from local filesystem.",
+      )
+
+  # Finally, show the corpus contents to the user.
   list_corpus_files(corpus_name=corpus.name)
 
 if __name__ == "__main__":

--- a/python/agents/RAG/tests/test_prepare_multi_file.py
+++ b/python/agents/RAG/tests/test_prepare_multi_file.py
@@ -1,0 +1,85 @@
+"""Unit tests for multiple-file support in prepare_corpus_and_data.py."""
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Import the module under test
+import importlib
+
+MODULE_PATH = "rag.shared_libraries.prepare_corpus_and_data"
+
+
+def reload_module():
+    """Reload the target module to ensure CLI parsing reads patched sys.argv."""
+    if MODULE_PATH in sys.modules:
+        return importlib.reload(sys.modules[MODULE_PATH])
+    return importlib.import_module(MODULE_PATH)
+
+
+def test__filename_from_url():
+    prepare = reload_module()
+    url = "https://example.com/path/to/myfile.pdf"
+    assert prepare._filename_from_url(url) == "myfile.pdf"
+
+
+@pytest.mark.parametrize("num_urls,num_files", [(1, 1), (2, 0), (0, 3)])
+def test_main_multi_file(monkeypatch, tmp_path, num_urls, num_files):
+    """Verify that `main` attempts to upload all provided files/URLs."""
+
+    # Dynamically build CLI args
+    url_list = [f"https://example.com/doc_{i}.pdf" for i in range(num_urls)]
+    file_list_paths = []
+    for i in range(num_files):
+        f_path = tmp_path / f"local_{i}.pdf"
+        f_path.write_bytes(b"dummy")
+        file_list_paths.append(str(f_path))
+
+    argv = ["prepare_corpus_and_data.py"]
+    if url_list:
+        argv.extend(["--pdf_urls", *url_list])
+    if file_list_paths:
+        argv.extend(["--pdf_files", *file_list_paths])
+
+    upload_calls = []
+
+    # Patch environment variables expected by the script
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "dummy-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    # First load module to reference its names for monkeypatching
+    prepare = reload_module()
+
+    # Stub external side-effect functions
+    monkeypatch.setattr(prepare, "initialize_vertex_ai", lambda: None)
+    monkeypatch.setattr(prepare, "create_or_get_corpus", lambda: types.SimpleNamespace(name="corpus/test"))
+    monkeypatch.setattr(prepare, "update_env_file", lambda *args, **kwargs: None)
+
+    def fake_download(url: str, output_path: str):
+        # Simulate download by writing bytes to the expected path
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as fp:
+            fp.write(b"dummy")
+        return output_path
+
+    monkeypatch.setattr(prepare, "download_pdf_from_url", fake_download)
+
+    def fake_upload(corpus_name, pdf_path, display_name, description):
+        upload_calls.append((corpus_name, pdf_path, display_name, description))
+        return None
+
+    monkeypatch.setattr(prepare, "upload_pdf_to_corpus", fake_upload)
+    monkeypatch.setattr(prepare, "list_corpus_files", lambda **kwargs: None)
+
+    # Patch sys.argv and rerun module.main()
+    monkeypatch.setattr(sys, "argv", argv)
+
+    prepare.main()
+
+    expected_total = num_urls + num_files if (num_urls + num_files) > 0 else 1  # default single PDF use-case
+    assert len(upload_calls) == expected_total, (
+        f"Expected {expected_total} uploads (URLs: {num_urls}, files: {num_files}), got {len(upload_calls)}"
+    ) 


### PR DESCRIPTION
- Adds CLI flags --pdf_urls and --pdf_files to accept multiple remote URLs and local file paths
- Refactors logic for iterative uploads, including helper functions and argparse handling
- Updates README with new usage examples and detailed instructions
- Adds unit tests (tests/test_prepare_multi_file.py) covering filename extraction and end-to-end multi-file workflow with mocks