### PR TITLE
Fix: Mitigate RCE vulnerability in test_templated_agent.yaml workflow

### DIFF
--- a/.github/workflows/test_templated_agent.yaml
+++ b/.github/workflows/test_templated_agent.yaml
@@ -73,7 +73,6 @@ jobs:
     # --- PERMISSIONS BLOCK FOR OIDC AUTHENTICATION ---
     permissions:
       contents: 'read'
-      id-token: 'write'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
By removing id-token: 'write', we are revoking the workflow's permission to get that token.