### PR TITLE
RAG: Remove hard coded Location from grant permissions and docs

### DIFF
--- a/python/agents/RAG/.env.example
+++ b/python/agents/RAG/.env.example
@@ -19,5 +19,5 @@ RAG_CORPUS=YOUR_VALUE_HERE
 # Staging bucket name for ADK agent deployment to Vertex AI Agent Engine (Shall respect this format gs://your-bucket-name)
 STAGING_BUCKET=YOUR_VALUE_HERE
 
-# Agent Engine ID in the following format: projects/<PROJECT_NUMBER>/locations/us-central1/reasoningEngines/<AGENT_ENGINE_ID>
+# Agent Engine ID in the following format: projects/<PROJECT_NUMBER>/locations/<GOOGLE_CLOUD_LOCATION>/reasoningEngines/<AGENT_ENGINE_ID>
 AGENT_ENGINE_ID=YOUR_VALUE_HERE

--- a/python/agents/RAG/README.md
+++ b/python/agents/RAG/README.md
@@ -224,7 +224,7 @@ uv run python deployment/deploy.py
 After deploying the agent, you'll be able to read the following INFO log message:
 
 ```
-Deployed agent to Vertex AI Agent Engine successfully, resource name: projects/<PROJECT_NUMBER>/locations/us-central1/reasoningEngines/<AGENT_ENGINE_ID>
+Deployed agent to Vertex AI Agent Engine successfully, resource name: projects/<PROJECT_NUMBER>/locations/<GOOGLE_CLOUD_LOCATION>/reasoningEngines/<AGENT_ENGINE_ID>
 ```
 
 Please note your Agent Engine resource name and update `.env` file accordingly as this is crucial for testing the remote agent.
@@ -239,14 +239,14 @@ After deploying the agent, follow these steps to test it:
    - Open your `.env` file.
    - The `AGENT_ENGINE_ID` should have been automatically updated by the `deployment/deploy.py` script when you deployed the agent. Verify that it is set correctly:
      ```
-     AGENT_ENGINE_ID=projects/<PROJECT_NUMBER>/locations/us-central1/reasoningEngines/<AGENT_ENGINE_ID>
+     AGENT_ENGINE_ID=projects/<PROJECT_NUMBER>/locations/<GOOGLE_CLOUD_LOCATION>/reasoningEngines/<AGENT_ENGINE_ID>
      ```
 
 2. **Grant RAG Corpus Access Permissions:**
    - Ensure your `.env` file has the following variables set correctly:
      ```
      GOOGLE_CLOUD_PROJECT=your-project-id
-     RAG_CORPUS=projects/<project-number>/locations/us-central1/ragCorpora/<corpus-id>
+     RAG_CORPUS=projects/<project-number>/locations/<GOOGLE_CLOUD_LOCATION>/ragCorpora/<corpus-id>
      ```
    - Run the permissions script:
      ```bash

--- a/python/agents/RAG/deployment/grant_permissions.sh
+++ b/python/agents/RAG/deployment/grant_permissions.sh
@@ -55,7 +55,7 @@ fi
 RAG_CORPUS_ID=$(echo $RAG_CORPUS | awk -F'/' '{print $NF}')
 
 # Define the RAG Corpus resource
-RAG_CORPUS="projects/${PROJECT_NUMBER}/locations/us-central1/ragCorpora/${RAG_CORPUS_ID}"
+RAG_CORPUS="projects/${PROJECT_NUMBER}/locations/${GOOGLE_CLOUD_LOCATION}/ragCorpora/${RAG_CORPUS_ID}"
 
 echo "Granting permissions to $SERVICE_ACCOUNT..."
 

--- a/python/agents/RAG/rag/__init__.py
+++ b/python/agents/RAG/rag/__init__.py
@@ -18,7 +18,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+# os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global") #TODO: find why this value is used in deploy instead of config
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent


### PR DESCRIPTION
In the RAG python sample, US-central1 is hard-coded in the grant permission script and as default region.
Deploy would fail.
This PR uses the env variable instead and updates the doc  to be consistant with other usage of env variables