### PR TITLE
fix(multiformat-hybrid-rag): setup-infra parallel commands losing PROJECT_ID

### DIFF
--- a/python/agents/multiformat-hybrid-rag/Makefile
+++ b/python/agents/multiformat-hybrid-rag/Makefile
@@ -42,16 +42,16 @@ setup-infra:
 	@echo "Provisioning infrastructure (APIs, BQ, VS2, Cloud Run, IAM)..."
 	@$(TF_VARS) && cd infra/terraform/dev && terraform init && terraform apply -auto-approve
 	@echo "Building all images in parallel..."
-	@. ./config.env && \
+	@set -a && . ./config.env && set +a && { \
 	gcloud builds submit --config=data_ingestion_pipeline/preprocess_service/cloudbuild.yaml \
 		--substitutions=_IMAGE="$$PREPROCESS_SERVICE_IMAGE" --project="$$PROJECT_ID" . & \
 	gcloud builds submit --config=data_ingestion_pipeline/chunk_index_service/cloudbuild.yaml \
 		--substitutions=_IMAGE="$$CHUNK_INDEX_SERVICE_IMAGE" --project="$$PROJECT_ID" . & \
 	gcloud builds submit --config=data_ingestion_pipeline/cloudbuild.yaml \
 		--substitutions=_IMAGE="$$PIPELINE_IMAGE" --project="$$PROJECT_ID" . & \
-	wait && echo "All images built."
+	wait && echo "All images built."; }
 	@echo "Deploying Cloud Run services..."
-	@. ./config.env && \
+	@set -a && . ./config.env && set +a && { \
 	gcloud run deploy $${PROJECT_NAME:-multiformat-hybrid-rag}-preprocess \
 		--image="$$PREPROCESS_SERVICE_IMAGE" \
 		--region="$$DEFAULT_REGION" \
@@ -62,7 +62,7 @@ setup-infra:
 		--region="$$DEFAULT_REGION" \
 		--project="$$PROJECT_ID" \
 		--quiet & \
-	wait && echo "All services deployed."
+	wait && echo "All services deployed."; }
 
 tf-plan:
 	@if [ ! -f ./config.env ]; then echo "Error: config.env not found"; exit 1; fi


### PR DESCRIPTION
## Summary

`make setup-infra` in `python/agents/multiformat-hybrid-rag` runs `gcloud builds submit` and `gcloud run deploy` in parallel via `&`. On a fresh project, 2 of 3 image builds and 1 of 2 pipeline-service deploys fail with:

```
ERROR: (gcloud.builds.submit) The project property is set to the empty string, which is invalid.
```

The chunk-index Cloud Run service then sits on the placeholder `hello` image, and the data-pipeline / chunk-index-service images never reach Artifact Registry, so `make data-ingestion-remote` later fails with missing-image errors.

## Root cause

Shell precedence binds `&&` tighter than `&`, so

```sh
. ./config.env && cmd1 & cmd2 & cmd3 & wait
```

parses as

```sh
(. ./config.env && cmd1) & cmd2 & cmd3 & wait
```

Only `cmd1`'s subshell sources `config.env`. `cmd2` and `cmd3` run with empty shell variables and pass `--project=""` to gcloud. `config.env` doesn't `export` either, so even fixing the precedence still wouldn't propagate vars to backgrounded children.

## Fix

- `set -a` before sourcing `config.env` so all assignments get exported and inherited by background subshells.
- Wrap the parallel block in `{ ... }` so `set -a; . ./config.env; set +a` runs in the parent shell rather than getting swallowed into the first `&` subshell.

Applied to both the build block and the deploy block in `setup-infra`.

## Test plan

- [x] Reproduced on a fresh GCP project (`test-rag-495411`): 2/3 builds and 1/2 deploys errored, chunk-index left on placeholder image.
- [x] Re-ran `make setup-infra` after the fix — no errors, all 3 images built, both pipeline services deployed with the correct images.
- [x] `make data-ingestion-remote` now succeeds end to end on a fresh project.