### PR TITLE
feat: add receipt-signing research agent sample

### DIFF
--- a/python/agents/receipt-signing-agent/README.md
+++ b/python/agents/receipt-signing-agent/README.md
@@ -1,0 +1,113 @@
+# Receipt-Signing Agent - Cryptographic Audit Trail for ADK
+
+**Created by [Tom Farley](https://github.com/tomjwxf)**
+
+A research agent that produces Ed25519-signed cryptographic receipts for every tool call. Receipts follow the [IETF Internet-Draft](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) format and are independently verifiable offline.
+
+## Why
+
+When ADK agents run in production, compliance teams need verifiable proof of what happened. Centralized logs can be tampered with. This agent produces a signed receipt chain where:
+
+- Every tool call is Ed25519-signed (tamper-evident)
+- Tool inputs/outputs are SHA-256 hashed (privacy-preserving)
+- Receipts are chain-linked via previousReceiptHash (ordering is tamper-evident)
+- Anyone can verify offline without trusting the agent operator
+
+## Project Structure
+
+```
+receipt-signing-agent/
+├── README.md
+├── pyproject.toml
+├── receipt_agent/
+│   ├── __init__.py
+│   ├── agent.py          # Agent definition with ReceiptPlugin
+│   └── tools.py          # Example research tools
+└── tests/
+    └── test_receipts.py  # Verify receipt chain integrity
+```
+
+## Setup
+
+```bash
+# Install dependencies
+pip install google-adk protect-mcp-adk
+
+# Set your Gemini API key
+export GOOGLE_API_KEY=your-key-here
+```
+
+## Run
+
+```bash
+# Run with ADK dev server
+cd receipt-signing-agent
+adk web
+```
+
+Or programmatically:
+
+```python
+from receipt_agent.agent import agent, receipt_plugin
+
+# After agent runs, check receipts
+print(f"Receipts signed: {receipt_plugin.receipt_count}")
+receipt_plugin.export_receipts("receipts.jsonl")
+print(f"Verify: {receipt_plugin.get_verification_command()}")
+```
+
+## Verify Receipts
+
+After the agent runs, verify the entire receipt chain:
+
+```bash
+npx @veritasacta/verify@0.2.5 receipts.jsonl --key <public-key-hex>
+# Exit 0 = all valid, 1 = tampered, 2 = malformed
+```
+
+## How It Works
+
+The agent uses the `ReceiptPlugin` from [protect-mcp-adk](https://pypi.org/project/protect-mcp-adk/), which hooks into ADK's `BasePlugin` interface:
+
+1. `after_tool_callback` fires after every tool execution
+2. The plugin signs `JCS(payload)` with Ed25519 (RFC 8032 + RFC 8785)
+3. Each receipt links to the previous via `previousReceiptHash`
+4. Receipts are exported as JSONL for offline verification
+
+## Receipt Format
+
+```json
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "spec": "draft-farley-acta-signed-receipts-01",
+    "tool_name": "web_search",
+    "tool_input_hash": "sha256:ff7e27...",
+    "decision": "allow",
+    "output_hash": "sha256:a3f8c9...",
+    "session_id": "sess_a1b2c3",
+    "sequence": 1,
+    "previousReceiptHash": null
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:adk:de073ae6",
+    "sig": "3da316..."
+  }
+}
+```
+
+## Interoperability
+
+Receipts produced by this agent verify against the same tooling used by:
+- [protect-mcp](https://npmjs.com/package/protect-mcp) (TypeScript, MCP/Claude Code)
+- [Agent Passport System](https://github.com/aeoess/agent-passport-system) (TypeScript)
+
+Four independent implementations produce interoperable receipts following the same IETF draft.
+
+## Links
+
+- [protect-mcp-adk on PyPI](https://pypi.org/project/protect-mcp-adk/)
+- [IETF Draft: Signed Receipts](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/)
+- [Verifier](https://npmjs.com/package/@veritasacta/verify) (Apache-2.0, offline)
+- [Veritas Acta Protocol](https://veritasacta.com)

--- a/python/agents/receipt-signing-agent/pyproject.toml
+++ b/python/agents/receipt-signing-agent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "receipt-signing-agent"
+version = "0.1.0"
+description = "ADK agent with Ed25519 receipt signing for every tool call"
+requires-python = ">=3.10"
+dependencies = [
+    "google-adk>=1.0.0",
+    "protect-mcp-adk>=0.1.0",
+]

--- a/python/agents/receipt-signing-agent/receipt_agent/__init__.py
+++ b/python/agents/receipt-signing-agent/receipt_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Receipt-signing ADK agent with cryptographic audit trail."""

--- a/python/agents/receipt-signing-agent/receipt_agent/agent.py
+++ b/python/agents/receipt-signing-agent/receipt_agent/agent.py
@@ -1,0 +1,41 @@
+"""
+Receipt-signing research agent.
+
+Every tool call produces an Ed25519-signed receipt following the
+IETF Internet-Draft format (draft-farley-acta-signed-receipts).
+Receipts are independently verifiable offline.
+"""
+
+from google.adk import Agent
+from google.adk.tools import FunctionTool
+from protect_mcp_adk import ReceiptPlugin, ReceiptSigner
+
+from . import tools
+
+# Initialize receipt signing
+# In production, load from file: ReceiptSigner.from_key_file("keys/agent.json")
+signer = ReceiptSigner.generate()
+
+receipt_plugin = ReceiptPlugin(
+    signer,
+    auto_export_path="receipts.jsonl",
+    log_receipts=True,
+)
+
+# Create the agent with receipt signing enabled
+agent = Agent(
+    model="gemini-2.0-flash",
+    name="research_agent",
+    instruction=(
+        "You are a research assistant that helps users investigate topics. "
+        "Use web_search to find information, read_document to extract content, "
+        "and analyze_data to produce insights. "
+        "Every tool call you make is cryptographically signed for audit purposes."
+    ),
+    tools=[
+        FunctionTool(tools.web_search),
+        FunctionTool(tools.read_document),
+        FunctionTool(tools.analyze_data),
+    ],
+    plugins=[receipt_plugin],
+)

--- a/python/agents/receipt-signing-agent/receipt_agent/tools.py
+++ b/python/agents/receipt-signing-agent/receipt_agent/tools.py
@@ -1,0 +1,59 @@
+"""Example research tools for the receipt-signing agent."""
+
+
+def web_search(query: str) -> dict:
+    """Search the web for information on a topic.
+
+    Args:
+        query: The search query string.
+
+    Returns:
+        Search results with title, snippet, and URL.
+    """
+    # Placeholder - replace with real search API
+    return {
+        "results": [
+            {
+                "title": f"Result for: {query}",
+                "snippet": f"Information about {query} from web search.",
+                "url": f"https://example.com/search?q={query}",
+            }
+        ],
+        "total_results": 1,
+    }
+
+
+def read_document(url: str) -> dict:
+    """Read and extract content from a document URL.
+
+    Args:
+        url: The URL of the document to read.
+
+    Returns:
+        Document content with title and text.
+    """
+    return {
+        "title": f"Document at {url}",
+        "content": f"Extracted content from {url}",
+        "word_count": 500,
+    }
+
+
+def analyze_data(data_description: str, analysis_type: str = "summary") -> dict:
+    """Analyze data and produce insights.
+
+    Args:
+        data_description: Description of the data to analyze.
+        analysis_type: Type of analysis (summary, trend, comparison).
+
+    Returns:
+        Analysis results with findings and confidence.
+    """
+    return {
+        "analysis_type": analysis_type,
+        "findings": [
+            f"Key finding about {data_description}",
+            f"Secondary insight from {analysis_type} analysis",
+        ],
+        "confidence": 0.85,
+    }

--- a/python/agents/receipt-signing-agent/tests/test_receipts.py
+++ b/python/agents/receipt-signing-agent/tests/test_receipts.py
@@ -1,0 +1,49 @@
+"""Test receipt signing and verification."""
+
+from protect_mcp_adk import ReceiptSigner
+
+
+def test_sign_and_verify():
+    """Test that signed receipts verify correctly."""
+    signer = ReceiptSigner.generate()
+    receipt = signer.sign_tool_call(
+        tool_name="web_search",
+        tool_args={"query": "test"},
+        decision="allow",
+        result={"results": [{"title": "Test"}]},
+    )
+
+    assert receipt.verify(signer.public_key_hex)
+    assert receipt.payload["tool_name"] == "web_search"
+    assert receipt.payload["decision"] == "allow"
+    assert "test" not in receipt.to_json()  # Privacy: raw args not in receipt
+
+
+def test_chain_integrity():
+    """Test that receipt chain links correctly."""
+    signer = ReceiptSigner.generate()
+
+    r1 = signer.sign_tool_call("web_search", {"query": "adk"})
+    r2 = signer.sign_tool_call("read_document", {"url": "https://example.com"})
+    r3 = signer.sign_tool_call("analyze_data", {"data_description": "results"})
+
+    assert r1.payload["previousReceiptHash"] is None
+    assert r2.payload["previousReceiptHash"] is not None
+    assert r3.payload["previousReceiptHash"] is not None
+    assert r1.payload["sequence"] == 1
+    assert r2.payload["sequence"] == 2
+    assert r3.payload["sequence"] == 3
+
+    # All verify
+    for r in [r1, r2, r3]:
+        assert r.verify(signer.public_key_hex)
+
+
+def test_tamper_detection():
+    """Test that tampered receipts fail verification."""
+    signer = ReceiptSigner.generate()
+    receipt = signer.sign_tool_call("web_search", {"query": "test"})
+
+    # Tamper with the payload
+    receipt.payload["decision"] = "deny"
+    assert not receipt.verify(signer.public_key_hex)


### PR DESCRIPTION
## Summary

Adds a sample research agent that produces Ed25519-signed cryptographic receipts for every tool call, using the [protect-mcp-adk](https://pypi.org/project/protect-mcp-adk/) plugin.

## What it demonstrates

- Hooking into ADK's BasePlugin interface for governance
- Ed25519 receipt signing with JCS canonicalization (RFC 8785)
- Privacy-preserving hashing (tool inputs/outputs are SHA-256 hashed, not stored raw)
- Chain-linked receipts (tamper-evident ordering via previousReceiptHash)
- Offline verification with `npx @veritasacta/verify@0.2.5`

## Structure

```
receipt-signing-agent/
├── README.md
├── pyproject.toml
├── receipt_agent/
│   ├── __init__.py
│   ├── agent.py          # Agent with ReceiptPlugin
│   └── tools.py          # 3 example tools
└── tests/
    └── test_receipts.py  # 3 tests: signing, chain, tamper detection
```

## Dependencies

- `google-adk>=1.0.0`
- `protect-mcp-adk>=0.1.0` ([PyPI](https://pypi.org/project/protect-mcp-adk/))

## Receipt format

Follows the [IETF Internet-Draft](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) (draft-farley-acta-signed-receipts-01). Receipts produced by this sample are interoperable with three other independent implementations across TypeScript and Python.

## Related

- ADK issue: https://github.com/google/adk-python/issues/5164
- Show-and-Tell: https://github.com/google/adk-python/discussions/5180