### PR TITLE
fix: update broken git clone url and base paths in evaluation notebooks

### DIFF
--- a/python/notebooks/evaluation/evaluation_criteria_in_adk.ipynb
+++ b/python/notebooks/evaluation/evaluation_criteria_in_adk.ipynb
@@ -222,9 +222,9 @@
    ],
    "source": [
     "# @title Download HelloWorld Agent From ADK Github Repo\n",
-    "AGENT_BASE_PATH = \"adk-python/contributing/samples/hello_world\"\n",
+    "AGENT_BASE_PATH = \"adk-samples/python/agents/hello_world\"\n",
     "\n",
-    "!git clone https://github.com/google/adk-python/\n",
+    "!git clone https://github.com/google/adk-samples.git\n",
     "!ls {AGENT_BASE_PATH}"
    ]
   },

--- a/python/notebooks/evaluation/user_simulation_in_adk_evals.ipynb
+++ b/python/notebooks/evaluation/user_simulation_in_adk_evals.ipynb
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "Sw_NmNz4nVQY"
    },
@@ -180,8 +180,8 @@
    "source": [
     "# @title Download HelloWorld Agent From ADK Github Repo\n",
     "\n",
-    "!git clone https://github.com/google/adk-python/\n",
-    "AGENT_BASE_PATH = \"adk-python/contributing/samples/hello_world\"\n",
+    "!git clone https://github.com/google/adk-samples.git\n",
+    "AGENT_BASE_PATH = \"adk-samples/python/agents/hello_world\"\n",
     "!ls {AGENT_BASE_PATH}"
    ]
   },


### PR DESCRIPTION
Fixes #1986

### Description
This PR resolves the broken git clone repository paths reported in issue #1986 within the `evaluation_criteria_in_adk.ipynb` and `user_simulation_in_adk_evals.ipynb` training workflows.

### Changes
* Swapped the legacy invalid `adk-python` target URLs out for the unified `google/adk-samples.git` location reference.
* Corrected `AGENT_BASE_PATH` pointers to accurately navigate down into the native `python/agents/hello_world` directory structure.

### Verification
* Verified directory layouts match up with structural configurations inside the unified repository setup.