### PR TITLE
fix: mitigate unauthenticated path traversal in genmedia SPA routing

### DIFF
--- a/python/agents/genmedia-for-commerce/genmedia4commerce/fast_api_app.py
+++ b/python/agents/genmedia-for-commerce/genmedia4commerce/fast_api_app.py
@@ -200,17 +200,25 @@ def _mount_frontend():
 
     @app.get("/{full_path:path}")
     async def serve_spa(full_path: str):
+        # 1. Resolve absolute paths to prevent directory traversal
+        resolved_frontend_dir = frontend_dir.resolve()
+        safe_path = (resolved_frontend_dir / full_path).resolve()
+        
+        # 2. Security Check: Ensure the resolved path remains strictly inside frontend_dir
+        if not safe_path.is_relative_to(resolved_frontend_dir):
+            from fastapi.responses import JSONResponse
+            return JSONResponse({"detail": "Access Denied"}, status_code=403)
+
         # If the path matches an actual file in dist/, serve it
-        file_path = frontend_dir / full_path
-        if full_path and file_path.is_file():
-            return FileResponse(str(file_path))
+        if full_path and safe_path.is_file():
+            return FileResponse(str(safe_path))
+        
         # Only serve index.html for SPA routes (paths without file extensions)
         # Asset requests (.json, .js, .css, etc.) that don't exist should 404
         if "." in full_path.split("/")[-1]:
             from fastapi.responses import JSONResponse
-
             return JSONResponse({"detail": "Not Found"}, status_code=404)
-        return FileResponse(index_html)
+        return FileResponse(str(index_html))
 
 
 @app.get("/health")


### PR DESCRIPTION
Fixes #2201

### Description
This PR resolves the unauthenticated path traversal vulnerability reported in issue #2201 within the `genmedia-for-commerce` application routing.

### Changes
* Replaced direct unsafe path concatenation with absolute path resolution via `pathlib.Path.resolve()`.
* Implemented a strict `safe_path.is_relative_to(resolved_frontend_dir)` check to ensure that the resolved asset path cannot traverse outside the boundary of the designated frontend assets directory.
* Preserved the original SPA behavior and fallback rules while explicitly returning a `403 Forbidden` JSON response if a path traversal attempt is detected.

### Verification
* Confirmed that directory climbing patterns (e.g., `../../`) are safely caught and rejected by the validation step.
* Ensured local formatting remains compliant with the repository's rules.