### PR TITLE
fix: correct duplicate condition in fomc-research agent tool

### DIFF
--- a/python/agents/fomc-research/fomc_research/tools/compare_statements.py
+++ b/python/agents/fomc-research/fomc_research/tools/compare_statements.py
@@ -54,7 +54,7 @@ async def compare_statements_tool(tool_context: ToolContext) -> dict[str, str]:
         prev_statement_url, "prev.pdf", tool_context
     )
 
-    if reqd_pdf_path is None or reqd_pdf_path is None:
+    if reqd_pdf_path is None or prev_pdf_path is None:
         logger.error("Failed to download files, aborting")
         return {
             "status": "error",


### PR DESCRIPTION
Replace duplicate reqd_pdf_path check with proper prev_pdf_path in compare_statements.py