### PR TITLE
Update deploy.py for correcting the whl file name

### DIFF
--- a/python/agents/data-science/deployment/deploy.py
+++ b/python/agents/data-science/deployment/deploy.py
@@ -38,7 +38,7 @@ flags.DEFINE_bool("create", False, "Create a new agent.")
 flags.DEFINE_bool("delete", False, "Delete an existing agent.")
 flags.mark_bool_flags_as_mutual_exclusive(["create", "delete"])
 
-AGENT_WHL_FILE = "data_science-0.1-py3-none-any.whl"
+AGENT_WHL_FILE = "data_science-0.1.0-py3-none-any.whl"
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
The file name has been changed to data_science-0.1.0-py3-none-any.whl from data_science-0.1-py3-none-any.whl 

As part of the commane "uv build --wheel --out-dir deployment", the whl file is created with the name "data_science-0.1.0-py3-none-any.whl". However in the deploy.py , it has been hardcoded to data_science-0.1-py3-none-any.whl 