### PR TITLE
Use uv to run adk

### DIFF
--- a/python/agents/earth-engine-geospatial/README.md
+++ b/python/agents/earth-engine-geospatial/README.md
@@ -61,13 +61,13 @@ ADK provides convenient ways to bring up agents locally and interact with them.
 You may talk to the agent using the CLI:
 
 ```bash
-adk run earth_engine_geospatial
+uv run adk run earth_engine_geospatial
 ```
 
 Or on a web interface:
 
 ```bash
-adk web
+uv run adk web
 ```
 
 Select `earth_engine_geospatial` from the dropdown.


### PR DESCRIPTION
The current README instructions show how to build a UV environment that includes ADK using `uv sync`, but they don't describe how to use that environment to run ADK. These changes show how to run ADK using the uv-created environment.

(An alternative approach would be to activate the virtual environment before running the ADK command.)