### PR TITLE
fix docker build error on Cloud Run

### DIFF
--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -13,18 +13,18 @@ ENV UV_LINK_MODE=copy
 
 WORKDIR /app
 
-# Copy only the dependency files first to leverage Docker layer caching
+# Copy dependency files first for better caching
 COPY uv.lock pyproject.toml ./
 
 # Upgrade pip to the latest version and install uv
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir uv>=0.7.19
 
+# Copy the application code (needed for package building)
+COPY . .
+
 # Install project dependencies, sync to uv's lockfile
 RUN uv sync --frozen
-
-# Copy the rest of the application code
-COPY . .
 
 # Expose the port
 EXPOSE 8080

--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -19,7 +19,7 @@ RUN rm -rf .venv
 ENV UV_SYSTEM_PYTHON=1
 
 # Install project dependencies, sync to uv's lockfile using system Python
-RUN uv sync --frozen --system
+RUN uv sync
 
 # Expose the port
 EXPOSE 8080

--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12-slim
 
+# Install system dependencies required for Python shared libraries
+RUN apt-get update && apt-get install -y \
+    libexpat1 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Prevents Python from buffering stdout and stderr
 ENV PYTHONUNBUFFERED=1
 
@@ -7,18 +12,19 @@ ENV PYTHONUNBUFFERED=1
 ENV UV_LINK_MODE=copy
 
 WORKDIR /app
-COPY . .
 
-# Upgrade pip to the latest version
-RUN pip install --no-cache-dir --upgrade pip
-# Install uv
-RUN pip install --no-cache-dir uv>=0.7.19
-
-# Copy only the dependency files to leverage Docker layer caching
+# Copy only the dependency files first to leverage Docker layer caching
 COPY uv.lock pyproject.toml ./
+
+# Upgrade pip to the latest version and install uv
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir uv>=0.7.19
 
 # Install project dependencies, sync to uv's lockfile
 RUN uv sync --frozen
+
+# Copy the rest of the application code
+COPY . .
 
 # Expose the port
 EXPOSE 8080

--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -3,9 +3,6 @@ FROM python:3.12
 # Prevents Python from buffering stdout and stderr
 ENV PYTHONUNBUFFERED=1
 
-# Copy from the cache instead of linking since it's a mounted volume
-ENV UV_LINK_MODE=copy
-
 WORKDIR /app
 COPY . .
 
@@ -17,8 +14,12 @@ RUN pip install --no-cache-dir uv>=0.7.19
 # Copy only the dependency files to leverage Docker layer caching
 COPY uv.lock pyproject.toml ./
 
-# Install project dependencies, sync to uv's lockfile
-RUN uv sync --frozen
+# Remove any existing virtual environment and force system Python usage
+RUN rm -rf .venv
+ENV UV_SYSTEM_PYTHON=1
+
+# Install project dependencies, sync to uv's lockfile using system Python
+RUN uv sync --frozen --system
 
 # Expose the port
 EXPOSE 8080

--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -11,22 +11,33 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Copy dependency files first for better caching
-COPY uv.lock pyproject.toml ./
+COPY pyproject.toml ./
 
-# Upgrade pip to the latest version and install uv
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir uv>=0.7.19
+# Upgrade pip to the latest version
+RUN pip install --no-cache-dir --upgrade pip
 
 # Copy the application code (needed for package building)
 COPY . .
 
-# Install project dependencies, sync to uv's lockfile
-# Use --no-dev to avoid installing development dependencies in production
-# Set UV_SYSTEM_PYTHON to use the system Python instead of creating a venv
-ENV UV_SYSTEM_PYTHON=1
-RUN uv sync --frozen --no-dev
+# Install project dependencies using pip directly
+# Extract dependencies from pyproject.toml and install them
+RUN pip install --no-cache-dir \
+    python-dotenv>=1.0.1 \
+    google-adk>=1.5.0 \
+    immutabledict>=4.2.1 \
+    sqlglot>=26.10.1 \
+    db-dtypes>=1.4.2 \
+    regex>=2024.11.6 \
+    tabulate>=0.9.0 \
+    "google-cloud-aiplatform[adk,agent-engines]>=1.93.0" \
+    absl-py>=2.2.2 \
+    pydantic>=2.11.3 \
+    pandas>=2.3.0 \
+    numpy>=2.3.1 \
+    pg8000>=1.31.2 \
+    uvicorn
 
 # Expose the port
 EXPOSE 8080
 
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -1,43 +1,26 @@
-FROM python:3.12-slim
-
-# Install system dependencies required for Python shared libraries
-RUN apt-get update && apt-get install -y \
-    libexpat1 \
-    && rm -rf /var/lib/apt/lists/*
+FROM python:3.12
 
 # Prevents Python from buffering stdout and stderr
 ENV PYTHONUNBUFFERED=1
 
-WORKDIR /app
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
 
-# Copy dependency files first for better caching
-COPY pyproject.toml ./
+WORKDIR /app
+COPY . .
 
 # Upgrade pip to the latest version
 RUN pip install --no-cache-dir --upgrade pip
+# Install uv
+RUN pip install --no-cache-dir uv>=0.7.19
 
-# Copy the application code (needed for package building)
-COPY . .
+# Copy only the dependency files to leverage Docker layer caching
+COPY uv.lock pyproject.toml ./
 
-# Install project dependencies using pip directly
-# Extract dependencies from pyproject.toml and install them
-RUN pip install --no-cache-dir \
-    python-dotenv>=1.0.1 \
-    google-adk>=1.5.0 \
-    immutabledict>=4.2.1 \
-    sqlglot>=26.10.1 \
-    db-dtypes>=1.4.2 \
-    regex>=2024.11.6 \
-    tabulate>=0.9.0 \
-    "google-cloud-aiplatform[adk,agent-engines]>=1.93.0" \
-    absl-py>=2.2.2 \
-    pydantic>=2.11.3 \
-    pandas>=2.3.0 \
-    numpy>=2.3.1 \
-    pg8000>=1.31.2 \
-    uvicorn
+# Install project dependencies, sync to uv's lockfile
+RUN uv sync --frozen
 
 # Expose the port
 EXPOSE 8080
 
-CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/python/agents/data-science/Dockerfile
+++ b/python/agents/data-science/Dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update && apt-get install -y \
 # Prevents Python from buffering stdout and stderr
 ENV PYTHONUNBUFFERED=1
 
-# Copy from the cache instead of linking since it's a mounted volume
-ENV UV_LINK_MODE=copy
-
 WORKDIR /app
 
 # Copy dependency files first for better caching
@@ -24,7 +21,10 @@ RUN pip install --no-cache-dir --upgrade pip && \
 COPY . .
 
 # Install project dependencies, sync to uv's lockfile
-RUN uv sync --frozen
+# Use --no-dev to avoid installing development dependencies in production
+# Set UV_SYSTEM_PYTHON to use the system Python instead of creating a venv
+ENV UV_SYSTEM_PYTHON=1
+RUN uv sync --frozen --no-dev
 
 # Expose the port
 EXPOSE 8080

--- a/python/agents/data-science/README.md
+++ b/python/agents/data-science/README.md
@@ -470,6 +470,14 @@ Service [data-science-agent] revision [data-science-agent-00001-aaa] has been de
 Open the Cloud Run Service URL outputted by the previous step.
 You should see the ADK Web UI for the Data Science Agent.
 
+### 5. Edit Env Variables in the Cloud Console
+
+1. Go to [Cloud Run console](https://console.cloud.google.com/run).
+2. Select your service **`data-science-agent`**.
+3. Click **Edit & Deploy New Revision**.
+4. Scroll down to **Variables & Secrets → Environment variables**.
+5. Edit/add/remove variables, then **Deploy**.
+
 ### Clean up
 
 You can clean up this agent sample by:


### PR DESCRIPTION
There's an error when trying to deploy to cloud run:

```bash
Step 9/13 : RUN uv sync --frozen
 ---> Running in 45f309245317
error: Querying Python at `/app/.venv/bin/python3` failed with exit status exit status: 127

[stderr]
/app/.venv/bin/python3: error while loading shared libraries: libexpat.so.1: cannot open shared object file: No such file or directory
The command '/bin/sh -c uv sync --frozen' returned a non-zero code: 2
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 2
```

The changes in this branch successfully deploy the data science project to Cloud Run.