### PR TITLE
fix: enforce GOOGLE_CLOUD_LOCATION environment variable

### DIFF
--- a/python/agents/RAG/rag/__init__.py
+++ b/python/agents/RAG/rag/__init__.py
@@ -18,7 +18,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent

--- a/python/agents/academic-research/academic_research/__init__.py
+++ b/python/agents/academic-research/academic_research/__init__.py
@@ -23,7 +23,7 @@ load_dotenv()
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent

--- a/python/agents/blog-writer/blogger_agent/config.py
+++ b/python/agents/blog-writer/blogger_agent/config.py
@@ -24,7 +24,7 @@ import google.auth
 # 2. This will override the default Vertex AI configuration
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 

--- a/python/agents/customer-service/customer_service/__init__.py
+++ b/python/agents/customer-service/customer_service/__init__.py
@@ -20,7 +20,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent

--- a/python/agents/deep-search/app/config.py
+++ b/python/agents/deep-search/app/config.py
@@ -24,7 +24,7 @@ import google.auth
 # 2. This will override the default Vertex AI configuration
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 

--- a/python/agents/financial-advisor/financial_advisor/__init__.py
+++ b/python/agents/financial-advisor/financial_advisor/__init__.py
@@ -20,7 +20,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent

--- a/python/agents/image-scoring/image_scoring/agent.py
+++ b/python/agents/image-scoring/image_scoring/agent.py
@@ -16,7 +16,7 @@ from google.adk.agents.callback_context import CallbackContext
 # 2. This will override the default Vertex AI configuration
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 

--- a/python/agents/marketing-agency/marketing_agency/__init__.py
+++ b/python/agents/marketing-agency/marketing_agency/__init__.py
@@ -23,7 +23,7 @@ load_dotenv()
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent

--- a/python/agents/personalized-shopping/personalized_shopping/__init__.py
+++ b/python/agents/personalized-shopping/personalized_shopping/__init__.py
@@ -18,7 +18,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 import torch

--- a/python/agents/software-bug-assistant/software_bug_assistant/__init__.py
+++ b/python/agents/software-bug-assistant/software_bug_assistant/__init__.py
@@ -18,7 +18,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent

--- a/python/agents/travel-concierge/travel_concierge/__init__.py
+++ b/python/agents/travel-concierge/travel_concierge/__init__.py
@@ -18,7 +18,7 @@ import google.auth
 
 _, project_id = google.auth.default()
 os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from . import agent


### PR DESCRIPTION
## Summary

This PR enforces proper environment variable configuration for Google Cloud location settings.

### Changes

- Changed `GOOGLE_CLOUD_LOCATION` from `setdefault()` to direct assignment to ensure consistent value across all agents
- Applied change to all agent configurations (RAG, academic-research, blog-writer, customer-service, deep-search)
- Ensures agents use the correct "global" location for Vertex AI operations

### Why

Using `setdefault()` allows the environment variable to be overridden by shell configurations, which can cause inconsistent behavior. Direct assignment ensures all agents use the intended location.