### PR TITLE
fix: normalize agent names to lowercase with hyphens in CI

### DIFF
--- a/.github/workflows/test_templated_agent.yaml
+++ b/.github/workflows/test_templated_agent.yaml
@@ -107,7 +107,7 @@ jobs:
             AGENT_NAME=$(basename \"$TEMPLATE_PATH\")
             DEPLOYMENT_TARGET=\"${{ matrix.deployment_target }}\"
             # Use shorter prefix and truncate if needed to stay under 26 chars
-            TRUNCATED_NAME=$(echo \"$AGENT_NAME\" | cut -c1-21)
+            TRUNCATED_NAME=$(echo \"$AGENT_NAME\" | cut -c1-21 | tr '[:upper:]' '[:lower:]' | tr '_' '-')
             AGENT_GENERATED_NAME=\"test-$TRUNCATED_NAME\"
             
             echo \"--- Testing template: $TEMPLATE_PATH with deployment target: $DEPLOYMENT_TARGET ---\"


### PR DESCRIPTION
## Summary

Normalizes generated agent names in the CI workflow to ensure consistent naming conventions by converting to lowercase and replacing underscores with hyphens.

## Changes

- Updated `TRUNCATED_NAME` variable to transform agent names: uppercase → lowercase, underscores → hyphens
- Prevents naming conflicts in generated test agents

## Example

- `Data_Science_Agent` → `data-science-agent`
- `My_Agent_Name` → `my-agent-name`