### PR TITLE
refactor: migrate from vertexai.preview to vertexai

### DIFF
--- a/python/agents/RAG/rag/agent.py
+++ b/python/agents/RAG/rag/agent.py
@@ -16,7 +16,7 @@ import os
 
 from google.adk.agents import Agent
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import VertexAiRagRetrieval
-from vertexai.preview import rag
+from vertexai import rag
 
 from dotenv import load_dotenv
 from .prompts import return_instructions_root

--- a/python/agents/RAG/rag/shared_libraries/prepare_corpus_and_data.py
+++ b/python/agents/RAG/rag/shared_libraries/prepare_corpus_and_data.py
@@ -15,7 +15,7 @@
 from google.auth import default
 from google.api_core.exceptions import ResourceExhausted
 import vertexai
-from vertexai.preview import rag
+from vertexai import rag
 import os
 from dotenv import load_dotenv, set_key
 import requests


### PR DESCRIPTION
## Summary
Migrates RAG-related code from using the preview API to the stable API.

## Changes Made
Updated import statements in RAG agent files.

## Rationale
The Vertex AI RAG API has moved from preview to stable. Using the stable import ensures:
- Better API stability and support
- Alignment with current Vertex AI best practices
- Future compatibility as preview APIs may be deprecated

## Testing
- Verified import statements are syntactically correct
- No functional changes to the code logic

Fixes #395