### PR TITLE
Add Android guide links to Kotlin and Android READMEs

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -16,7 +16,7 @@ Follow these steps to set up and run the sample agents:
 
 1.  **Prerequisites:**
     *   **Install ADK Kotlin:** Follow the
-        [Android setup guide](https://adk.dev/get-started/installation/#kotlin)
+        [Build ADK agents for Android](https://developer.android.com/ai/adk)
         for project configuration and dependency setup.
     *   **Android Studio** (latest stable release) with Android SDK
         (compileSdk 34+, minSdk 26+).

--- a/android/agents/fun-facts/README.md
+++ b/android/agents/fun-facts/README.md
@@ -12,6 +12,9 @@ fun-facts agent from the [Kotlin samples](../../kotlin/agents/fun-facts/) in a
 Compose-based chat UI, using `InMemoryRunner` inside a ViewModel to manage
 agent interactions.
 
+For a full walkthrough of ADK Android project setup, see
+[Build ADK agents for Android](https://developer.android.com/ai/adk).
+
 ## Agent Details
 
 | Feature | Description |

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -9,6 +9,9 @@ Kotlin](https://github.com/google/adk-kotlin). These agents cover a range of
 common use cases and complexities, from simple conversational bots to complex
 multi-agent workflows.
 
+> **Building for Android?** See the [android/](../android/) samples and the
+> [Build ADK agents for Android](https://developer.android.com/ai/adk) guide.
+
 ## Getting Started with Kotlin Samples
 
 Follow these steps to set up and run the sample agents:


### PR DESCRIPTION
Add links to the new [Build ADK agents for Android](https://developer.android.com/ai/adk) guide:

- Add link in the fun-facts sample README overview
- Fix stale link in the Android samples README
- Add "Building for Android?" callout in the Kotlin samples README