### PR TITLE
Fix typo in README command instructions

### DIFF
--- a/python/agents/customer-service/README.md
+++ b/python/agents/customer-service/README.md
@@ -150,7 +150,7 @@ The agent has access to the following tools:
 
 ## Running the Agent
 
-You can run the agent using the ADK commant in your terminal.
+You can run the agent using the ADK command in your terminal.
 from the root project directory:
 
 1.  Run agent in CLI:


### PR DESCRIPTION
This pull request makes a minor correction to the documentation for running the agent. The change fixes a small typo in the `python/agents/customer-service/README.md` file.