### PR TITLE
fix: rag agent fix, updated google-adk and google-cloud-aiplatform versions

### DIFF
--- a/python/agents/RAG/deployment/deploy.py
+++ b/python/agents/RAG/deployment/deploy.py
@@ -55,8 +55,8 @@ logging.debug("deploying agent to agent engine:")
 remote_app = agent_engines.create(
     app,
     requirements=[
-        "google-cloud-aiplatform[adk,agent-engines]==1.88.0",
-        "google-adk",
+        "google-cloud-aiplatform[adk,agent-engines]==1.108.0",
+        "google-adk==1.10.0",
         "python-dotenv",
         "google-auth",
         "tqdm",

--- a/python/agents/RAG/pyproject.toml
+++ b/python/agents/RAG/pyproject.toml
@@ -16,11 +16,11 @@ pydantic-settings = "^2.8.1"
 tabulate = "^0.9.0"
 google-auth = "^2.36.0"
 requests = "^2.32.3"
-google-adk = "^1.0.0"
+google-adk = "^1.10.0"
 google-cloud-aiplatform = { extras = [
         "adk",
         "agent-engines",
-], version = "^1.93.0" }
+], version = "^1.108.0" }
 llama-index = "^0.12"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Fixes issue #88 
Also, please make sure to run ./deployment/grant_permissions.sh to grant your agent engine agent access to your rag engine.