### PR TITLE
Add workflow-sales-analysis-crew: sequential analyst-critic-reporter using Workflow

### DIFF
--- a/python/agents/workflow-sales-analysis-crew/README.md
+++ b/python/agents/workflow-sales-analysis-crew/README.md
@@ -1,0 +1,32 @@
+# Sales Analysis Crew
+
+A minimal multi-agent example showing a sequential analyst-critic-reporter
+pipeline using ADK's `Workflow` class.
+
+## Architecture
+
+Three `Agent` instances are wired in a straight line:
+
+- **analyst** — fetches embedded sales CSV via a function tool, computes
+  regional totals and trends.
+- **critic** — receives the analyst's output and surfaces limitations:
+  sample size, seasonality, missing context.
+- **report_writer** — synthesises both prior outputs into a concise
+  executive summary addressed to senior leadership.
+
+```python
+root_agent = Workflow(
+    name="sales_analysis_crew",
+    edges=[("START", analyst, critic, report_writer)],
+)
+```
+
+## Running locally
+
+```sh
+pip install google-adk python-dotenv
+adk run python/agents/workflow-sales-analysis-crew/agent.py:root_agent
+```
+
+Set `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` in a `.env` file
+or export them before running.

--- a/python/agents/workflow-sales-analysis-crew/agent.py
+++ b/python/agents/workflow-sales-analysis-crew/agent.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sequential analyst → critic → report_writer crew using Workflow.
+
+Three LlmAgents wired in a straight line with ADK's Workflow class.
+Each agent receives the previous agent's output as its node_input.
+No file I/O: the sales dataset is embedded as a constant string and
+returned by the get_sales_data tool used by the analyst.
+"""
+
+from google.adk import Agent
+from google.adk import Workflow
+
+# ---------------------------------------------------------------------------
+# Synthetic sales data (4 regions × 3 months = 12 rows)
+# ---------------------------------------------------------------------------
+
+SALES_CSV = """\
+region,month,revenue_usd,units_sold
+North,January,142500,1140
+North,February,138200,1105
+North,March,159800,1278
+South,January,98700,789
+South,February,87300,698
+South,March,104600,837
+East,January,211400,1690
+East,February,224800,1798
+East,March,198600,1589
+West,January,76200,610
+West,February,81500,652
+West,March,79400,635
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tool: expose the embedded CSV to the analyst
+# ---------------------------------------------------------------------------
+
+
+def get_sales_data() -> str:
+    """Return a 12-row CSV of regional monthly sales figures."""
+    return SALES_CSV
+
+
+# ---------------------------------------------------------------------------
+# Sub-agents
+# ---------------------------------------------------------------------------
+
+analyst = Agent(
+    name="analyst",
+    model="gemini-2.5-flash",
+    instruction="""You are a data analyst.
+
+Use the get_sales_data tool to fetch the sales CSV, then:
+1. Compute total revenue per region across all three months.
+2. Identify the top-performing and bottom-performing region by total revenue.
+3. Compute month-over-month revenue change for each region.
+
+Present your findings as a structured analysis with clearly labelled
+sections: Regional Totals, Top/Bottom Performers, and Month-over-Month
+Trends. Be precise — include the actual numbers.""",
+    tools=[get_sales_data],
+)
+
+critic = Agent(
+    name="critic",
+    model="gemini-2.5-flash",
+    instruction="""You are a critical analyst reviewing a data analysis report.
+
+The analysis you are reviewing:
+{node_input}
+
+Challenge the analysis on at least three of the following dimensions:
+- Sample size limitations (only 3 months of data)
+- Seasonal effects that could distort the ranking
+- Missing context (market size, cost structure, headcount)
+- Variance significance given the small sample
+- Metrics that might tell a different story (units vs. revenue)
+
+Be constructive but direct. Each challenge should be a separate
+paragraph. Do not repeat the original numbers back at length — focus
+on what the analyst missed or overstated.""",
+    tools=[],
+)
+
+report_writer = Agent(
+    name="report_writer",
+    model="gemini-2.5-flash",
+    instruction="""You are an executive communications specialist.
+
+You have access to an analyst report followed by a critical review.
+Your input contains both:
+{node_input}
+
+Write a concise executive summary (aim for 200-300 words) that:
+1. Leads with the most important finding from the analyst.
+2. Acknowledges the top one or two limitations raised by the critic.
+3. Closes with a single recommended next step for leadership.
+
+Use plain prose. No bullet points. No section headers. Write as if
+this will be read by a VP of Sales who has two minutes to spare.""",
+    tools=[],
+)
+
+# ---------------------------------------------------------------------------
+# Workflow: analyst → critic → report_writer
+# ---------------------------------------------------------------------------
+
+root_agent = Workflow(
+    name="sales_analysis_crew",
+    edges=[
+        ("START", analyst, critic, report_writer),
+    ],
+)

--- a/python/agents/workflow-sales-analysis-crew/pyproject.toml
+++ b/python/agents/workflow-sales-analysis-crew/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "workflow-sales-analysis-crew"
+version = "0.1.0"
+description = "Sequential analyst-critic-reporter crew built with ADK Workflow."
+authors = [
+    { name = "Adrian Hartanto", email = "adrianhartanto16@yahoo.com" }
+]
+license = { text = "Apache License 2.0" }
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "google-adk>=1.5.0,<2.0.0",
+    "google-cloud-aiplatform[adk,agent-engines]>=1.100.0,<2.0.0",
+    "python-dotenv>=1.1.1,<2.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "google-adk>=1.5.0,<2.0.0",
+]
+deployment = [
+    "absl-py>=2.2.2",
+    "google-cloud-aiplatform[adk,agent-engines]>=1.100.0",
+]
+
+[tool.ruff]
+extend = "../../../pyproject.toml"
+
+[tool.ruff.lint.isort]
+known-first-party = ["workflow-sales-analysis-crew"]
+
+[tool.agent-starter-pack.settings]
+agent_directory = "workflow-sales-analysis-crew"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
The existing `llm-auditor` example wires agents together with the deprecated `SequentialAgent` class. With ADK 1.x moving to the `Workflow`-based graph API, there is no example in the samples repo that shows a straight analyst→critic→reporter pipeline using the current `edges` convention — the kind of pattern developers reach for first when they want a sequential crew.

This PR adds `python/agents/workflow-sales-analysis-crew/`, a self-contained example with three `Agent` instances (analyst, critic, report_writer) connected via a single `Workflow` edges tuple. The analyst is given a function tool that returns an embedded 12-row synthetic CSV (4 regions × 3 months), so the example requires no file I/O or external data sources. The critic and report_writer operate on the streamed output of the previous step through the standard `{node_input}` mechanism. Running the example requires nothing beyond a valid `GOOGLE_CLOUD_PROJECT` environment variable and `google-adk`.

The file structure and `pyproject.toml` conventions match `workflow-morning_email_debrief`. The model is `gemini-2.5-flash` throughout.

I noticed the gap while following the migration guide from `SequentialAgent` to `Workflow` and found it easier to write a clean example from scratch than to explain the pattern in prose.