### PR TITLE
Removed keyring instruction from README.md in data-science

### DIFF
--- a/python/agents/data-science/README.md
+++ b/python/agents/data-science/README.md
@@ -55,12 +55,6 @@ The key features of the Data Science Multi-Agent include:
 
 2.  **Install Dependencies with uv:**
 
-    **Note for Linux users:** If you get an error related to `keyring` during the installation, you can disable it by running the following command:
-    ```bash
-    poetry config keyring.enabled false
-    ```
-    This is a one-time setup.
-
     ```bash
     uv sync
     ```


### PR DESCRIPTION
The data-science agent was updated to use uv for package management instead of uv, so the instruction regarding updating the keyring during poetry installation is out of date.