### PR TITLE
Feat/update repo perms

### DIFF
--- a/.github/workflows/ruff-checks.yml
+++ b/.github/workflows/ruff-checks.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write # Essential for posting the suggestion comments
+  id-token: write
 
 jobs:
   ruff-format-suggestions:
@@ -23,7 +24,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
-    
+
       - name: Install Reviewdog
         uses: reviewdog/action-setup@v1
         with:


### PR DESCRIPTION
Add OIDC permissions for GitHub Actions auth

The CI runs were failing during the authentication step because the workflow didn't have permission to request an ID token from Google Cloud. 

I’ve updated the permissions block in the Checks.yml file to include id-token: write.