### PR TITLE
fix: Dockerfile mvn go fully offline

### DIFF
--- a/java/agents/software-bug-assistant/software-bug-assistant/Dockerfile
+++ b/java/agents/software-bug-assistant/software-bug-assistant/Dockerfile
@@ -1,12 +1,14 @@
 FROM maven:3.8-openjdk-17 AS builder
 WORKDIR /app
 COPY pom.xml .
-RUN mvn dependency:go-offline -B
+RUN mvn -B dependency:go-offline exec:help
 
 COPY src ./src
+RUN mvn -B compile
+
 EXPOSE 8080
 
-ENTRYPOINT ["mvn", "compile", "exec:java", \
+ENTRYPOINT ["mvn", "exec:java", \
      "-Dexec.args=--server.port=8080 \
      --adk.agents.source-dir=src/ \
      --logging.level.com.google.adk.dev=DEBUG \

--- a/java/agents/time-series-forecasting/Dockerfile
+++ b/java/agents/time-series-forecasting/Dockerfile
@@ -3,13 +3,14 @@ FROM maven:3.8-openjdk-17 AS builder
 WORKDIR /app
 
 COPY pom.xml .
-RUN mvn dependency:go-offline -B
+RUN mvn -B dependency:go-offline exec:help
 
 COPY src ./src
+RUN mvn -B compile
 
 EXPOSE 8080
 
-ENTRYPOINT ["mvn", "compile", "exec:java", \
+ENTRYPOINT ["mvn", "exec:java", \
     "-Dexec.args=--server.port=${PORT} \
     --adk.agents.source-dir=src/main/java \
     --logging.level.com.google.adk.dev=DEBUG \


### PR DESCRIPTION
so that internet is not needed at runtime

compile at image build time, not runtime

download the exec plugin at build time