### PR TITLE
fix(security): prevent prompt injection via issue content in Gemini triage workflow

### DIFF
--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -60,8 +60,8 @@ jobs:
         id: 'gemini_issue_triage'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
-          ISSUE_TITLE: '${{ github.event.issue.title }}'
-          ISSUE_BODY: '${{ github.event.issue.body }}'
+          # ISSUE_TITLE/ISSUE_BODY omitted: prompt-injection vector.
+          # Agent fetches content via GitHub API using ISSUE_NUMBER.
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'
         with:


### PR DESCRIPTION
The `gemini-issue-automated-triage.yml` workflow passes `ISSUE_TITLE` and `ISSUE_BODY` from `github.event.issue` directly as env vars to a `gemini-cli` triage agent. Any user who can open an issue can inject adversarial content that hijacks the agent's behavior. Fix: remove the env vars; the agent uses `ISSUE_NUMBER` to fetch content via the GitHub API.