### PR TITLE
fix: blog-writer export delegates to wrong sub-agent (#388)

### DIFF
--- a/python/agents/blog-writer/blogger_agent/agent.py
+++ b/python/agents/blog-writer/blogger_agent/agent.py
@@ -48,7 +48,16 @@ interactive_blogger_agent = Agent(
     5.  **Write:** Once the user approves the outline, you will write the blog post. To do this, use the `robust_blog_writer` tool. Be then open for feedback.
     6.  **Edit:** After the first draft is written, you will present it to the user and ask for feedback. You will then revise the blog post based on the feedback. This process will be repeated until the user is satisfied with the result.
     7.  **Social Media:** After the user approves the blog post, you will ask if they want to generate social media posts to promote the article. If the user agrees to create a social media post, use the `social_media_writer` tool.
-    8.  **Export:** When the user approves the final version, you will ask for a filename and save the blog post as a markdown file. If the user agrees, use the `save_blog_post_to_file` tool to save the blog post.
+    8.  **Export:** When the user approves the final version, or whenever the user asks to save, export, or download the blog post, YOU (the main agent) must handle this directly. Ask the user for a filename and then use the `save_blog_post_to_file` tool to save the blog post as a markdown file. Do NOT delegate save or export requests to any sub-agent.
+
+    **Important: After completing the social media step, proactively offer to save the blog post by asking the user if they would like to export it to a file.**
+
+    **Delegation rules:**
+    - Only delegate to `robust_blog_planner` for creating outlines.
+    - Only delegate to `robust_blog_writer` for writing blog post drafts.
+    - Only delegate to `blog_editor` for editing and revising drafts.
+    - Only delegate to `social_media_writer` for generating social media posts.
+    - NEVER delegate save, export, or file operations to any sub-agent. Handle these yourself using the `save_blog_post_to_file` tool.
 
     Current date: {datetime.datetime.now().strftime("%Y-%m-%d")}
     """,

--- a/python/agents/blog-writer/blogger_agent/sub_agents/social_media_writer.py
+++ b/python/agents/blog-writer/blogger_agent/sub_agents/social_media_writer.py
@@ -21,7 +21,11 @@ social_media_writer = Agent(
     name="social_media_writer",
     description="Writes social media posts to promote the blog post.",
     instruction="""
-    You are a social media marketing expert. You will be given a blog post, and your task is to write social media posts for the following platforms:
+    You are a social media marketing expert. You will be given a blog post, and your task is to write social media posts for the following platforms.
+
+    **Important:** Your ONLY responsibility is writing social media posts. You cannot save files, export content, or perform any file operations. If the user asks to save, export, or download anything, tell them to ask the main assistant to handle that request.
+
+    Write social media posts for the following platforms:
     - Twitter: A short, engaging tweet that summarizes the blog post and includes relevant hashtags.
     - LinkedIn: A professional post that provides a brief overview of the blog post and encourages discussion.
 


### PR DESCRIPTION
Fixes #388

## Problem
The blog-writer agent's export/save functionality was broken. When users asked
to save or export their blog post, the `social_media_writer` sub-agent would
incorrectly respond with "I can't save files directly" instead of the main
agent handling the request with its `save_blog_post_to_file` tool.

## Root Cause
The main agent's instruction didn't explicitly claim ownership of save/export
requests, so after the social media step, the LLM would route the user's save
request to the last active sub-agent (`social_media_writer`) instead of handling
it directly.

## Fix

### `agent.py` (main agent instruction)
- Strengthened Step 8 (Export) to explicitly state the main agent must handle
  all save/export/download requests directly
- Added proactive export offer after social media step
- Added explicit **Delegation rules** clarifying which sub-agent handles what,
  with a clear rule: "NEVER delegate save/export to any sub-agent"

### `social_media_writer.py` (sub-agent boundary)
- Added boundary instruction clarifying file operations are outside its scope
- Directs users back to the main assistant for save requests

## Testing
- After the fix, asking "save this file" or "export this blog post" at any
  point in the workflow will be handled by the main agent using
  `save_blog_post_to_file`
- The social_media_writer no longer attempts to respond to save requests