### PR TITLE
ci: add validate-lockfiles workflow to enforce PyPI-only lockfiles and integrity checks

### DIFF
--- a/.github/scripts/check_lockfile_hashes.py
+++ b/.github/scripts/check_lockfile_hashes.py
@@ -1,0 +1,34 @@
+"""
+Checks that every wheel and sdist distribution in a uv.lock file has a hash.
+
+Usage: python check_lockfile_hashes.py <path-to-uv.lock>
+
+Exits 0 if all distributions have hashes, 1 otherwise.
+"""
+
+import sys
+import tomllib
+
+lockfile_path = sys.argv[1]
+with open(lockfile_path, "rb") as f:
+    data = tomllib.load(f)
+
+missing = []
+for pkg in data.get("package", []):
+    name = pkg.get("name", "<unknown>")
+    version = pkg.get("version", "")
+    source = pkg.get("source", {})
+    if source.get("virtual"):
+        continue  # workspace virtual package, no hash needed
+    for dist in pkg.get("wheels", []) + (
+        [pkg["sdist"]] if "sdist" in pkg else []
+    ):
+        if not dist.get("hash"):
+            missing.append(
+                f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}"
+            )
+
+if missing:
+    print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
+    print("\n".join(missing))
+    sys.exit(1)

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -59,7 +59,7 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="${{ github.event.pull_request.base.ref }}"
-            git fetch origin "$BASE_REF" --depth=1
+            git fetch origin "$BASE_REF"
             CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
 
             # Collect directly changed uv.lock files under core/ or contrib/
@@ -84,16 +84,14 @@ jobs:
             WORKFLOW_CHANGED=$(echo "$CHANGED" | grep -E "^\.github/workflows/validate-lockfiles\.yml$" || true)
             if [ -n "$WORKFLOW_CHANGED" ]; then
               echo "Workflow file changed — falling back to full scan."
-              LOCKS=$(find core contrib -name "uv.lock" 2>/dev/null || true)
-              [ -f "uv.lock" ] && LOCKS=$(printf "%s\nuv.lock" "$LOCKS")
+              LOCKS=$(find uv.lock core contrib -name "uv.lock" 2>/dev/null || true)
             fi
 
             # Deduplicate and filter to only existing files
             LOCKS=$(echo "$LOCKS" | sort -u | grep -v '^$' | while read -r f; do [ -f "$f" ] && echo "$f"; done || true)
           else
             # push to main or workflow_dispatch — scan everything
-            LOCKS=$(find core contrib -name "uv.lock" 2>/dev/null || true)
-            [ -f "uv.lock" ] && LOCKS=$(printf "%s\nuv.lock" "$LOCKS")
+            LOCKS=$(find uv.lock core contrib -name "uv.lock" 2>/dev/null || true)
           fi
 
           if [ -z "$LOCKS" ]; then
@@ -113,13 +111,15 @@ jobs:
       # ---------------------------------------------------------------------------
       - name: Check for non-PyPI registry URLs
         if: steps.lockfiles.outputs.lockfiles != ''
+        env:
+          LOCKFILES: ${{ steps.lockfiles.outputs.lockfiles }}
         run: |
           set -euo pipefail
 
           FAILED=0
           INTERNAL_PATTERN='pkg\.dev|artifactregistry\.googleapis\.com'
 
-          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+          for lockfile in $LOCKFILES; do
             MATCHES=$(grep -En "(url|registry)\s*=.*($INTERNAL_PATTERN)" "$lockfile" || true)
             if [ -n "$MATCHES" ]; then
               echo "[FAIL] $lockfile contains non-PyPI registry URLs (pkg.dev or similar):"
@@ -140,18 +140,21 @@ jobs:
 
       # ---------------------------------------------------------------------------
       # Check 2: No git/VCS dependencies
-      # git+https:// or git+ssh:// sources are non-reproducible when the ref is a
-      # branch name, and they bypass registry trust entirely.
+      # In uv.lock, git dependencies are represented as source = { git = "..." }.
+      # These are non-reproducible when the ref is a branch name, and bypass
+      # registry trust entirely.
       # ---------------------------------------------------------------------------
       - name: Check for VCS (git) dependencies
         if: steps.lockfiles.outputs.lockfiles != ''
+        env:
+          LOCKFILES: ${{ steps.lockfiles.outputs.lockfiles }}
         run: |
           set -euo pipefail
 
           FAILED=0
 
-          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
-            MATCHES=$(grep -En "source\s*=.*git\+" "$lockfile" || true)
+          for lockfile in $LOCKFILES; do
+            MATCHES=$(grep -En "source\s*=.*[{,\s](git)\s*=" "$lockfile" || true)
             if [ -n "$MATCHES" ]; then
               echo "[FAIL] $lockfile contains git/VCS dependencies:"
               echo "$MATCHES" | sed 's/^/  /'
@@ -169,19 +172,22 @@ jobs:
           echo "[PASS] No VCS dependencies found."
 
       # ---------------------------------------------------------------------------
-      # Check 3: No local path or file:// dependencies
-      # Local paths only exist on the committer's machine and break all other
-      # environments including CI.
+      # Check 3: No local path or editable dependencies
+      # In uv.lock, path/editable/directory sources use unquoted keys in inline
+      # tables: source = { path = "..." } or source = { editable = "..." }.
+      # These only exist on the committer's machine and break all other environments.
       # ---------------------------------------------------------------------------
       - name: Check for local path dependencies
         if: steps.lockfiles.outputs.lockfiles != ''
+        env:
+          LOCKFILES: ${{ steps.lockfiles.outputs.lockfiles }}
         run: |
           set -euo pipefail
 
           FAILED=0
 
-          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
-            MATCHES=$(grep -En 'source\s*=.*"(path|directory)"' "$lockfile" || true)
+          for lockfile in $LOCKFILES; do
+            MATCHES=$(grep -En 'source\s*=.*[{,\s](path|editable|directory)\s*=' "$lockfile" || true)
             if [ -n "$MATCHES" ]; then
               echo "[FAIL] $lockfile contains local path dependencies:"
               echo "$MATCHES" | sed 's/^/  /'
@@ -206,15 +212,20 @@ jobs:
       # ---------------------------------------------------------------------------
       - name: Check that all packages have hashes
         if: steps.lockfiles.outputs.lockfiles != ''
+        env:
+          LOCKFILES: ${{ steps.lockfiles.outputs.lockfiles }}
         run: |
           set -euo pipefail
 
           FAILED=0
 
-          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+          for lockfile in $LOCKFILES; do
             python3 - "$lockfile" <<'PYEOF'
           import sys
-          import tomllib
+          try:
+              import tomllib
+          except ImportError:
+              import pip._vendor.tomli as tomllib
 
           lockfile_path = sys.argv[1]
           with open(lockfile_path, "rb") as f:
@@ -259,12 +270,14 @@ jobs:
       # ---------------------------------------------------------------------------
       - name: Check lockfiles are up-to-date
         if: steps.lockfiles.outputs.lockfiles != ''
+        env:
+          LOCKFILES: ${{ steps.lockfiles.outputs.lockfiles }}
         run: |
           set -euo pipefail
 
           FAILED=0
 
-          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+          for lockfile in $LOCKFILES; do
             lockdir=$(dirname "$lockfile")
             if [ ! -f "$lockdir/pyproject.toml" ]; then
               continue
@@ -288,7 +301,7 @@ jobs:
       # Check 6: Every pyproject.toml (root, core/, contrib/) must have a sibling
       # uv.lock. Only checked for pyproject.toml files touched in this PR (or all
       # of them on push/dispatch). Skips config-only pyproject.toml files that have
-      # no [project] table and no [tool.uv] table.
+      # no [project] table and no [tool.uv] section.
       # ---------------------------------------------------------------------------
       - name: Check every pyproject.toml has a lockfile
         run: |
@@ -300,12 +313,7 @@ jobs:
             # Include root pyproject.toml and any under core/ or contrib/
             PYPROJECTS=$(echo "$CHANGED" | grep -E "^(pyproject\.toml|(core|contrib)/.*pyproject\.toml)$" || true)
           else
-            PYPROJECTS=$(find . -name "pyproject.toml" \
-              -not -path "./.git/*" \
-              -not -path "./core/*/\.*" \
-              | grep -E "^\./?(pyproject\.toml|(core|contrib)/.+)" \
-              | sed 's|^\./||' \
-              || true)
+            PYPROJECTS=$(find pyproject.toml core contrib -name "pyproject.toml" 2>/dev/null || true)
           fi
 
           if [ -z "$PYPROJECTS" ]; then
@@ -319,7 +327,7 @@ jobs:
             [ -f "$pyproject" ] || continue  # may have been deleted in the PR
 
             HAS_PROJECT=$(grep -c '^\[project\]' "$pyproject" || true)
-            HAS_UV=$(grep -c '^\[tool\.uv\]' "$pyproject" || true)
+            HAS_UV=$(grep -c '^\[tool\.uv' "$pyproject" || true)
             if [ "$HAS_PROJECT" -eq 0 ] && [ "$HAS_UV" -eq 0 ]; then
               continue  # config-only, no lockfile expected
             fi

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -1,0 +1,319 @@
+name: Validate Lockfiles
+
+on:
+  pull_request:
+    paths:
+      - 'core/**/*.lock'
+      - 'core/**/pyproject.toml'
+      - 'contrib/**/*.lock'
+      - 'contrib/**/pyproject.toml'
+      - '.github/workflows/validate-lockfiles.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'core/**/*.lock'
+      - 'core/**/pyproject.toml'
+      - 'contrib/**/*.lock'
+      - 'contrib/**/pyproject.toml'
+      - '.github/workflows/validate-lockfiles.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-lockfiles:
+    name: Check uv.lock files for policy violations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      # ---------------------------------------------------------------------------
+      # Resolve which uv.lock files to validate.
+      #
+      # On pull_request: only lockfiles that were added/modified in this PR, plus
+      #   the sibling uv.lock for any pyproject.toml that was changed.
+      # On push to main or workflow_dispatch: all uv.lock files under core/ and
+      #   contrib/ (full scan as a safety net).
+      #
+      # Samples live exclusively under core/ and contrib/ — nothing outside those
+      # directories is considered.
+      # ---------------------------------------------------------------------------
+      - name: Resolve lockfiles to validate
+        id: lockfiles
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            git fetch origin "$BASE_REF" --depth=1
+            CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+
+            # Collect directly changed uv.lock files under core/ or contrib/
+            LOCKS=$(echo "$CHANGED" | grep -E "^(core|contrib)/.*uv\.lock$" || true)
+
+            # For any changed pyproject.toml, add its sibling uv.lock if it exists
+            PYPROJECTS=$(echo "$CHANGED" | grep -E "^(core|contrib)/.*pyproject\.toml$" || true)
+            for pyproject in $PYPROJECTS; do
+              sibling="$(dirname "$pyproject")/uv.lock"
+              if [ -f "$sibling" ]; then
+                LOCKS=$(printf "%s\n%s" "$LOCKS" "$sibling")
+              fi
+            done
+
+            # Also re-validate everything if the workflow itself changed
+            WORKFLOW_CHANGED=$(echo "$CHANGED" | grep -E "^\.github/workflows/validate-lockfiles\.yml$" || true)
+            if [ -n "$WORKFLOW_CHANGED" ]; then
+              echo "Workflow file changed — falling back to full scan."
+              LOCKS=$(find core contrib -name "uv.lock" 2>/dev/null || true)
+            fi
+
+            # Deduplicate and filter to only existing files
+            LOCKS=$(echo "$LOCKS" | sort -u | grep -v '^$' | while read -r f; do [ -f "$f" ] && echo "$f"; done || true)
+          else
+            # push to main or workflow_dispatch — scan everything
+            LOCKS=$(find core contrib -name "uv.lock" 2>/dev/null || true)
+          fi
+
+          if [ -z "$LOCKS" ]; then
+            echo "No uv.lock files to validate."
+            echo "lockfiles=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Lockfiles to validate:"
+            echo "$LOCKS" | sed 's/^/  /'
+            # Store as space-separated for use in subsequent steps
+            echo "lockfiles=$(echo "$LOCKS" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------------------
+      # Check 1: No internal/non-PyPI registry URLs
+      # Catches pkg.dev (go/airlock) and any other non-pypi.org source hosts.
+      # Lockfiles referencing internal registries cannot be reproduced outside Google.
+      # ---------------------------------------------------------------------------
+      - name: Check for non-PyPI registry URLs
+        if: steps.lockfiles.outputs.lockfiles != ''
+        run: |
+          set -euo pipefail
+
+          FAILED=0
+          INTERNAL_PATTERN='pkg\.dev|artifactregistry\.googleapis\.com'
+
+          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+            MATCHES=$(grep -En "(url|registry)\s*=.*($INTERNAL_PATTERN)" "$lockfile" || true)
+            if [ -n "$MATCHES" ]; then
+              echo "[FAIL] $lockfile contains non-PyPI registry URLs (go/airlock / pkg.dev):"
+              echo "$MATCHES" | sed 's/^/  /'
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "Lockfiles must only reference public PyPI (pypi.org)."
+            echo "Re-run 'uv lock' outside of Google's internal network, or unset internal"
+            echo "registry configuration before locking."
+            exit 1
+          fi
+
+          echo "[PASS] No internal registry URLs found."
+
+      # ---------------------------------------------------------------------------
+      # Check 2: No git/VCS dependencies
+      # git+https:// or git+ssh:// sources are non-reproducible when the ref is a
+      # branch name, and they bypass registry trust entirely.
+      # ---------------------------------------------------------------------------
+      - name: Check for VCS (git) dependencies
+        if: steps.lockfiles.outputs.lockfiles != ''
+        run: |
+          set -euo pipefail
+
+          FAILED=0
+
+          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+            MATCHES=$(grep -En "source\s*=.*git\+" "$lockfile" || true)
+            if [ -n "$MATCHES" ]; then
+              echo "[FAIL] $lockfile contains git/VCS dependencies:"
+              echo "$MATCHES" | sed 's/^/  /'
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "VCS dependencies are not allowed in lockfiles — they are non-reproducible"
+            echo "and bypass registry-level trust. Pin to a released version on PyPI instead."
+            exit 1
+          fi
+
+          echo "[PASS] No VCS dependencies found."
+
+      # ---------------------------------------------------------------------------
+      # Check 3: No local path or file:// dependencies
+      # Local paths only exist on the committer's machine and break all other
+      # environments including CI.
+      # ---------------------------------------------------------------------------
+      - name: Check for local path dependencies
+        if: steps.lockfiles.outputs.lockfiles != ''
+        run: |
+          set -euo pipefail
+
+          FAILED=0
+
+          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+            MATCHES=$(grep -En 'source\s*=.*"(path|directory)"' "$lockfile" || true)
+            if [ -n "$MATCHES" ]; then
+              echo "[FAIL] $lockfile contains local path dependencies:"
+              echo "$MATCHES" | sed 's/^/  /'
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "Local path dependencies cannot be reproduced outside the committer's machine."
+            echo "Publish the package to PyPI or use a workspace dependency instead."
+            exit 1
+          fi
+
+          echo "[PASS] No local path dependencies found."
+
+      # ---------------------------------------------------------------------------
+      # Check 4: All packages must have hashes
+      # Missing hashes mean the lockfile cannot verify supply chain integrity.
+      # uv generates sha256 hashes for all registry packages by default; their
+      # absence indicates the lockfile was tampered with or generated incorrectly.
+      # ---------------------------------------------------------------------------
+      - name: Check that all packages have hashes
+        if: steps.lockfiles.outputs.lockfiles != ''
+        run: |
+          set -euo pipefail
+
+          FAILED=0
+
+          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+            python3 - "$lockfile" <<'PYEOF'
+          import sys
+          import tomllib
+
+          lockfile_path = sys.argv[1]
+          with open(lockfile_path, "rb") as f:
+              data = tomllib.load(f)
+
+          missing = []
+          for pkg in data.get("package", []):
+              name = pkg.get("name", "<unknown>")
+              version = pkg.get("version", "")
+              # Only registry-sourced packages are expected to have hashes.
+              source = pkg.get("source", {})
+              if source.get("virtual"):
+                  continue  # workspace virtual package, no hash needed
+              for dist in pkg.get("wheels", []) + (
+                  [pkg["sdist"]] if "sdist" in pkg else []
+              ):
+                  if not dist.get("hash"):
+                      missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
+
+          if missing:
+              print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
+              print("\n".join(missing))
+              sys.exit(1)
+          PYEOF
+            if [ $? -ne 0 ]; then
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "All distributions must have sha256 hashes for supply chain integrity."
+            echo "Re-generate the lockfile with 'uv lock'."
+            exit 1
+          fi
+
+          echo "[PASS] All distributions have hashes."
+
+      # ---------------------------------------------------------------------------
+      # Check 5: Lockfiles are up-to-date with their pyproject.toml
+      # Catches the "forgot to re-run uv lock after editing pyproject.toml" mistake.
+      # ---------------------------------------------------------------------------
+      - name: Check lockfiles are up-to-date
+        if: steps.lockfiles.outputs.lockfiles != ''
+        run: |
+          set -euo pipefail
+
+          FAILED=0
+
+          for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
+            lockdir=$(dirname "$lockfile")
+            if [ ! -f "$lockdir/pyproject.toml" ]; then
+              continue
+            fi
+
+            # uv lock --check exits non-zero if the lockfile is out of date
+            if ! uv lock --check --project "$lockdir" 2>&1; then
+              echo "[FAIL] $lockfile is out of date with $lockdir/pyproject.toml"
+              echo "  Run 'uv lock' in $lockdir to regenerate it."
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            exit 1
+          fi
+
+          echo "[PASS] All lockfiles are up-to-date."
+
+      # ---------------------------------------------------------------------------
+      # Check 6: Every pyproject.toml under core/ and contrib/ must have a sibling
+      # uv.lock. Only checked for pyproject.toml files touched in this PR (or all
+      # of them on push/dispatch). Skips config-only pyproject.toml files that have
+      # no [project] table (e.g. the repo root ruff/codespell config).
+      # ---------------------------------------------------------------------------
+      - name: Check every pyproject.toml has a lockfile
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            PYPROJECTS=$(git diff --name-only "origin/$BASE_REF"...HEAD \
+              | grep -E "^(core|contrib)/.*pyproject\.toml$" || true)
+          else
+            PYPROJECTS=$(find core contrib -name "pyproject.toml" 2>/dev/null || true)
+          fi
+
+          if [ -z "$PYPROJECTS" ]; then
+            echo "[SKIP] No pyproject.toml files in scope."
+            exit 0
+          fi
+
+          FAILED=0
+
+          for pyproject in $PYPROJECTS; do
+            [ -f "$pyproject" ] || continue  # may have been deleted in the PR
+
+            HAS_PROJECT=$(grep -c '^\[project\]' "$pyproject" || true)
+            HAS_UV=$(grep -c '^\[tool\.uv\]' "$pyproject" || true)
+            if [ "$HAS_PROJECT" -eq 0 ] && [ "$HAS_UV" -eq 0 ]; then
+              continue  # config-only, no lockfile expected
+            fi
+
+            dir=$(dirname "$pyproject")
+            if [ ! -f "$dir/uv.lock" ]; then
+              echo "[FAIL] $pyproject has no sibling uv.lock — run 'uv lock' in $dir"
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            exit 1
+          fi
+
+          echo "[PASS] All in-scope pyproject.toml files have a sibling uv.lock."

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -220,12 +220,9 @@ jobs:
           FAILED=0
 
           for lockfile in $LOCKFILES; do
-            python3 - "$lockfile" <<'PYEOF'
+            python3 - "$lockfile" <<'PYEOF' || FAILED=1
 import sys
-try:
-    import tomllib
-except ImportError:
-    import pip._vendor.tomli as tomllib
+import tomllib
 
 lockfile_path = sys.argv[1]
 with open(lockfile_path, "rb") as f:
@@ -250,9 +247,7 @@ if missing:
     print("\n".join(missing))
     sys.exit(1)
 PYEOF
-            if [ $? -ne 0 ]; then
-              FAILED=1
-            fi
+
           done
 
           if [ "$FAILED" -eq 1 ]; then
@@ -309,6 +304,7 @@ PYEOF
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="${{ github.event.pull_request.base.ref }}"
+            git fetch origin "$BASE_REF"
             CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
             # Include root pyproject.toml and any under core/ or contrib/
             PYPROJECTS=$(echo "$CHANGED" | grep -E "^(pyproject\.toml|(core|contrib)/.*pyproject\.toml)$" || true)

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -3,6 +3,8 @@ name: Validate Lockfiles
 on:
   pull_request:
     paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
       - 'core/**/*.lock'
       - 'core/**/pyproject.toml'
       - 'contrib/**/*.lock'
@@ -12,6 +14,8 @@ on:
     branches:
       - main
     paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
       - 'core/**/*.lock'
       - 'core/**/pyproject.toml'
       - 'contrib/**/*.lock'
@@ -40,12 +44,13 @@ jobs:
       # Resolve which uv.lock files to validate.
       #
       # On pull_request: only lockfiles that were added/modified in this PR, plus
-      #   the sibling uv.lock for any pyproject.toml that was changed.
+      #   the sibling uv.lock for any pyproject.toml that was changed. The root
+      #   uv.lock is included if the root uv.lock or pyproject.toml was touched.
       # On push to main or workflow_dispatch: all uv.lock files under core/ and
-      #   contrib/ (full scan as a safety net).
+      #   contrib/, plus the root uv.lock (full scan as a safety net).
       #
-      # Samples live exclusively under core/ and contrib/ — nothing outside those
-      # directories is considered.
+      # Samples live exclusively under core/ and contrib/. The root uv.lock is
+      # treated separately as repo-level infrastructure.
       # ---------------------------------------------------------------------------
       - name: Resolve lockfiles to validate
         id: lockfiles
@@ -60,7 +65,7 @@ jobs:
             # Collect directly changed uv.lock files under core/ or contrib/
             LOCKS=$(echo "$CHANGED" | grep -E "^(core|contrib)/.*uv\.lock$" || true)
 
-            # For any changed pyproject.toml, add its sibling uv.lock if it exists
+            # For any changed pyproject.toml under core/ or contrib/, add its sibling uv.lock
             PYPROJECTS=$(echo "$CHANGED" | grep -E "^(core|contrib)/.*pyproject\.toml$" || true)
             for pyproject in $PYPROJECTS; do
               sibling="$(dirname "$pyproject")/uv.lock"
@@ -69,11 +74,18 @@ jobs:
               fi
             done
 
+            # Include the root uv.lock if the root uv.lock or pyproject.toml was touched
+            ROOT_CHANGED=$(echo "$CHANGED" | grep -E "^(uv\.lock|pyproject\.toml)$" || true)
+            if [ -n "$ROOT_CHANGED" ] && [ -f "uv.lock" ]; then
+              LOCKS=$(printf "%s\n%s" "$LOCKS" "uv.lock")
+            fi
+
             # Also re-validate everything if the workflow itself changed
             WORKFLOW_CHANGED=$(echo "$CHANGED" | grep -E "^\.github/workflows/validate-lockfiles\.yml$" || true)
             if [ -n "$WORKFLOW_CHANGED" ]; then
               echo "Workflow file changed — falling back to full scan."
               LOCKS=$(find core contrib -name "uv.lock" 2>/dev/null || true)
+              [ -f "uv.lock" ] && LOCKS=$(printf "%s\nuv.lock" "$LOCKS")
             fi
 
             # Deduplicate and filter to only existing files
@@ -81,6 +93,7 @@ jobs:
           else
             # push to main or workflow_dispatch — scan everything
             LOCKS=$(find core contrib -name "uv.lock" 2>/dev/null || true)
+            [ -f "uv.lock" ] && LOCKS=$(printf "%s\nuv.lock" "$LOCKS")
           fi
 
           if [ -z "$LOCKS" ]; then
@@ -272,10 +285,10 @@ jobs:
           echo "[PASS] All lockfiles are up-to-date."
 
       # ---------------------------------------------------------------------------
-      # Check 6: Every pyproject.toml under core/ and contrib/ must have a sibling
+      # Check 6: Every pyproject.toml (root, core/, contrib/) must have a sibling
       # uv.lock. Only checked for pyproject.toml files touched in this PR (or all
       # of them on push/dispatch). Skips config-only pyproject.toml files that have
-      # no [project] table (e.g. the repo root ruff/codespell config).
+      # no [project] table and no [tool.uv] table.
       # ---------------------------------------------------------------------------
       - name: Check every pyproject.toml has a lockfile
         run: |
@@ -283,10 +296,16 @@ jobs:
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_REF="${{ github.event.pull_request.base.ref }}"
-            PYPROJECTS=$(git diff --name-only "origin/$BASE_REF"...HEAD \
-              | grep -E "^(core|contrib)/.*pyproject\.toml$" || true)
+            CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+            # Include root pyproject.toml and any under core/ or contrib/
+            PYPROJECTS=$(echo "$CHANGED" | grep -E "^(pyproject\.toml|(core|contrib)/.*pyproject\.toml)$" || true)
           else
-            PYPROJECTS=$(find core contrib -name "pyproject.toml" 2>/dev/null || true)
+            PYPROJECTS=$(find . -name "pyproject.toml" \
+              -not -path "./.git/*" \
+              -not -path "./core/*/\.*" \
+              | grep -E "^\./?(pyproject\.toml|(core|contrib)/.+)" \
+              | sed 's|^\./||' \
+              || true)
           fi
 
           if [ -z "$PYPROJECTS" ]; then

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -210,6 +210,35 @@ jobs:
       # uv generates sha256 hashes for all registry packages by default; their
       # absence indicates the lockfile was tampered with or generated incorrectly.
       # ---------------------------------------------------------------------------
+      - name: Write hash-check script
+        run: |
+          cat > /tmp/check_hashes.py << 'EOF'
+import sys
+import tomllib
+
+lockfile_path = sys.argv[1]
+with open(lockfile_path, "rb") as f:
+    data = tomllib.load(f)
+
+missing = []
+for pkg in data.get("package", []):
+    name = pkg.get("name", "<unknown>")
+    version = pkg.get("version", "")
+    source = pkg.get("source", {})
+    if source.get("virtual"):
+        continue  # workspace virtual package, no hash needed
+    for dist in pkg.get("wheels", []) + (
+        [pkg["sdist"]] if "sdist" in pkg else []
+    ):
+        if not dist.get("hash"):
+            missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
+
+if missing:
+    print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
+    print("\n".join(missing))
+    sys.exit(1)
+EOF
+
       - name: Check that all packages have hashes
         if: steps.lockfiles.outputs.lockfiles != ''
         env:
@@ -220,33 +249,7 @@ jobs:
           FAILED=0
 
           for lockfile in $LOCKFILES; do
-            python3 - "$lockfile" <<'PYEOF' || FAILED=1
-            import sys
-            import tomllib
-
-            lockfile_path = sys.argv[1]
-            with open(lockfile_path, "rb") as f:
-                data = tomllib.load(f)
-
-            missing = []
-            for pkg in data.get("package", []):
-                name = pkg.get("name", "<unknown>")
-                version = pkg.get("version", "")
-                source = pkg.get("source", {})
-                if source.get("virtual"):
-                    continue  # workspace virtual package, no hash needed
-                for dist in pkg.get("wheels", []) + (
-                    [pkg["sdist"]] if "sdist" in pkg else []
-                ):
-                    if not dist.get("hash"):
-                        missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
-
-            if missing:
-                print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
-                print("\n".join(missing))
-                sys.exit(1)
-            PYEOF
-
+            python3 /tmp/check_hashes.py "$lockfile" || FAILED=1
           done
 
           if [ "$FAILED" -eq 1 ]; then

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -95,8 +95,8 @@ jobs:
 
       # ---------------------------------------------------------------------------
       # Check 1: No internal/non-PyPI registry URLs
-      # Catches pkg.dev (go/airlock) and any other non-pypi.org source hosts.
-      # Lockfiles referencing internal registries cannot be reproduced outside Google.
+      # Catches pkg.dev and any other non-pypi.org source hosts.
+      # Lockfiles referencing internal registries cannot be reproduced outside the original environment.
       # ---------------------------------------------------------------------------
       - name: Check for non-PyPI registry URLs
         if: steps.lockfiles.outputs.lockfiles != ''
@@ -109,7 +109,7 @@ jobs:
           for lockfile in ${{ steps.lockfiles.outputs.lockfiles }}; do
             MATCHES=$(grep -En "(url|registry)\s*=.*($INTERNAL_PATTERN)" "$lockfile" || true)
             if [ -n "$MATCHES" ]; then
-              echo "[FAIL] $lockfile contains non-PyPI registry URLs (go/airlock / pkg.dev):"
+              echo "[FAIL] $lockfile contains non-PyPI registry URLs (pkg.dev or similar):"
               echo "$MATCHES" | sed 's/^/  /'
               FAILED=1
             fi
@@ -118,7 +118,7 @@ jobs:
           if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "Lockfiles must only reference public PyPI (pypi.org)."
-            echo "Re-run 'uv lock' outside of Google's internal network, or unset internal"
+            echo "Re-run 'uv lock' with only public PyPI configured, or unset any internal"
             echo "registry configuration before locking."
             exit 1
           fi

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -221,35 +221,35 @@ jobs:
 
           for lockfile in $LOCKFILES; do
             python3 - "$lockfile" <<'PYEOF'
-          import sys
-          try:
-              import tomllib
-          except ImportError:
-              import pip._vendor.tomli as tomllib
+import sys
+try:
+    import tomllib
+except ImportError:
+    import pip._vendor.tomli as tomllib
 
-          lockfile_path = sys.argv[1]
-          with open(lockfile_path, "rb") as f:
-              data = tomllib.load(f)
+lockfile_path = sys.argv[1]
+with open(lockfile_path, "rb") as f:
+    data = tomllib.load(f)
 
-          missing = []
-          for pkg in data.get("package", []):
-              name = pkg.get("name", "<unknown>")
-              version = pkg.get("version", "")
-              # Only registry-sourced packages are expected to have hashes.
-              source = pkg.get("source", {})
-              if source.get("virtual"):
-                  continue  # workspace virtual package, no hash needed
-              for dist in pkg.get("wheels", []) + (
-                  [pkg["sdist"]] if "sdist" in pkg else []
-              ):
-                  if not dist.get("hash"):
-                      missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
+missing = []
+for pkg in data.get("package", []):
+    name = pkg.get("name", "<unknown>")
+    version = pkg.get("version", "")
+    # Only registry-sourced packages are expected to have hashes.
+    source = pkg.get("source", {})
+    if source.get("virtual"):
+        continue  # workspace virtual package, no hash needed
+    for dist in pkg.get("wheels", []) + (
+        [pkg["sdist"]] if "sdist" in pkg else []
+    ):
+        if not dist.get("hash"):
+            missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
 
-          if missing:
-              print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
-              print("\n".join(missing))
-              sys.exit(1)
-          PYEOF
+if missing:
+    print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
+    print("\n".join(missing))
+    sys.exit(1)
+PYEOF
             if [ $? -ne 0 ]; then
               FAILED=1
             fi

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -221,32 +221,31 @@ jobs:
 
           for lockfile in $LOCKFILES; do
             python3 - "$lockfile" <<'PYEOF' || FAILED=1
-import sys
-import tomllib
+            import sys
+            import tomllib
 
-lockfile_path = sys.argv[1]
-with open(lockfile_path, "rb") as f:
-    data = tomllib.load(f)
+            lockfile_path = sys.argv[1]
+            with open(lockfile_path, "rb") as f:
+                data = tomllib.load(f)
 
-missing = []
-for pkg in data.get("package", []):
-    name = pkg.get("name", "<unknown>")
-    version = pkg.get("version", "")
-    # Only registry-sourced packages are expected to have hashes.
-    source = pkg.get("source", {})
-    if source.get("virtual"):
-        continue  # workspace virtual package, no hash needed
-    for dist in pkg.get("wheels", []) + (
-        [pkg["sdist"]] if "sdist" in pkg else []
-    ):
-        if not dist.get("hash"):
-            missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
+            missing = []
+            for pkg in data.get("package", []):
+                name = pkg.get("name", "<unknown>")
+                version = pkg.get("version", "")
+                source = pkg.get("source", {})
+                if source.get("virtual"):
+                    continue  # workspace virtual package, no hash needed
+                for dist in pkg.get("wheels", []) + (
+                    [pkg["sdist"]] if "sdist" in pkg else []
+                ):
+                    if not dist.get("hash"):
+                        missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
 
-if missing:
-    print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
-    print("\n".join(missing))
-    sys.exit(1)
-PYEOF
+            if missing:
+                print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
+                print("\n".join(missing))
+                sys.exit(1)
+            PYEOF
 
           done
 

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -10,6 +10,7 @@ on:
       - 'contrib/**/*.lock'
       - 'contrib/**/pyproject.toml'
       - '.github/workflows/validate-lockfiles.yml'
+      - '.github/scripts/check_lockfile_hashes.py'
   push:
     branches:
       - main
@@ -21,6 +22,7 @@ on:
       - 'contrib/**/*.lock'
       - 'contrib/**/pyproject.toml'
       - '.github/workflows/validate-lockfiles.yml'
+      - '.github/scripts/check_lockfile_hashes.py'
   workflow_dispatch:
 
 permissions:
@@ -209,36 +211,10 @@ jobs:
       # Missing hashes mean the lockfile cannot verify supply chain integrity.
       # uv generates sha256 hashes for all registry packages by default; their
       # absence indicates the lockfile was tampered with or generated incorrectly.
+      # The check logic lives in .github/scripts/check_lockfile_hashes.py to
+      # avoid embedding Python at column 0 inside this YAML file, which breaks
+      # the zizmor security scanner's YAML parser.
       # ---------------------------------------------------------------------------
-      - name: Write hash-check script
-        run: |
-          cat > /tmp/check_hashes.py << 'EOF'
-import sys
-import tomllib
-
-lockfile_path = sys.argv[1]
-with open(lockfile_path, "rb") as f:
-    data = tomllib.load(f)
-
-missing = []
-for pkg in data.get("package", []):
-    name = pkg.get("name", "<unknown>")
-    version = pkg.get("version", "")
-    source = pkg.get("source", {})
-    if source.get("virtual"):
-        continue  # workspace virtual package, no hash needed
-    for dist in pkg.get("wheels", []) + (
-        [pkg["sdist"]] if "sdist" in pkg else []
-    ):
-        if not dist.get("hash"):
-            missing.append(f"  {name}=={version}: {dist.get('url', dist.get('path', '?'))}")
-
-if missing:
-    print(f"[FAIL] {lockfile_path} — distributions missing hashes:")
-    print("\n".join(missing))
-    sys.exit(1)
-EOF
-
       - name: Check that all packages have hashes
         if: steps.lockfiles.outputs.lockfiles != ''
         env:
@@ -249,7 +225,7 @@ EOF
           FAILED=0
 
           for lockfile in $LOCKFILES; do
-            python3 /tmp/check_hashes.py "$lockfile" || FAILED=1
+            python3 .github/scripts/check_lockfile_hashes.py "$lockfile" || FAILED=1
           done
 
           if [ "$FAILED" -eq 1 ]; then


### PR DESCRIPTION
## Why
When `uv lock` is run inside certain private network environments, it can resolve packages from internal registries instead of public PyPI. The resulting `uv.lock` contains URLs unreachable by anyone outside that environment, making the project silently non-reproducible for external contributors and CI. There is no visible error at commit time — it slips through undetected.
## What
Adds `.github/workflows/validate-lockfiles.yml` and a helper script `.github/scripts/check_lockfile_hashes.py` that enforce the following on every relevant `uv.lock` file:
1. **No non-PyPI registry URLs** — fails if any package source contains `pkg.dev`, `artifactregistry.googleapis.com`, or any other non-`pypi.org` host
2. **No VCS/git dependencies** — fails if any package uses `source = { git = "..." }`, which bypasses registry trust and is non-reproducible
3. **No local path dependencies** — fails if any package uses `path`, `editable`, or `directory` sources that only exist on the committer's machine
4. **All packages have hashes** — fails if any wheel or sdist is missing a `sha256` hash, which is required for supply chain integrity
5. **Lockfile is up-to-date** — runs `uv lock --check` to catch the case where `pyproject.toml` was edited but `uv lock` was not re-run
6. **Every `pyproject.toml` has a lockfile** — fails if a sample has a `[project]` table but no sibling `uv.lock`
**Scope on PRs is intentionally narrow:** only lockfiles touched by the current PR are validated, plus the sibling `uv.lock` of any `pyproject.toml` that was modified. This prevents a contributor's PR from failing due to an unrelated sample's lockfile. On push to `main` and manual dispatch, all lockfiles under `core/`, `contrib/`, and the repo root are scanned as a full safety net.