### PR TITLE
docs: fix inconsistent setup instructions in travel-concierge README: use uv instead of poetry

### DIFF
--- a/python/agents/travel-concierge/README.md
+++ b/python/agents/travel-concierge/README.md
@@ -151,12 +151,11 @@ Expand on the "Key Components" from above.
     gcloud auth application-default login
     ```
 
-5. Activate the virtual environment set up by Poetry, run:
+5. (Optional) Activate the virtual environment:
     ```bash
-    eval $(poetry env activate)
-    (travel-concierge-py3.12) $ # Virtualenv entered
+    source .venv/bin/activate
     ```
-    Repeat this command whenever you have a new shell, before running the commands in this README.
+    Note: If you prefer not to activate the environment, you can run any command in this README by prefixing it with `uv run` (e.g., `uv run adk run travel_concierge`).
 
 ## Running the Agent
 
@@ -167,13 +166,13 @@ You may talk to the agent using the CLI:
 
 ```bash
 # Under the travel-concierge directory:
-adk run travel_concierge
+uv run adk run travel_concierge
 ```
 
 or via its web interface:
 ```bash
 # Under the travel-concierge directory:
-adk web
+uv run adk web
 ```
 
 This will start a local web server on your machine. You may open the URL, select "travel_concierge" in the top-left drop-down menu, and


### PR DESCRIPTION
This PR fixes inconsistent setup and execution instructions in the `travel-concierge` sample.

**Changes:**
- Removed obsolete references to `poetry env activate` in the installation steps.
- Aligned documentation with the project's use of `uv` (as evidenced by the existing `uv.lock` file).
- Updated the "Running the Agent" section to recommend the `uv run` workflow.
- Standardized command examples to use `uv run adk ...` for better developer experience and reliability.
 
### Motivation
Currently, the README directs users to install dependencies with `uv sync` but then attempts to activate a non-existent Poetry environment. This creates a "breaking point" for new developers trying to run the sample. These changes ensure a smooth, end-to-end setup process using the modern `u toolchain already adopted by the repository.

### CLA
I have signed the Google CLA with the email associated with this commit.