### PR TITLE
Fix typo in academic-research eval docstring (evalualtion -> evaluation)

### DIFF
--- a/python/agents/academic-research/eval/test_eval.py
+++ b/python/agents/academic-research/eval/test_eval.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Basic evalualtion for Academic Research"""
+"""Basic evaluation for Academic Research"""
 
 import pathlib
 


### PR DESCRIPTION
## Summary

Fixes a small typo in the module docstring of `python/agents/academic-research/eval/test_eval.py`:

- `"""Basic evalualtion for Academic Research"""` → `"""Basic evaluation for Academic Research"""`

## Test plan

- No code behavior changes; this is a docstring-only fix.
- Verified `git diff` shows a single character change.


Made with [Cursor](https://cursor.com)