### PR TITLE
fix: Correct PyTorch installation in pyproject.toml

### DIFF
--- a/python/agents/machine-learning-engineering/pyproject.toml
+++ b/python/agents/machine-learning-engineering/pyproject.toml
@@ -22,9 +22,7 @@ scikit-learn = "^1.7.1"
 # The CPU version of PyTorch is installed here. Change this is you need GPUs, or
 # want to use PyTorch on a different hardware architecture or CPU.
 # (https://download.pytorch.org/whl)
-torch = [
-  {url = "https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.7.1%2Bcpu.cxx11.abi-cp312-cp312-linux_x86_64.whl", markers = "sys_platform == 'linux'"},
-]
+torch = {version = "^2.7.1", source = "pytorch_cpu"}
 [tool.poetry.group.dev]
 optional = true
 
@@ -44,9 +42,7 @@ scikit-learn = "^1.7.1"
 # The CPU version of PyTorch is installed here. Change this is you need GPUs, or
 # want to use PyTorch on a different hardware architecture or CPU.
 # (https://download.pytorch.org/whl)
-torch = [
-  {url = "https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.7.1%2Bcpu.cxx11.abi-cp312-cp312-linux_x86_64.whl", markers = "sys_platform == 'linux'"},
-]
+torch = {version = "^2.7.1", source = "pytorch_cpu"}
 
 [tool.poetry.group.deployment]
 optional = true
@@ -56,6 +52,11 @@ absl-py = "^2.2.1"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[[tool.poetry.source]]
+name = "pytorch_cpu"
+url = "https://download.pytorch.org/whl/cpu"
+priority = "explicit"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
This commit fixes the PyTorch installation by using a dedicated source instead of a direct URL. This makes the installation platform-agnostic and resolves the issue where the previous URL was specific to Linux.

Fixes https://github.com/google/adk-samples/issues/292