### PR TITLE
Fix build issue with uv build backend.

### DIFF
--- a/python/agents/data-science/pyproject.toml
+++ b/python/agents/data-science/pyproject.toml
@@ -33,6 +33,9 @@ dev = [
 requires = ["uv_build>=0.7.19,<0.8.0"]
 build-backend = "uv_build"
 
+[tool.uv.build-backend]
+module-name = "data_science"
+module-root = ""
 
 [tool.pytest.ini_options]
 # This section is for pytest configuration and does not need to be changed.


### PR DESCRIPTION
The uv build backend expects a different project layout by default. This change provides the configuration for uv to recognize the existing data-science agent project layout.