### PR TITLE
fix: remove trailing slashes from integration test BASE_URLs to prevent double-slash

### DIFF
--- a/python/agents/genmedia-for-commerce/tests/integration/test_server_e2e.py
+++ b/python/agents/genmedia-for-commerce/tests/integration/test_server_e2e.py
@@ -30,9 +30,9 @@ from requests.exceptions import RequestException
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-BASE_URL = "http://127.0.0.1:8000/"
-STREAM_URL = BASE_URL + "run_sse"
-FEEDBACK_URL = BASE_URL + "feedback"
+BASE_URL = "http://127.0.0.1:8000"
+STREAM_URL = BASE_URL + "/run_sse"
+FEEDBACK_URL = BASE_URL + "/feedback"
 
 HEADERS = {"Content-Type": "application/json"}
 

--- a/python/agents/memory-bank/tests/integration/test_server_e2e.py
+++ b/python/agents/memory-bank/tests/integration/test_server_e2e.py
@@ -30,9 +30,9 @@ from requests.exceptions import RequestException
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-BASE_URL = "http://127.0.0.1:8000/"
-STREAM_URL = BASE_URL + "run_sse"
-FEEDBACK_URL = BASE_URL + "feedback"
+BASE_URL = "http://127.0.0.1:8000"
+STREAM_URL = BASE_URL + "/run_sse"
+FEEDBACK_URL = BASE_URL + "/feedback"
 
 HEADERS = {"Content-Type": "application/json"}
 

--- a/python/agents/multiformat-hybrid-rag/tests/integration/test_server_e2e.py
+++ b/python/agents/multiformat-hybrid-rag/tests/integration/test_server_e2e.py
@@ -29,8 +29,8 @@ from requests.exceptions import RequestException
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-BASE_URL = "http://127.0.0.1:8000/"
-STREAM_URL = BASE_URL + "run_sse"
+BASE_URL = "http://127.0.0.1:8000"
+STREAM_URL = BASE_URL + "/run_sse"
 
 HEADERS = {"Content-Type": "application/json"}
 


### PR DESCRIPTION
Slash at end of BASE_URL causes double-slash in session URLs which results in 404 for integration tests.

Double-url causing line:
```python
session_url = f"{BASE_URL}/apps/software_bug_assistant/users/{user_id}/sessions"`
```