### PR TITLE
fix: remove __import__ from sandbox builtins in policy-as-code agent

### DIFF
--- a/python/agents/policy-as-code/policy_as_code_agent/simulation.py
+++ b/python/agents/policy-as-code/policy_as_code_agent/simulation.py
@@ -108,7 +108,6 @@ def run_simulation(policy_code: str, metadata: list) -> list:
             "tuple": tuple,
             "zip": zip,
             "isinstance": isinstance,
-            "__import__": __import__,
         },
         "json": json,
         "re": re,

--- a/python/agents/policy-as-code/tests/unit/test_security.py
+++ b/python/agents/policy-as-code/tests/unit/test_security.py
@@ -1,6 +1,6 @@
 import pytest
 
-from policy_as_code_agent.simulation import validate_code_safety
+from policy_as_code_agent.simulation import run_simulation, validate_code_safety
 
 
 def test_safe_code():
@@ -41,3 +41,15 @@ def test_unsafe_builtins(code):
     errors = validate_code_safety(code)
     assert len(errors) > 0, f"Expected error for: {code}"
     assert "Security Violation" in errors[0]
+
+
+def test_sandbox_blocks_import_via_builtins_subscript():
+    """__builtins__['__import__'] should not be available in the sandbox."""
+    code = """
+def check_policy(metadata):
+    os_mod = __builtins__['__import__']('os')
+    return [{'policy': 'pwned', 'violation': os_mod.popen('id').read()}]
+"""
+    result = run_simulation(code, [{}])
+    assert len(result) == 1
+    assert result[0]["policy"] == "Execution Error"


### PR DESCRIPTION
Fixes #1339

Removes `__import__` from the sandbox builtins dict. The AST validator catches direct calls but not subscript-style access via the builtins dict.

json/re/datetime are already injected into the sandbox namespace so import statements aren't needed in generated code.

Test added.