### PR TITLE
fix(pyproject.toml): resolve duplicate dependency tables via PEP 621

### DIFF
--- a/python/agents/RAG/pyproject.toml
+++ b/python/agents/RAG/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
         { name = "Hangfei Lin", email = "hangfei@google.com" },
         { name = "Chouaieb Nemri", email = "nemri@google.com" },
 ]
-license = { text = "Apache-2.0" }
+license = { text = "Apache License 2.0" }
 readme = "README.md"
 dependencies = [
     "google-cloud-aiplatform[adk,agent-engines]>=1.108.0",
@@ -17,6 +17,7 @@ dependencies = [
     "requests>=2.32.3",
     "llama-index>=0.12",
 ]
+requires-python = ">=3.11,<3.13"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"

--- a/python/agents/RAG/pyproject.toml
+++ b/python/agents/RAG/pyproject.toml
@@ -1,12 +1,12 @@
-[tool.poetry]
+[project]
 name = "rag"
 version = "0.1.0"
 description = "Answer questions related to Vertex AI documentation using Vertex AI RAG Engine"
 authors = [
-        "Hangfei Lin <hangfei@google.com>",
-        "Chouaieb Nemri <nemri@google.com>",
+        { name = "Hangfei Lin", email = "hangfei@google.com" },
+        { name = "Chouaieb Nemri", email = "nemri@google.com" },
 ]
-license = "Apache License 2.0"
+license = { text = "Apache-2.0" }
 readme = "README.md"
 dependencies = [
     "google-cloud-aiplatform[adk,agent-engines]>=1.108.0",


### PR DESCRIPTION
# Fix pyproject.toml duplicate dependency tables by aligning with PEP 621

## Problem:
The current `pyproject.toml` declares dependencies twice under
`[tool.poetry]` and `[tool.poetry.dependencies]`, which creates duplicate table declarations and is invalid TOML.

This causes:
- `poetry install` to fail with a duplicate table error
- `uv sync` to fail during TOML parsing

## Solution:
- Move project metadata and dependencies to `[project]` per PEP 621
- Retain `[tool.poetry.dependencies]` for Poetry compatibility
- Remove duplicate dependency declaration

Verification:

### Before:

```bash
abhijith@Abhijiths-MacBook-Air RAG % poetry install

/Users/abhijith/adk-samples/python/agents/RAG/pyproject.toml is not a valid TOML file.
TOMLDecodeError: Cannot declare ('tool', 'poetry', 'dependencies') twice (at line 21, column 26)

abhijith@Abhijiths-MacBook-Air RAG % uv sync
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 21, column 14
     |
  21 | [tool.poetry.dependencies]
     |              ^^^^^^^^^^^^
  duplicate key

error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 21, column 14
   |
21 | [tool.poetry.dependencies]
   |              ^^^^^^^^^^^^
duplicate key
```

### After:

```bash
abhijith@Abhijiths-MacBook-Air RAG % poetry install
Creating virtualenv rag-ZkpOJD3b-py3.11 in /Users/abhijith/Library/Caches/pypoetry/virtualenvs
Updating dependencies
Resolving dependencies... (79.4s)

Package operations: 170 installs, 0 updates, 0 removals

abhijith@Abhijiths-MacBook-Air RAG % uv sync
Resolved 197 packages in 1.57s
      Built rag @ file:///Users/abhijith/adk-samples/python/agents/RAG
```
