### PR TITLE
chore: overhaul manifest schema and simplify ownership model

### DIFF
--- a/.agents/skills/generate-manifest/SKILL.md
+++ b/.agents/skills/generate-manifest/SKILL.md
@@ -17,83 +17,72 @@ The user will provide a path to a recipe directory (e.g. `core/rag-agent-search`
 
 Read `.github/schemas/manifest-schema.json` from the repo root to understand the current required and optional fields, allowed enum values, and constraints. Do not rely on memory — always read the live schema file so changes to it are automatically picked up.
 
-### 3. Scan the recipe directory thoroughly
+### 3. Scan the recipe directory and infer only what the code proves
 
-Explore the recipe directory and gather the information needed to fill every schema field. Read the following files if they exist:
+Read the following files if they exist:
 
-- `README.md` — description, services, deployment story
-- `AGENTS.md` — agent architecture, tools, entry point
-- `pyproject.toml` / `requirements.txt` — library dependencies, Python version
-- `Makefile` — how the recipe is run and deployed
-- `infra/` or `terraform/` — GCP services provisioned, deployment automation
-- `app/agent.py` or equivalent entry point — single vs multi-agent, tools used
-- `data_ingestion/` or equivalent — ingestion pipeline, data sources
-- `.env.example` — environment variables, external services required
-- Any `cloudbuild.yaml`, `deploy/`, or CI/CD config
+- `pyproject.toml` / `requirements.txt` — primary language (for `language` field)
+- `app/agent.py` or equivalent entry point — single vs multi-agent, agent count
+- `Makefile` — deploy targets (determines `deployable`)
+- `app/` source files — stateful writes, datasource patterns
+- `AGENTS.md` — architecture notes if present
 
-Answer the following questions from what you find:
+**Field-by-field rules — read carefully before filling any field:**
 
-| Field | Question to answer |
+| Field | Rule |
 |---|---|
-| `type` | Does the recipe have its own entry point and can run independently (`standalone`), or is it a sub-agent meant to be imported by another workflow (`module`)? |
-| `deployable` | Can it be deployed with a single command or click, with no manual steps required? |
-| `status` | Is it actively maintained? Default to `active` unless there is evidence otherwise. |
-| `language` | What is the primary programming language? |
-| `description` | What does this recipe do and what value does it provide? Write 2-3 sentences. |
-| `architecture.agent` | Is there one agent or multiple agents? |
-| `architecture.stateful` | Does it write persistently to external systems (DB, vector store, etc.) or maintain memory across sessions? |
-| `architecture.datasources` | Does it use hardcoded data, local files bundled in the repo, and/or live external systems at runtime? Select all that apply. |
-| `architecture.rag` | Does it use a RAG pipeline (retrieval + augmentation + generation)? |
-| `dependencies.libraries` | What libraries does it depend on? Always include `ADK`. |
-| `dependencies.services` | What GCP or external services does it require? Always include `GCP Project`. |
-| `team` | Always use the placeholder values `YOUR TEAM NAME` / `team@email.com`. |
-| `poc` | Always use the placeholder values `POINT OF CONTACT NAME` / `poc@email.com`. |
-| `tags` | What free-form labels best describe this recipe? Include technology names, patterns, and use case. |
+| `type` | Infer from code: `standalone` if it has its own runnable entry point; `module` if it is only importable. |
+| `deployable` | `true` only if a single `make` target or script deploys everything with no manual steps. Default `false`. |
+| `status` | Always `"active"` unless there is explicit evidence of abandonment. |
+| `language` | Read from file extensions or `pyproject.toml`. Never guess. |
+| `description` | Read `README.md` and `AGENTS.md` only (author-written intent, not code). Write a draft of at most 15 words summarising what the recipe does. Append the comment `# TODO: review and expand this draft description`. If neither file exists or the intent is unclear, fall back to `"DESCRIPTION"` with the same TODO comment. |
+| `architecture.agent` | Infer from code only: count `Agent(` or equivalent constructor calls. `single` or `multi`. Omit the whole `architecture` block if uncertain. |
+| `architecture.stateful` | Infer from code: `true` only if the recipe writes persistently to an external system (DB, vector store, GCS) during normal operation — not just one-time setup. |
+| `architecture.datasources` | Infer from code: `hardcoded` = data literals in source; `local` = files bundled in repo; `external` = live systems queried at runtime. Can be multiple. |
+| `dependencies` | Include the block but comment it out entirely. Do NOT infer library or service names — GCP product names change and guesses will be wrong. Use the commented-out sample shown in the template. |
+| `ownership.team` | Always use the placeholder `"YOUR TEAM NAME"`. Never invent or infer a team name. |
+| `ownership.poc` | Always use the placeholder `"your-github-id"`. Never invent or infer a GitHub ID from email addresses, file authors, or any other source. |
+| `tags` | Include but comment out entirely, with a sample entry showing the expected style. Do NOT generate real tags — tag choices are the author's call. |
 
 ### 4. Make judgment calls explicitly
 
-Some fields require interpretation — document your reasoning briefly before writing the manifest so the user can correct you if needed:
-
-- **`deployable`**: Only `true` if there is a one-click/one-command deploy path with no manual config steps required.
-- **`stateful`**: `true` if the recipe writes to any external system (vector store, database, GCS) as part of its normal operation — not just one-time setup.
-- **`datasources`**: Can be multiple values. `hardcoded` = data embedded in source code. `local` = files bundled in the repo. `external` = live systems queried at runtime.
+Before writing the manifest, briefly state what you found for each inferred field (`type`, `deployable`, `architecture.*`) and cite the specific file/line that supports your conclusion. This lets the user catch errors before they land in the file.
 
 ### 5. Write the manifest
 
 Write `manifest.yaml` to the root of the recipe directory. Follow this format exactly — include inline comments for every field documenting the allowed values, matching the style of the reference manifest in `tools/` or `core/`:
 
 ```yaml
-type: "..."         # Options: [standalone | module]
-deployable: false   # Options: [true | false]. Default: false
-status: "active"    # Options: [active | inactive]
-language: "..."     # Options: [python | java | go | kotlin | typescript]
-description: "..."
+type: "..."           # Options: [standalone | module] — inferred from code
+deployable: false     # Options: [true | false]. Default: false — inferred from Makefile/scripts
+status: "active"      # Options: [active | inactive]
+language: "..."       # Options: [python | java | go | kotlin | typescript] — read from pyproject.toml
+description: "..."  # TODO: review and expand this draft description (max 15 words, generated from README/AGENTS.md)
 
 architecture:
-  agent: "..."          # Options: [single | multi]
-  stateful: false       # Options: [true | false]
-  datasources:          # Options: [hardcoded | local | external]
+  agent: "..."          # Options: [single | multi] — inferred from code
+  stateful: false       # Options: [true | false] — inferred from code
+  datasources:          # Options: [hardcoded | local | external] — inferred from code
     - "..."
-  rag: false            # Options: [true | false]
 
-dependencies:
-  libraries:
-    - "ADK"
-  services:
-    - "GCP Project"
+# dependencies: (optional) uncomment and fill in with canonical names
+#   libraries:
+#     - "ADK"
+#     - "pandas"            # example — replace with actual libraries used
+#   services:
+#     - "GCP Project"
+#     - "Cloud Run"         # example — replace with actual GCP/external services used
 
-team:
-  name: "YOUR TEAM NAME"
-  email: "team@email.com"
-poc:
-  name: "POINT OF CONTACT NAME"
-  email: "poc@email.com"
+ownership:
+  team: "YOUR TEAM NAME"  # TODO: replace with your team name
+  poc: "your-github-id"   # TODO: replace with the GitHub ID of the primary contact
 
-tags:
-  - "..."
+# tags: (optional) uncomment and replace with meaningful labels
+#   - "rag"               # example — use technology names, patterns, and use-case keywords
+#   - "gemini"
 ```
 
-Omit `architecture` entirely if none of its sub-fields can be determined.
+Omit `architecture` entirely if none of its sub-fields can be determined from the code.
 
 ### 6. Validate
 
@@ -107,4 +96,6 @@ If validation fails, fix the errors and re-validate until it passes. Report the 
 
 ### 7. Report back
 
-Briefly summarize the key judgment calls you made (e.g. why `stateful: true`, why certain datasources were chosen) so the user can review and correct anything that doesn't look right.
+Tell the user:
+1. What was inferred from the code and which file/line supports each inference.
+2. Which fields need human input: `description` (draft generated — must be reviewed and expanded), `ownership.team`, `ownership.poc` (placeholders), and `dependencies`/`tags` (commented out, ready to uncomment and fill in).

--- a/.agents/skills/generate-manifest/SKILL.md
+++ b/.agents/skills/generate-manifest/SKILL.md
@@ -53,32 +53,58 @@ Before writing the manifest, briefly state what you found for each inferred fiel
 Write `manifest.yaml` to the root of the recipe directory. Follow this format exactly — include inline comments for every field documenting the allowed values, matching the style of the reference manifest in `tools/` or `core/`:
 
 ```yaml
-type: "..."           # Options: [standalone | module] — inferred from code
-deployable: false     # Options: [true | false]. Default: false — inferred from Makefile/scripts
-status: "active"      # Options: [active | inactive]
-language: "..."       # Options: [python | java | go | kotlin | typescript] — read from pyproject.toml
-description: "..."  # TODO: review and expand this draft description (max 15 words, generated from README/AGENTS.md)
+# REQUIRED — Recipe type.
+#   standalone : complete, runnable recipe with its own entry point
+#   module     : importable sub-agent meant to be orchestrated by another workflow
+type: "..."
 
+# REQUIRED — One-click/one-command deployable with no manual steps?
+deployable: false
+
+# REQUIRED — Maintenance status.
+#   active | inactive
+status: "active"
+
+# REQUIRED — Primary programming language.
+#   python | java | go | kotlin | typescript
+language: "..."
+
+# REQUIRED — Short description of what this recipe does and the value it provides.
+description: "..."  # TODO: review and expand this draft description
+
+# OPTIONAL — Agent architecture details. Omit the whole block if unknown.
 architecture:
-  agent: "..."          # Options: [single | multi] — inferred from code
-  stateful: false       # Options: [true | false] — inferred from code
-  datasources:          # Options: [hardcoded | local | external] — inferred from code
+  # single | multi
+  agent: "..."
+
+  # true  : recipe writes persistently to an external system during normal operation
+  # false : read-only at runtime
+  stateful: false
+
+  # One or more of: hardcoded | local | external
+  #   hardcoded : data literals embedded in source code
+  #   local     : files bundled in the repo
+  #   external  : live system queried at runtime (DB, API, etc.)
+  datasources:
     - "..."
 
-# dependencies: (optional) uncomment and fill in with canonical names
+# OPTIONAL — Library and service dependencies.
+# dependencies:
 #   libraries:
 #     - "ADK"
-#     - "pandas"            # example — replace with actual libraries used
+#     - "pandas"     # replace with actual libraries used
 #   services:
 #     - "GCP Project"
-#     - "Cloud Run"         # example — replace with actual GCP/external services used
+#     - "Cloud Run"  # replace with actual GCP/external services used
 
+# REQUIRED — Ownership. Both sub-fields are required.
 ownership:
   team: "YOUR TEAM NAME"  # TODO: replace with your team name
   poc: "your-github-id"   # TODO: replace with the GitHub ID of the primary contact
 
-# tags: (optional) uncomment and replace with meaningful labels
-#   - "rag"               # example — use technology names, patterns, and use-case keywords
+# OPTIONAL — Classification tags (technology names, patterns, use-case keywords).
+# tags:
+#   - "rag"
 #   - "gemini"
 ```
 

--- a/.github/schemas/manifest-schema.json
+++ b/.github/schemas/manifest-schema.json
@@ -9,10 +9,7 @@
     "status",
     "language",
     "description",
-    "dependencies",
-    "team",
-    "poc",
-    "tags"
+    "ownership"
   ],
   "additionalProperties": false,
   "properties": {
@@ -87,19 +84,11 @@
           },
           "uniqueItems": true,
           "description": "The data sources used by the recipe. 'hardcoded': data is hardcoded within the recipe itself. 'local': data comes from files bundled with the recipe. 'external': data comes from a live outside system at runtime (e.g. a database, an API)."
-        },
-        "rag": {
-          "type": "boolean",
-          "description": "Whether the recipe implements or uses a RAG pipeline."
         }
       }
     },
     "dependencies": {
       "type": "object",
-      "required": [
-        "libraries",
-        "services"
-      ],
       "additionalProperties": false,
       "properties": {
         "libraries": {
@@ -107,7 +96,6 @@
           "items": {
             "type": "string"
           },
-          "minItems": 1,
           "description": "Library dependencies (e.g. ADK, LangGraph)."
         },
         "services": {
@@ -115,48 +103,28 @@
           "items": {
             "type": "string"
           },
-          "minItems": 1,
           "description": "GCP or external service dependencies."
         }
       }
     },
-    "team": {
+    "ownership": {
       "type": "object",
       "required": [
-        "name",
-        "email"
+        "team",
+        "poc"
       ],
       "additionalProperties": false,
+      "description": "Ownership information for the recipe.",
       "properties": {
-        "name": {
+        "team": {
           "type": "string",
           "minLength": 1,
           "description": "Team name."
         },
-        "email": {
-          "type": "string",
-          "format": "email",
-          "description": "Team contact email."
-        }
-      }
-    },
-    "poc": {
-      "type": "object",
-      "required": [
-        "name",
-        "email"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "name": {
+        "poc": {
           "type": "string",
           "minLength": 1,
-          "description": "Point of contact name."
-        },
-        "email": {
-          "type": "string",
-          "format": "email",
-          "description": "Point of contact email."
+          "description": "GitHub user ID of the primary point of contact accountable for this recipe."
         }
       }
     },
@@ -165,7 +133,6 @@
       "items": {
         "type": "string"
       },
-      "minItems": 1,
       "description": "Classification tags for the recipe."
     }
   }

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -6,7 +6,7 @@ on:
       - 'core/**'
       - 'contrib/**'
       - '.github/schemas/manifest-schema.json'
-      - '.github/workflows/validate-manifests.yml'
+      - '.github/workflows/validate-manifest.yml'
   push:
     branches:
       - main
@@ -14,7 +14,7 @@ on:
       - 'core/**'
       - 'contrib/**'
       - '.github/schemas/manifest-schema.json'
-      - '.github/workflows/validate-manifests.yml'
+      - '.github/workflows/validate-manifest.yml'
   workflow_dispatch:
 
 permissions:
@@ -60,7 +60,7 @@ jobs:
           echo "$CHANGED_FILES"
 
           # If the schema or workflow itself changed, validate all recipes
-          SCHEMA_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^\.github/(schemas/manifest-schema\.json|workflows/validate-manifests\.yml)$" || true)
+          SCHEMA_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^\.github/(schemas/manifest-schema\.json|workflows/validate-manifest\.yml)$" || true)
 
           if [ -n "$SCHEMA_CHANGED" ]; then
             echo "Schema or workflow changed — will validate all recipes."

--- a/core/python/rag-agent-search/manifest.yaml
+++ b/core/python/rag-agent-search/manifest.yaml
@@ -1,41 +1,27 @@
-type: "standalone"
-deployable: false
-status: "active"
-language: "python"
-description: "A conversational RAG agent grounded on documents indexed in Google Agent Platform Search (Discovery Engine). Users upload unstructured documents to a GCS bucket, which are automatically ingested and indexed via a managed GCS Data Connector. The agent answers natural-language questions by retrieving relevant passages from the data store and synthesizing grounded answers using Gemini."
+type: "standalone"   # Options: [standalone | module]
+deployable: false    # Options: [true | false]. Default: false
+status: "active"     # Options: [active | inactive]
+language: "python"   # Options: [python | java | go | kotlin | typescript]
+description: "RAG agent answering questions over documents indexed in Agent Platform Search via GCS Data Connector."  # TODO: review and expand this draft description
 
 architecture:
-  agent: "single"
-  stateful: false
-  datasources:
-    - "local"
+  agent: "single"       # Options: [single | multi]
+  stateful: false       # Options: [true | false]
+  datasources:          # Options: [hardcoded | local | external]
     - "external"
-  rag: true
 
-dependencies:
-  libraries:
-    - "ADK"
-    - "Vertex AI SDK"
-    - "Terraform"
-  services:
-    - "GCP Project"
-    - "Vertex AI API"
-    - "Discovery Engine / Agent Platform Search"
-    - "Google Cloud Storage"
+# dependencies: (optional) uncomment and fill in with canonical names
+#   libraries:
+#     - "ADK"
+#     - "pandas"            # example — replace with actual libraries used
+#   services:
+#     - "GCP Project"
+#     - "Cloud Run"         # example — replace with actual GCP/external services used
 
-team:
-  name: "Cloud AI Developer Engineering & Evangelism"
-  email: "cloud-ai-devrel@google.com"
-poc:
-  name: "Elia Seccchi"
-  email: "eliasecchi@google.com"
+ownership:
+  team: "Cloud AI Developer Engineering & Evangelism"
+  poc: "eliasecchi"
 
-tags:
-  - "rag"
-  - "vertex-ai-search"
-  - "discovery-engine"
-  - "gcs-data-connector"
-  - "grounding"
-  - "gemini"
-  - "terraform"
-  - "single-agent"
+# tags: (optional) uncomment and replace with meaningful labels
+#   - "rag"               # example — use technology names, patterns, and use-case keywords
+#   - "gemini"

--- a/core/python/rag-vector-search/manifest.yaml
+++ b/core/python/rag-vector-search/manifest.yaml
@@ -1,47 +1,27 @@
-type: "standalone"
-deployable: false
-status: "active"
-language: "python"
-description: "A conversational RAG agent grounded on documents indexed in Vertex AI Vector Search 2.0 (Agent Platform Vector Search). A Kubeflow Pipelines ingestion pipeline chunks documents, stages them in BigQuery, and batch-creates data objects in a VS 2.0 Collection with server-side auto-embedding. The agent answers natural-language questions by retrieving relevant chunks via semantic search and synthesizing grounded answers using Gemini."
+type: "standalone"   # Options: [standalone | module]
+deployable: false    # Options: [true | false]. Default: false
+status: "active"     # Options: [active | inactive]
+language: "python"   # Options: [python | java | go | kotlin | typescript]
+description: "RAG agent answering questions over documents indexed in Agent Platform Vector Search with KFP ingestion."  # TODO: review and expand this draft description
 
 architecture:
-  agent: "single"
-  stateful: true
-  datasources:
-    - "hardcoded"
+  agent: "single"       # Options: [single | multi]
+  stateful: true        # Options: [true | false]
+  datasources:          # Options: [hardcoded | local | external]
     - "external"
-  rag: true
 
-dependencies:
-  libraries:
-    - "ADK"
-    - "Vertex AI SDK"
-    - "Kubeflow Pipelines (KFP)"
-    - "LangChain Text Splitters"
-    - "Terraform"
-  services:
-    - "GCP Project"
-    - "Vertex AI API"
-    - "Vertex AI Vector Search 2.0"
-    - "BigQuery"
-    - "Google Cloud Storage"
-    - "Cloud Build"
+# dependencies: (optional) uncomment and fill in with canonical names
+#   libraries:
+#     - "ADK"
+#     - "pandas"            # example — replace with actual libraries used
+#   services:
+#     - "GCP Project"
+#     - "Cloud Run"         # example — replace with actual GCP/external services used
 
-team:
-  name: "Cloud AI Developer Engineering & Evangelism"
-  email: "cloud-ai-devrel@google.com"
-poc:
-  name: "Elia Seccchi"
-  email: "eliasecchi@google.com"
+ownership:
+  team: "Cloud AI Developer Engineering & Evangelism"
+  poc: "eliasecchi"
 
-tags:
-  - "rag"
-  - "vector-search"
-  - "vertex-ai-vector-search"
-  - "kubeflow-pipelines"
-  - "bigquery"
-  - "data-ingestion"
-  - "gemini"
-  - "auto-embedding"
-  - "terraform"
-  - "single-agent"
+# tags: (optional) uncomment and replace with meaningful labels
+#   - "rag"               # example — use technology names, patterns, and use-case keywords
+#   - "gemini"

--- a/core/rag-agent-search/manifest.yaml
+++ b/core/rag-agent-search/manifest.yaml
@@ -1,41 +1,27 @@
-type: "standalone"
-deployable: false
-status: "active"
-language: "python"
-description: "A conversational RAG agent grounded on documents indexed in Google Agent Platform Search (Discovery Engine). Users upload unstructured documents to a GCS bucket, which are automatically ingested and indexed via a managed GCS Data Connector. The agent answers natural-language questions by retrieving relevant passages from the data store and synthesizing grounded answers using Gemini."
+type: "standalone"   # Options: [standalone | module]
+deployable: false    # Options: [true | false]. Default: false
+status: "active"     # Options: [active | inactive]
+language: "python"   # Options: [python | java | go | kotlin | typescript]
+description: "RAG agent answering questions over documents indexed in Agent Platform Search via GCS Data Connector."  # TODO: review and expand this draft description
 
 architecture:
-  agent: "single"
-  stateful: false
-  datasources:
-    - "local"
+  agent: "single"       # Options: [single | multi]
+  stateful: false       # Options: [true | false]
+  datasources:          # Options: [hardcoded | local | external]
     - "external"
-  rag: true
 
-dependencies:
-  libraries:
-    - "ADK"
-    - "Vertex AI SDK"
-    - "Terraform"
-  services:
-    - "GCP Project"
-    - "Vertex AI API"
-    - "Discovery Engine / Agent Platform Search"
-    - "Google Cloud Storage"
+# dependencies: (optional) uncomment and fill in with canonical names
+#   libraries:
+#     - "ADK"
+#     - "pandas"            # example — replace with actual libraries used
+#   services:
+#     - "GCP Project"
+#     - "Cloud Run"         # example — replace with actual GCP/external services used
 
-team:
-  name: "Cloud AI Developer Engineering & Evangelism"
-  email: "cloud-ai-devrel@google.com"
-poc:
-  name: "Elia Seccchi"
-  email: "eliasecchi@google.com"
+ownership:
+  team: "Cloud AI Developer Engineering & Evangelism"
+  poc: "eliasecchi"
 
-tags:
-  - "rag"
-  - "vertex-ai-search"
-  - "discovery-engine"
-  - "gcs-data-connector"
-  - "grounding"
-  - "gemini"
-  - "terraform"
-  - "single-agent"
+# tags: (optional) uncomment and replace with meaningful labels
+#   - "rag"               # example — use technology names, patterns, and use-case keywords
+#   - "gemini"

--- a/core/rag-vector-search/manifest.yaml
+++ b/core/rag-vector-search/manifest.yaml
@@ -1,47 +1,27 @@
-type: "standalone"
-deployable: false
-status: "active"
-language: "python"
-description: "A conversational RAG agent grounded on documents indexed in Vertex AI Vector Search 2.0 (Agent Platform Vector Search). A Kubeflow Pipelines ingestion pipeline chunks documents, stages them in BigQuery, and batch-creates data objects in a VS 2.0 Collection with server-side auto-embedding. The agent answers natural-language questions by retrieving relevant chunks via semantic search and synthesizing grounded answers using Gemini."
+type: "standalone"   # Options: [standalone | module]
+deployable: false    # Options: [true | false]. Default: false
+status: "active"     # Options: [active | inactive]
+language: "python"   # Options: [python | java | go | kotlin | typescript]
+description: "RAG agent answering questions over documents indexed in Agent Platform Vector Search with KFP ingestion."  # TODO: review and expand this draft description
 
 architecture:
-  agent: "single"
-  stateful: true
-  datasources:
-    - "hardcoded"
+  agent: "single"       # Options: [single | multi]
+  stateful: true        # Options: [true | false]
+  datasources:          # Options: [hardcoded | local | external]
     - "external"
-  rag: true
 
-dependencies:
-  libraries:
-    - "ADK"
-    - "Vertex AI SDK"
-    - "Kubeflow Pipelines (KFP)"
-    - "LangChain Text Splitters"
-    - "Terraform"
-  services:
-    - "GCP Project"
-    - "Vertex AI API"
-    - "Vertex AI Vector Search 2.0"
-    - "BigQuery"
-    - "Google Cloud Storage"
-    - "Cloud Build"
+# dependencies: (optional) uncomment and fill in with canonical names
+#   libraries:
+#     - "ADK"
+#     - "pandas"            # example — replace with actual libraries used
+#   services:
+#     - "GCP Project"
+#     - "Cloud Run"         # example — replace with actual GCP/external services used
 
-team:
-  name: "Cloud AI Developer Engineering & Evangelism"
-  email: "cloud-ai-devrel@google.com"
-poc:
-  name: "Elia Seccchi"
-  email: "eliasecchi@google.com"
+ownership:
+  team: "Cloud AI Developer Engineering & Evangelism"
+  poc: "eliasecchi"
 
-tags:
-  - "rag"
-  - "vector-search"
-  - "vertex-ai-vector-search"
-  - "kubeflow-pipelines"
-  - "bigquery"
-  - "data-ingestion"
-  - "gemini"
-  - "auto-embedding"
-  - "terraform"
-  - "single-agent"
+# tags: (optional) uncomment and replace with meaningful labels
+#   - "rag"               # example — use technology names, patterns, and use-case keywords
+#   - "gemini"

--- a/tools/validate_manifest.py
+++ b/tools/validate_manifest.py
@@ -7,8 +7,7 @@ Checks:
   - Every manifest.yaml is valid YAML.
   - Every manifest.yaml conforms to the schema at
     .github/schemas/manifest-schema.json.
-  - team.name, team.email, poc.name, and poc.email are not left as
-    their generated placeholder values.
+  - ownership.team and ownership.poc are not left as placeholder values.
 
 Usage:
   # Validate all recipes (both core/ and contrib/):
@@ -43,12 +42,8 @@ SCHEMA_PATH = REPO_ROOT / ".github" / "schemas" / "manifest-schema.json"
 MANIFEST_FILENAME = "manifest.yaml"
 RECIPE_ROOTS = ["core", "contrib"]
 
-PLACEHOLDER_CHECKS = [
-    ("team", "name", "YOUR TEAM NAME", "team.name"),
-    ("team", "email", "team@email.com", "team.email"),
-    ("poc", "name", "POINT OF CONTACT NAME", "poc.name"),
-    ("poc", "email", "poc@email.com", "poc.email"),
-]
+OWNERSHIP_TEAM_PLACEHOLDER = "YOUR TEAM NAME"
+OWNERSHIP_POC_PLACEHOLDER = "your-github-id"
 
 
 def is_recipe_dir(path: Path) -> bool:
@@ -85,16 +80,18 @@ def validate_manifest(manifest_path: Path, schema: dict) -> list[str]:
 
     # Check that placeholder values have been replaced with real ones
     if isinstance(data, dict):
-        for section, field, placeholder, label in PLACEHOLDER_CHECKS:
-            sec_val = data.get(section)
-            if isinstance(sec_val, dict):
-                value = sec_val.get(field, "")
-                if value == placeholder:
-                    errors.append(
-                        f"  [{label}] is still set to the placeholder value "
-                        f'"{placeholder}". Please replace it with a real '
-                        f"{label}."
-                    )
+        ownership = data.get("ownership")
+        if isinstance(ownership, dict):
+            if ownership.get("team") == OWNERSHIP_TEAM_PLACEHOLDER:
+                errors.append(
+                    f'  [ownership.team] is still set to the placeholder value '
+                    f'"{OWNERSHIP_TEAM_PLACEHOLDER}". Please replace it with a real team name.'
+                )
+            if ownership.get("poc") == OWNERSHIP_POC_PLACEHOLDER:
+                errors.append(
+                    f'  [ownership.poc] is still set to the placeholder value '
+                    f'"{OWNERSHIP_POC_PLACEHOLDER}". Please replace it with a real GitHub ID.'
+                )
 
     return errors
 


### PR DESCRIPTION
## Summary

Redesigns the manifest schema and updates all related tooling and existing manifests to match.

### Schema changes (`manifest-schema.json`)
- **Ownership**: replaces the separate `team` (string) and `contributors` (list) fields with a single `ownership` block containing `team` (name) and `poc` (GitHub ID of the primary contact). Contributors can be derived from git history.
- **Removed**: `rag` boolean from `architecture` (redundant with tags).
- **Now optional**: `dependencies`, `tags`, and all `architecture` sub-fields (`agent`, `stateful`, `datasources`).

### CI (`validate-manifests.yml` → `validate-manifest.yml`)
- Renamed workflow file and updated all internal self-references accordingly.

### Validator (`validate_manifest.py`)
- Updated placeholder checks to match the new `ownership.team` / `ownership.poc` structure.

### Manifests (all 4 under `core/`)
- Regenerated to match the new schema: real ownership values, draft description from README (≤15 words, marked TODO), optional blocks commented out with sample values.

### Skill (`generate-manifest/SKILL.md`)
- Updated inference rules: never guess `dependencies` or `tags` (left as commented-out stubs); draft `description` from `README.md`/`AGENTS.md` only; always use placeholders for `ownership`.