### PR TITLE
docs: fix grammar error and markdown formatting issues

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -106,5 +106,5 @@ This is not an officially supported Google product. This project is not eligible
 for the
 [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).
 
-The agents in this project are intended for demonstration purposes only. They is
+The agents in this project are intended for demonstration purposes only. They are
 not intended for use in a production environment.

--- a/python/agents/data-science/README.md
+++ b/python/agents/data-science/README.md
@@ -318,7 +318,7 @@ DATASET_CONFIG_FILE='./forecasting_sticker_sales_dataset_config.json'
 ```
 or
 ```bash
-DATASET_CONFIG_FILE='./flights_dataset_config.json
+DATASET_CONFIG_FILE='./flights_dataset_config.json'
 ```
 #### Dataset Configuration File Format
 The two provided configuration files give examples of how to specify
@@ -387,7 +387,7 @@ Airlines flights dataset.
     export ALLOYDB_USER=<your AlloyDB user>
     ```
 
-1.  Connect to your database using `psql:
+1.  Connect to your database using `psql`:
     ```bash
     psql -h $ALLOYDB_HOSTNAME -p $ALLOYDB_PORT -U $ALLOYDB_USER -d $ALLOYDB_DATABASE
     ```


### PR DESCRIPTION
## Summary
• Fixed subject-verb agreement: 'They is' to 'They are' in python/README.md
• Added missing closing quote in data-science README bash example  
• Fixed missing closing backtick for inline code formatting

## Test plan
- [x] Verified changes by reading the modified files
- [x] Confirmed no functional code changes, only documentation fixes