### PR TITLE
bugfix(camel): fix incorrect reader type check in CaMeL demo

### DIFF
--- a/python/agents/camel/camel/camel_library/security_policy.py
+++ b/python/agents/camel/camel/camel_library/security_policy.py
@@ -77,7 +77,7 @@ def base_security_policy(
   """
   r = [capabilities_utils.get_all_readers(data) for data in kwargs.values()]
   if (
-      any(reader != readers.Public() for reader in r)
+      any(reader[0] != readers.Public() for reader in r)
       and tool_name not in no_side_effect_tools
   ):
     return Denied("Data is not public.")


### PR DESCRIPTION
This fixes a bug where reader != readers.Public() raised an error due to reader being a tuple.
Now correctly compares the first element: reader[0] != readers.Public().

This change ensures compatibility with the current output format of get_all_readers, which returns a tuple of (Readers[Any], frozenset[int]).