### PR TITLE
Improve workflow reliability and remove unnecessary infrastructure deployment

### DIFF
--- a/.github/workflows/test_templated_agent.yaml
+++ b/.github/workflows/test_templated_agent.yaml
@@ -94,6 +94,7 @@ jobs:
       # --- RUN THE TEMPLATE GENERATION AND TESTING USING CONTAINER ---
       - name: ${{ matrix.task }} - ${{ matrix.agent_path }} (${{ matrix.deployment_target }})
         uses: docker://europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests
+        continue-on-error: ${{ matrix.task == 'lint' }}
         with:
           entrypoint: /bin/bash
           args: |
@@ -128,7 +129,6 @@ jobs:
             elif [ \"${{ matrix.task }}\" = \"test\" ]; then
               echo \"--- Running tests ---\"
               export AGENT_NAME=\"$DEPLOYMENT_TARGET-$AGENT_NAME\"
-              make deploy-infra
               make test
             else
               echo \"--- Unknown task: ${{ matrix.task }} ---\"

--- a/python/agents/gemini-fullstack/Makefile
+++ b/python/agents/gemini-fullstack/Makefile
@@ -20,6 +20,3 @@ lint:
 	uv run ruff check . --diff
 	uv run ruff format . --check --diff
 	uv run mypy .
-
-deploy-infra:
-	echo "Skipping: Infra not required"


### PR DESCRIPTION
## Summary
- Make linting non-blocking in GitHub Actions workflow to prevent lint failures from blocking PR merges
- Remove deploy-infra step from test workflow as infrastructure deployment is not needed for testing
- Clean up Makefile by removing unused deploy-infra target