### PR TITLE
fix: support both Dependabot author formats in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -74,7 +74,7 @@ jobs:
           echo "PR Mergeable: $PR_MERGEABLE"
           echo "PR State: $PR_STATE"
 
-          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ] || [ "$PR_AUTHOR" = "app/dependabot" ]; then
             echo "is_dependabot=true" >> $GITHUB_OUTPUT
           else
             echo "is_dependabot=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fixed auto-merge workflow failing to detect Dependabot PRs when the author is returned as `app/dependabot` instead of `dependabot[bot]`.

## Changes
- Updated author check to accept both `dependabot[bot]` and `app/dependabot` formats