### PR TITLE
fix: Add root folder to extra_packages in deployment.py

### DIFF
--- a/python/agents/marketing-agency/deployment/deploy.py
+++ b/python/agents/marketing-agency/deployment/deploy.py
@@ -49,7 +49,7 @@ def create() -> None:
             "pydantic (>=2.10.6,<3.0.0)",
             "absl-py (>=2.2.1,<3.0.0)",
         ],
-        #        extra_packages=[""],
+        #        extra_packages=["./marketing_agency"],
     )
     print(f"Created remote agent: {remote_agent.resource_name}")
 


### PR DESCRIPTION
Running into issues when running deployment where the rest of the code is unable to be found. Adding this requirement includes the rest of the code when deploying.