### PR TITLE
fix: Set GEMINI_API_KEY in workflow environment

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -140,6 +140,9 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Set GEMINI_API_KEY
+        run: echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" >> $GITHUB_ENV
+
       - name: 'Run Gemini PR Review'
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_pr_review'


### PR DESCRIPTION
Adds a step to export the GEMINI_API_KEY secret to the GitHub Actions environment, ensuring it is available for subsequent workflow steps.