### PR TITLE
Update Kotlin and Android samples for ADK Kotlin 0.2.0

### DIFF
--- a/android/agents/fun-facts/app/src/main/java/com/example/adkdemoapp/agents/FunFactsAgent.kt
+++ b/android/agents/fun-facts/app/src/main/java/com/example/adkdemoapp/agents/FunFactsAgent.kt
@@ -29,7 +29,7 @@ object FunFactsAgent {
     val rootAgent = LlmAgent(
         name = "fun_facts",
         description = "An agent that provides fun facts about a given topic.",
-        model = Gemini(name = "gemini-3-flash-preview", apiKey = BuildConfig.GEMINI_API_KEY),
+        model = Gemini(name = "gemini-flash-latest", apiKey = BuildConfig.GEMINI_API_KEY),
         instruction = Instruction(
             "Provide the most mind-blowing, obscure, and wacky fun facts about "
                     + "the topic. Aim for maximum 'wow' factor with rare and surprising "

--- a/android/agents/fun-facts/gradle/libs.versions.toml
+++ b/android/agents/fun-facts/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 coreKtx = "1.18.0"
-googleAdkKotlinCore = "0.1.0"
+googleAdkKotlinCore = "0.2.0"
 lifecycleRuntimeKtx = "2.10.0"
 lifecycleViewmodelCompose = "2.10.0"
 activityCompose = "1.13.0"

--- a/kotlin/agents/fun-facts/build.gradle.kts
+++ b/kotlin/agents/fun-facts/build.gradle.kts
@@ -9,9 +9,9 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.adk:google-adk-kotlin-core:0.1.0")
-    implementation("com.google.adk:google-adk-kotlin-webserver:0.1.0")
-    ksp("com.google.adk:google-adk-kotlin-processor:0.1.0")
+    implementation("com.google.adk:google-adk-kotlin-core:0.2.0")
+    implementation("com.google.adk:google-adk-kotlin-webserver:0.2.0")
+    ksp("com.google.adk:google-adk-kotlin-processor:0.2.0")
 }
 
 kotlin {
@@ -23,4 +23,8 @@ application {
         project.findProperty("mainClass") as? String
             ?: "com.google.adk.samples.agents.funfacts.MainKt"
     )
+}
+
+tasks.named<JavaExec>("run") {
+    standardInput = System.`in`
 }

--- a/kotlin/agents/fun-facts/src/main/kotlin/com/google/adk/samples/agents/funfacts/FunFactsAgent.kt
+++ b/kotlin/agents/fun-facts/src/main/kotlin/com/google/adk/samples/agents/funfacts/FunFactsAgent.kt
@@ -26,7 +26,7 @@ object FunFactsAgent {
     val rootAgent = LlmAgent(
         name = "fun_facts",
         description = "An agent that provides fun facts about a given topic.",
-        model = Gemini(name = "gemini-2.5-flash"),
+        model = Gemini(name = "gemini-flash-latest"),
         instruction = Instruction(
             "Provide the most mind-blowing, obscure, and wacky fun facts about "
                 + "the topic. Aim for maximum 'wow' factor with rare and surprising "

--- a/kotlin/agents/fun-facts/src/main/kotlin/com/google/adk/samples/agents/funfacts/WebMain.kt
+++ b/kotlin/agents/fun-facts/src/main/kotlin/com/google/adk/samples/agents/funfacts/WebMain.kt
@@ -17,7 +17,6 @@
 package com.google.adk.samples.agents.funfacts
 
 import com.google.adk.kt.artifacts.InMemoryArtifactService
-import com.google.adk.kt.runners.InMemoryRunner
 import com.google.adk.kt.sessions.InMemorySessionService
 import com.google.adk.kt.webserver.AdkWebServer
 import com.google.adk.kt.webserver.loaders.SingleAgentLoader
@@ -33,11 +32,6 @@ fun main() {
         sessionService = sessionService,
         artifactService = artifactService,
         agentLoader = SingleAgentLoader(agent),
-        runner = InMemoryRunner(
-            agent = agent,
-            sessionService = sessionService,
-            artifactService = artifactService,
-        ),
         apiServerSpanExporter = ApiServerSpanExporter(),
     )
 

--- a/kotlin/agents/llm-auditor/build.gradle.kts
+++ b/kotlin/agents/llm-auditor/build.gradle.kts
@@ -9,9 +9,9 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.adk:google-adk-kotlin-core:0.1.0")
-    implementation("com.google.adk:google-adk-kotlin-webserver:0.1.0")
-    ksp("com.google.adk:google-adk-kotlin-processor:0.1.0")
+    implementation("com.google.adk:google-adk-kotlin-core:0.2.0")
+    implementation("com.google.adk:google-adk-kotlin-webserver:0.2.0")
+    ksp("com.google.adk:google-adk-kotlin-processor:0.2.0")
 }
 
 kotlin {
@@ -23,4 +23,8 @@ application {
         project.findProperty("mainClass") as? String
             ?: "com.google.adk.samples.agents.llmauditor.MainKt"
     )
+}
+
+tasks.named<JavaExec>("run") {
+    standardInput = System.`in`
 }

--- a/kotlin/agents/llm-auditor/src/main/kotlin/com/google/adk/samples/agents/llmauditor/LlmAuditorAgent.kt
+++ b/kotlin/agents/llm-auditor/src/main/kotlin/com/google/adk/samples/agents/llmauditor/LlmAuditorAgent.kt
@@ -29,7 +29,7 @@ import com.google.adk.kt.models.Gemini
  *    minimally edits the answer to correct any inaccuracies.
  */
 object LlmAuditorAgent {
-    private val model = Gemini(name = "gemini-2.5-flash")
+    private val model = Gemini(name = "gemini-flash-latest")
 
     @JvmField
     val rootAgent = SequentialAgent(

--- a/kotlin/agents/llm-auditor/src/main/kotlin/com/google/adk/samples/agents/llmauditor/WebMain.kt
+++ b/kotlin/agents/llm-auditor/src/main/kotlin/com/google/adk/samples/agents/llmauditor/WebMain.kt
@@ -17,7 +17,6 @@
 package com.google.adk.samples.agents.llmauditor
 
 import com.google.adk.kt.artifacts.InMemoryArtifactService
-import com.google.adk.kt.runners.InMemoryRunner
 import com.google.adk.kt.sessions.InMemorySessionService
 import com.google.adk.kt.webserver.AdkWebServer
 import com.google.adk.kt.webserver.loaders.SingleAgentLoader
@@ -33,11 +32,6 @@ fun main() {
         sessionService = sessionService,
         artifactService = artifactService,
         agentLoader = SingleAgentLoader(agent),
-        runner = InMemoryRunner(
-            agent = agent,
-            sessionService = sessionService,
-            artifactService = artifactService,
-        ),
         apiServerSpanExporter = ApiServerSpanExporter(),
     )
 


### PR DESCRIPTION
Updates Kotlin and Android samples for the ADK Kotlin 0.2.0 release.

- Bump `google-adk-kotlin-*` deps from 0.1.0 to 0.2.0
- Remove deprecated runner parameter from `AdkWebServer` in `WebMain.kt`
- Add `standardInput` to `gradle run` task so `ReplRunner` accepts input
- Use `gemini-flash-latest` model alias across Kotlin and Android samples