### PR TITLE
Fix: remove hardcoded us-central1 for RAG engine region

### DIFF
--- a/python/agents/data-science/data_science/utils/reference_guide_RAG.py
+++ b/python/agents/data-science/data_science/utils/reference_guide_RAG.py
@@ -28,7 +28,7 @@ load_dotenv(dotenv_path=env_file_path)
 
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
 corpus_name = os.getenv("BQML_RAG_CORPUS_NAME")
-
+LOCATION = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 display_name = "bqml_referenceguide_corpus"
 
 paths = [
@@ -37,7 +37,7 @@ paths = [
 
 
 # Initialize Vertex AI API once per session
-vertexai.init(project=PROJECT_ID, location="us-central1")
+vertexai.init(project=PROJECT_ID, location=LOCATION)
 
 
 def create_RAG_corpus():


### PR DESCRIPTION
## Description

This PR removes the hardcoded `us-central1` location in the RAG example and instead reads the region from the `GOOGLE_CLOUD_LOCATION` environment variable.

## Motivation

For new Google Cloud projects, RAG Engine is restricted in `us-central1`, `us-east1`, and `us-east4`. The current example fails with an `INVALID_ARGUMENT` error in those regions.

Using the environment variable improves flexibility and prevents unnecessary errors.

## Changes

- Replaced hardcoded region in - adk-samples/python/agents/data-science/utils/reference_guide_RAG.py - with environment variable fallback
- Preserved backward compatibility by defaulting to `us-central1`