### PR TITLE
docs: clarify that ADK is a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Welcome to the ADK Sample Agents repository! This collection provides ready-to-u
 ## ✨ Getting Started 
 This repo contains ADK sample agents for both **Python** and **Java.** Navigate to the **[Python](python/)** and **[Java](java/)** subfolders to see language-specific setup instructions, and learn more about the available sample agents. 
 
+> [!IMPORTANT]
+> The agents in this repository are built using the **Agent Development Kit (ADK)**. Before you can run any of the samples, you must have the ADK installed. For instructions, please refer to the [**ADK Installation Guide**](https://google.github.io/adk-docs/get-started/installation).
+
 To learn more, check out the [ADK Documentation](https://google.github.io/adk-docs/), and the GitHub repositories for [ADK Python](https://github.com/google/adk-python) and [ADK Java](https://github.com/google/adk-java). 
 
 ## 🌳 Repository Structure


### PR DESCRIPTION
The current README.md file does not explicitly state that the Agent Development Kit (ADK) is a prerequisite that needs to be installed separately. This can lead to confusion and `ModuleNotFoundError` errors when you try to run the sample agents.

I have added a note to the "Getting Started" section of the main `README.md` file to clarify that the ADK must be installed before running any of the samples. I also included a link to the ADK installation guide to make it easier for you to find the necessary instructions.