### PR TITLE
fix(personalized-shopping): gym 0.26 env checker and uv indexing

### DIFF
--- a/python/agents/personalized-shopping/personalized_shopping/shared_libraries/init_env.py
+++ b/python/agents/personalized-shopping/personalized_shopping/shared_libraries/init_env.py
@@ -24,10 +24,13 @@ gym.envs.registration.register(
 
 
 def init_env(num_products):
+    # WebAgentTextEnv predates Gym 0.26's PassiveEnvChecker; it does not set
+    # action_space / observation_space (actions are free-form strings).
     return gym.make(
         "WebAgentTextEnv-v0",
         observation_mode="text",
         num_products=num_products,
+        disable_env_checker=True,
     )
 
 

--- a/python/agents/personalized-shopping/personalized_shopping/shared_libraries/search_engine/run_indexing.sh
+++ b/python/agents/personalized-shopping/personalized_shopping/shared_libraries/search_engine/run_indexing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+# uv discovers pyproject.toml in a parent directory; cwd must stay here for
+# resources_* and indexes_* paths.
+PYTHON=(uv run python)
 
-python -m pyserini.index.lucene \
+"${PYTHON[@]}" -m pyserini.index.lucene \
   --collection JsonCollection \
   --input resources_100 \
   --index indexes_100 \
@@ -22,7 +28,7 @@ python -m pyserini.index.lucene \
   --threads 1 \
   --storePositions --storeDocvectors --storeRaw
 
-python -m pyserini.index.lucene \
+"${PYTHON[@]}" -m pyserini.index.lucene \
   --collection JsonCollection \
   --input resources_1k \
   --index indexes_1k \
@@ -30,7 +36,7 @@ python -m pyserini.index.lucene \
   --threads 1 \
   --storePositions --storeDocvectors --storeRaw
 
-python -m pyserini.index.lucene \
+"${PYTHON[@]}" -m pyserini.index.lucene \
   --collection JsonCollection \
   --input resources_10k \
   --index indexes_10k \
@@ -38,7 +44,7 @@ python -m pyserini.index.lucene \
   --threads 1 \
   --storePositions --storeDocvectors --storeRaw
 
-python -m pyserini.index.lucene \
+"${PYTHON[@]}" -m pyserini.index.lucene \
   --collection JsonCollection \
   --input resources_50k \
   --index indexes_50k \


### PR DESCRIPTION
## What

Fix local WebShop setup when using Gym 0.26 and uv-managed environments: disable the passive env checker for the legacy text env, and run Pyserini indexing through `uv run python`.

## Why

Gym 0.26 wraps envs in `PassiveEnvChecker`, which requires `action_space` / `observation_space`. `WebAgentTextEnv` uses free-form string actions and never defined those, so `gym.make` fails at runtime after data loads. Separately, `run_indexing.sh` invoked bare `python`, which is often missing on macOS when only `uv` is used.

## How

- Pass `disable_env_checker=True` in `init_env.py` when creating `WebAgentTextEnv-v0`.
- Change `run_indexing.sh` to run from the `search_engine` directory and call `uv run python -m pyserini.index.lucene` for each index size.

## Tests

- [ ] `uv run python convert_product_file_format.py` and `bash run_indexing.sh` from `shared_libraries/search_engine` (with data present)
- [ ] `uv run adk web` from the agent project root; trigger a search tool call and confirm no `AssertionError` from Gym env checker


Made with [Cursor](https://cursor.com)