### PR TITLE
docs(rag): add pip install fallback to README

### DIFF
--- a/python/agents/RAG/README.md
+++ b/python/agents/RAG/README.md
@@ -56,10 +56,15 @@ This diagram outlines the agent's workflow, designed to provide informed and con
 
 2.  **Install Dependencies:**
 
+    If you have `uv` installed (recommended):
     ```bash
     uv sync
     ```
 
+    Alternatively, using standard `pip`:
+    ```bash
+    pip install .
+    ```
     This command reads the `pyproject.toml` file and installs all the necessary dependencies into a virtual environment.
 
 3.  **Set up Environment Variables:**


### PR DESCRIPTION
While testing the RAG sample, I encountered an error because the README only provided uv sync instructions, and there was no requirements.txt. I have verified that pip install . works correctly as a fallback for users not using uv. Updated the README to include both options.