### PR TITLE
chore: add auto-merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -56,8 +56,55 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge PR
+      - name: Checkout code
         if: steps.check.outputs.is_dependabot == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          fetch-depth: 0
+
+      - name: Check if changes are in agents using starter pack for testing
+        if: steps.check.outputs.is_dependabot == 'true'
+        id: check-agent
+        run: |
+          # Get the base branch for comparison
+          BASE_BRANCH=$(gh pr view ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --json baseRefName --jq '.baseRefName')
+          git fetch origin $BASE_BRANCH
+
+          # Get all changed files
+          CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH...HEAD)
+
+          # Check if all changed files are in python/agents/** directories using agent starter pack for testing
+          HAS_AUTOMATED_TESTS=true
+
+          # Get all changed agent directories
+          CHANGED_AGENT_DIRS=$(echo "$CHANGED_FILES" | grep -o 'python/agents/[^/]*' | sort -u || true)
+
+          if [ -z "$CHANGED_AGENT_DIRS" ]; then
+            echo "No changes in python/agents/** directories"
+            HAS_AUTOMATED_TESTS=false
+          else
+            for dir in $CHANGED_AGENT_DIRS; do
+              if [ ! -f "$dir/pyproject.toml" ]; then
+                echo "$dir does not have pyproject.toml"
+                HAS_AUTOMATED_TESTS=false
+                break
+              fi
+
+              if ! grep -q '\[tool\.agent-starter-pack\]' "$dir/pyproject.toml"; then
+                echo "$dir is not using agent starter pack for testing"
+                HAS_AUTOMATED_TESTS=false
+                break
+              fi
+            done
+          fi
+
+          echo "has_tests=$HAS_AUTOMATED_TESTS" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge PR
+        if: steps.check.outputs.is_dependabot == 'true' && steps.check-agent.outputs.has_tests == 'true'
         run: gh pr merge ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --squash --auto
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implements automatic approval and merging of Dependabot pull requests once all CI checks pass successfully.

- Auto-approves Dependabot PRs when opened
- Auto-merges Dependabot PRs only after all check suites complete successfully
- Uses squash merge strategy for clean commit history