### PR TITLE
fix(ci): restrict pull_request_target job to same-repo PRs only

### DIFF
--- a/.github/workflows/test_templated_agent.yaml
+++ b/.github/workflows/test_templated_agent.yaml
@@ -70,7 +70,11 @@ jobs:
   test-agent-template:
     name: ${{ matrix.task }} | ${{ matrix.agent_path }} (${{ matrix.deployment_target }})
     needs: discover-changed-agents
-    if: needs.discover-changed-agents.outputs.matrix != '[]'
+    # Restrict to same-repo PRs only: pull_request_target runs with write permissions
+    # and access to secrets. Fork PRs must not reach this job to prevent credential theft.
+    if: |
+      needs.discover-changed-agents.outputs.matrix != '[]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     # --- PERMISSIONS BLOCK FOR OIDC AUTHENTICATION ---


### PR DESCRIPTION
## Summary

The `test-agent-template` job in `test_templated_agent.yaml` is triggered by `pull_request_target`, which runs with repository write permissions and `id-token: write` access to the `adk-devops` GCP project via Workload Identity Federation.

**The vulnerability:** Without a repository guard, any fork PR triggers this job, which checks out and executes attacker-controlled code (`make install && make test`) while holding GCP credentials. This is the [GitHub Actions artifact poisoning / `pull_request_target` misconfiguration](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) class of vulnerability (CWE-829).

**Attack path:**
1. Attacker forks the repo and opens a PR that modifies `Makefile` (adds malicious commands to `make install` or `make test`)
2. `pull_request_target` triggers the `test-agent-template` job with the fork code at `github.event.pull_request.head.sha`
3. The job authenticates to GCP via OIDC WIF (`projects/628595556591/.../github-pool`) and then executes the attacker's Makefile
4. Attacker exfiltrates the Google Cloud credentials or abuses the `adk-devops` project

**Fix:** Add a guard condition so the GCP-authenticated job only runs for PRs originating from the same repository:

```yaml
if: |
  needs.discover-changed-agents.outputs.matrix != '[]' &&
  github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs will be silently skipped by this job (the `discover-changed-agents` job will still run, but it only does a file diff with no credentials).

## Changes

- `.github/workflows/test_templated_agent.yaml`: Add `github.event.pull_request.head.repo.full_name == github.repository` guard to `test-agent-template` job's `if:` condition

## Test Plan

- [ ] Same-repo PRs: `test-agent-template` still runs (condition is `true && true`)
- [ ] Fork PRs: `test-agent-template` is skipped (condition is `true && false`)
- [ ] No functional change for the normal contributor workflow

---

*Reported to Google via OSS VRP. Fix PR submitted as part of responsible disclosure.*