### PR TITLE
update dependencies to allow deployment to agent engine

### DIFF
--- a/python/agents/travel-concierge/deployment/deploy.py
+++ b/python/agents/travel-concierge/deployment/deploy.py
@@ -61,9 +61,9 @@ def create(env_vars: dict[str, str]) -> None:
         display_name="Travel-Concierge-ADK",
         description="An Example AgentEngine Deployment",                    
         requirements=[
-            "google-adk (==1.0.0)",
-            "google-cloud-aiplatform[agent_engines] (==1.93.1)",
-            "google-genai (==1.16.1)",
+            "google-adk (>=1.16.0)",
+            "google-cloud-aiplatform[agent_engines] (>=1.93.1)",
+            "google-genai (>=1.16.1)",
             "pydantic (>=2.10.6,<3.0.0)",
             "absl-py (>=2.2.1,<3.0.0)",
             "pydantic (>=2.10.6,<3.0.0)",

--- a/python/agents/travel-concierge/pyproject.toml
+++ b/python/agents/travel-concierge/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10,<3.13"
 [dependency-groups]
 dev = [
     "pytest>=8.3.5",
-    "google-adk[eval]>=1.0.0",
+    "google-adk[eval]>=1.16.0",
     "pytest-asyncio>=0.26.0",
     "agent-starter-pack>=0.14.1",
 ]

--- a/python/agents/travel-concierge/uv.lock
+++ b/python/agents/travel-concierge/uv.lock
@@ -3169,7 +3169,7 @@ deployment = [
 ]
 dev = [
     { name = "agent-starter-pack", specifier = ">=0.14.1" },
-    { name = "google-adk", extras = ["eval"], specifier = ">=1.0.0" },
+    { name = "google-adk", extras = ["eval"], specifier = ">=1.16.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
 ]


### PR DESCRIPTION
Dependencies in `deploy.py` were pinned using `==` while `pyproject.toml` deps were using `>=` causing a mismatch in versions for local vs agent engine deployments.