### PR TITLE
chore: add missing uv.lock files to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,22 @@ version: 2
 updates:
   # Python agents with uv.lock files
   - package-ecosystem: "uv"
+    directory: "/python/agents/academic-research"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
     directory: "/python/agents/blog-writer"
     schedule:
       interval: "weekly"
@@ -19,6 +35,22 @@ updates:
 
   - package-ecosystem: "uv"
     directory: "/python/agents/data-science"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/python/agents/financial-advisor"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -82,6 +114,22 @@ updates:
           - "*"
 
   - package-ecosystem: "uv"
+    directory: "/python/agents/marketing-agency"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
     directory: "/python/agents/realtime-conversational-agent/server"
     schedule:
       interval: "weekly"
@@ -99,6 +147,22 @@ updates:
 
   - package-ecosystem: "uv"
     directory: "/python/agents/software-bug-assistant"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/python/agents/short-movie-agents"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -147,6 +211,22 @@ updates:
 
   - package-ecosystem: "uv"
     directory: "/python/agents/personalized-shopping"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/python/agents/podcast_transcript_agent"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
Adds 5 missing Python agent directories to dependabot configuration for automated dependency updates.

## Changes
- Added academic-research
- Added financial-advisor
- Added marketing-agency
- Added podcast_transcript_agent
- Added short-movie-agents

All entries follow the existing configuration pattern with weekly updates on Mondays.