### PR TITLE
feat: add manifest.yaml for core recipes

### DIFF
--- a/core/rag-agent-search/manifest.yaml
+++ b/core/rag-agent-search/manifest.yaml
@@ -1,0 +1,42 @@
+type: "standalone"
+deployable: false
+large: false
+status: "active"
+language: "python"
+description: "A conversational RAG agent grounded on documents indexed in Google Agent Platform Search (Discovery Engine). Users upload unstructured documents to a GCS bucket, which are automatically ingested and indexed via a managed GCS Data Connector. The agent answers natural-language questions by retrieving relevant passages from the data store and synthesizing grounded answers using Gemini."
+
+architecture:
+  agent: "single"
+  stateful: false
+  datasources:
+    - "local"
+    - "external"
+  rag: true
+
+dependencies:
+  libraries:
+    - "ADK"
+    - "Vertex AI SDK"
+    - "Terraform"
+  services:
+    - "GCP Project"
+    - "Vertex AI API"
+    - "Discovery Engine / Agent Platform Search"
+    - "Google Cloud Storage"
+
+team:
+  name: "ADK Samples"
+  email: "adk-samples@google.com"
+poc:
+  name: "Shahin Saadati"
+  email: "shahins@google.com"
+
+tags:
+  - "rag"
+  - "vertex-ai-search"
+  - "discovery-engine"
+  - "gcs-data-connector"
+  - "grounding"
+  - "gemini"
+  - "terraform"
+  - "single-agent"

--- a/core/rag-vector-search/manifest.yaml
+++ b/core/rag-vector-search/manifest.yaml
@@ -1,0 +1,48 @@
+type: "standalone"
+deployable: false
+large: false
+status: "active"
+language: "python"
+description: "A conversational RAG agent grounded on documents indexed in Vertex AI Vector Search 2.0 (Agent Platform Vector Search). A Kubeflow Pipelines ingestion pipeline chunks documents, stages them in BigQuery, and batch-creates data objects in a VS 2.0 Collection with server-side auto-embedding. The agent answers natural-language questions by retrieving relevant chunks via semantic search and synthesizing grounded answers using Gemini."
+
+architecture:
+  agent: "single"
+  stateful: true
+  datasources:
+    - "hardcoded"
+    - "external"
+  rag: true
+
+dependencies:
+  libraries:
+    - "ADK"
+    - "Vertex AI SDK"
+    - "Kubeflow Pipelines (KFP)"
+    - "LangChain Text Splitters"
+    - "Terraform"
+  services:
+    - "GCP Project"
+    - "Vertex AI API"
+    - "Vertex AI Vector Search 2.0"
+    - "BigQuery"
+    - "Google Cloud Storage"
+    - "Cloud Build"
+
+team:
+  name: "ADK Samples"
+  email: "adk-samples@google.com"
+poc:
+  name: "Shahin Saadati"
+  email: "shahins@google.com"
+
+tags:
+  - "rag"
+  - "vector-search"
+  - "vertex-ai-vector-search"
+  - "kubeflow-pipelines"
+  - "bigquery"
+  - "data-ingestion"
+  - "gemini"
+  - "auto-embedding"
+  - "terraform"
+  - "single-agent"


### PR DESCRIPTION
## Summary

- Adds `manifest.yaml` to `core/rag-agent-search`
- Adds `manifest.yaml` to `core/rag-vector-search`
- Both files conform to the schema defined in `.github/schemas/manifest-schema.json`

## Notes

Both manifests were generated by scanning each recipe directory and inferring field values from the source code, README, AGENTS.md, pyproject.toml, Makefile, and Terraform infrastructure files.