### PR TITLE
fix: change regex in bigquery validation for diallowing dml

### DIFF
--- a/python/agents/data-science/data_science/sub_agents/bigquery/tools.py
+++ b/python/agents/data-science/data_science/sub_agents/bigquery/tools.py
@@ -354,7 +354,7 @@ def run_bigquery_validation(
 
     # More restrictive check for BigQuery - disallow DML and DDL
     if re.search(
-        r"(?i)(update|delete|drop|insert|create|alter|truncate|merge)", sql_string
+        r"(?i)\b(update|delete|drop|insert|create|alter|truncate|merge)\b", sql_string
     ):
         final_result["error_message"] = (
             "Invalid SQL: Contains disallowed DML/DDL operations."


### PR DESCRIPTION
In the Data Science Agent, the current regex for rejecting DML looks like this:

```
r"(?i)(update|delete|drop|insert|create|alter|truncate|merge)"
```

This treats all queries including columns like `created_at` and `updated_at` as invalid, for example. By adding word boundaries to the regex expression like this:

```
r"(?i)\b(update|delete|drop|insert|create|alter|truncate|merge)\b"
```

The db_agent is able to perform queries without getting validation errors for common SELECT statements.