### PR TITLE
Harden extract-python-environment-variables skill (v2.1) via real-recipe testing

### DIFF
--- a/.agents/skills/extract-python-environment-variables/SKILL.md
+++ b/.agents/skills/extract-python-environment-variables/SKILL.md
@@ -1,38 +1,52 @@
 ---
 name: extract-python-environment-variables
 description: >
-  Scans a Python recipe to find every place an environment variable is read,
-  then ensures all variables are declared in .env.example, that load_dotenv()
-  is bootstrapped in the package __init__.py, and that python-dotenv>=1.0.0
-  is listed in pyproject.toml.   Also detects hardcoded model-name string literals in the recipe's source
-  (e.g. "gemini-3.5-flash" in agent.py) and rewrites them to bare
-  os.getenv("MODEL_NAME") calls (single model) or
-  os.getenv("MODEL_NAME_GENERATED_1") / os.getenv("MODEL_NAME_GENERATED_2")
-  etc. (multiple models) — NO fallback default in source. The actual model
-  string is written as the value in .env.example (e.g.
-  MODEL_NAME_GENERATED_1=gemini-3.5-flash) with a comment reminding the
-  maintainer to rename the variable — this modifies source files, not just
-  configuration. IMPORTANT — two hard rules the skill NEVER breaks:
-  (1) Regular env vars in `.env.example` get ONLY TODO placeholders, never
-  inferred defaults. Hardcoded model strings are the exception: their known
-  value IS written to .env.example because it is not inferred — it was
-  literally in the source.
-  (2) Python source files get NO default values written by the skill —
-  the model-replacement path emits `os.getenv("VAR")` with no second
-  argument, and the skill never emits `os.environ.setdefault(...)`
-  bootstrap lines. Pre-existing `os.environ.setdefault(...)` or
+  Scans a Python recipe to find every place an environment variable is
+  accessed — including `os.environ.setdefault("V", "d")`, whose "d" would
+  otherwise be a hidden default a user editing .env.example has no way to
+  discover — then ensures all variables are declared in `.env.example`,
+  that `load_dotenv()` is bootstrapped in the package `__init__.py`, and
+  that `python-dotenv>=1.0.0` is listed in `pyproject.toml`. When a new
+  entry is added to `.env.example`, the extracted default from source is
+  written as the value (with a `# extracted-by:extract-env-vars` marker
+  and provenance comment); values that look like stubs
+  (`"my-project-id"`, `"changeme"`, `"<...>"`) are downgraded to the TODO
+  placeholder but the source string is preserved in the marker comment.
+  Also detects hardcoded model-name string literals (e.g.
+  `"gemini-3.5-flash"` in `agent.py`) and rewrites them to bare
+  `os.getenv("MODEL_NAME")` (single model) or
+  `os.getenv("MODEL_NAME_GENERATED_1")` / `MODEL_NAME_GENERATED_2`, …
+  (multiple models) — no fallback default in the Python source. The
+  model string is written as the value in `.env.example` with a comment
+  prompting a rename.   When re-run against a recipe whose `.env.example` already has entries,
+  the writer classifies each entry (skill-authored vs. user-authored,
+  TODO vs. real value) and only rewrites lines it can prove it authored;
+  user-authored lines are always preserved. A stale TODO (either
+  skill-authored or a bare v1-era `<TODO: update-this-value>` with no
+  inline comment) is upgraded in place when source can supply a real
+  default.
+  IMPORTANT — two hard rules the skill NEVER breaks:
+  (1) USER-EDIT SAFETY. Any `.env.example` line the skill cannot prove
+  it authored is USER_OWNED and is never modified. The rewriter fails
+  closed on any structural ambiguity (quoted values, backslash
+  continuation, duplicate declarations) — a stale TODO left in place is
+  cheap; a clobbered user edit is not.
+  (2) ADDITIVE-ONLY FOR PYTHON FILES. The skill never writes new
+  `os.environ.setdefault(...)` bootstrap lines into any Python file.
+  Pre-existing `os.environ.setdefault(...)` or
   `os.getenv("VAR", "default")` calls that the recipe author wrote by
-  hand are LEFT UNTOUCHED — the skill is additive-only for Python files
-  (adds `load_dotenv()` bootstrap; replaces hardcoded model literals;
-  appends `# noqa: E402` to trailing relative imports in `__init__.py`
-  when they'd otherwise trip Ruff after an env-bootstrap block).
+  hand are LEFT UNTOUCHED — the skill's only writes to Python files are
+  (a) the `load_dotenv()` bootstrap; (b) `# noqa: E402` on trailing
+  relative imports that would otherwise trip Ruff; (c) hardcoded
+  model-literal replacement.
   Use when the user wants to "extract env vars", "update .env.example",
-  "add load_dotenv", "replace hardcoded model names", or "fix environment
+  "add load_dotenv", "surface setdefault defaults", "upgrade stale TODOs
+  in .env.example", "replace hardcoded model names", or "fix environment
   variables" in a Python recipe.
 metadata:
   author: Google
   license: Apache-2.0
-  version: 1.0.0
+  version: 2.1.0
 ---
 
 # Extract Python Environment Variables
@@ -46,24 +60,45 @@ environment variables it uses.
 
 Runs `scripts/extract_env_vars.py` against a recipe directory. The script:
 
-1. **Scans** all `.py` files (excluding `tests/`) for environment variable reads:
+1. **Scans** all `.py` files (excluding `tests/` and common cache/venv
+   directories) for environment variable accesses:
    - `os.environ["VAR"]`
    - `os.environ.get("VAR")` / `os.environ.get("VAR", "default")`
    - `os.getenv("VAR")` / `os.getenv("VAR", "default")`
+   - `os.environ.setdefault("VAR", "default")` &nbsp;&nbsp;*(v2)*
 
    Only names matching `^[A-Z_][A-Z0-9_]*$` (UPPER_SNAKE_CASE) are captured;
    a lowercase name like `os.getenv("my_api_key")` is **skipped** and a
    `[WARN]` line lists any that were dropped. Rename such vars to uppercase
    in source, or add them to `.env.example` by hand.
 
-2. **Updates `.env.example`** — appends any variables not already declared.
-   - **Every value is the placeholder `<TODO: update-this-value>`.** The
-     skill never writes inferred defaults into `.env.example`, even when
-     the source code has an `os.getenv("VAR", "some_default")` fallback.
-     `.env.example` is a template the human fills in; the source-code
-     fallback is a runtime default, not a value the maintainer has
-     committed to as canonical.
+2. **Updates `.env.example`** — appends any variables not already
+   declared AND upgrades stale TODO entries in place. Existing
+   user-authored lines are always preserved (see Rule 1 below).
    - Creates `.env.example` from scratch if it does not exist.
+   - Each new/upgraded line has the shape:
+     ```
+     VAR=<value>  # extracted-by:extract-env-vars; <provenance>
+     ```
+   - `<value>` is the **resolved default** extracted from source when the
+     author committed to one — with `os.environ.setdefault(...)` beating
+     `os.getenv("V", "d")` / `os.environ.get("V", "d")` (setdefault is a
+     stronger commitment: it mutates the process environment, while getenv
+     fallback is per-read). Alphabetical file order breaks ties.
+   - Values that look like **stubs** are downgraded to
+     `<TODO: update-this-value>` — e.g. `my-project-id`, `your-api-key`,
+     `changeme`, `<...>`, anything containing `example.com`. The source
+     string is preserved in the marker comment so the maintainer sees
+     what was found and can fix the source too.
+   - When no source supplied a string-literal default, the value is
+     `<TODO: update-this-value>` with a `no default in source` note.
+   - **Stale TODO upgrade (v2.1):** if an existing entry is either a
+     skill-authored TODO (has the marker) or a bare v1-era TODO (exact
+     value `<TODO: update-this-value>`, no marker, no inline comment)
+     AND source can now supply a real default, the line is rewritten in
+     place. This closes the discoverability loop for recipes originally
+     processed by v1 (which always wrote TODOs regardless of what source
+     said).
 
 3. **Injects `load_dotenv()`** into the package `__init__.py` (the first
    subdirectory inside the recipe that contains an `__init__.py`, skipping
@@ -117,30 +152,54 @@ Runs `scripts/extract_env_vars.py` against a recipe directory. The script:
 
 ## Hard rules the skill NEVER breaks
 
-**Rule 1 — No inferred defaults for regular env vars.** For variables read
-via `os.getenv`/`os.environ`, `.env.example` always gets `<TODO: update-this-value>`,
-even when the source has an `os.getenv("VAR", "some-fallback")`. Exception:
-hardcoded model strings replaced in source ARE written with their actual value
-in `.env.example` (e.g. `MODEL_NAME_GENERATED_1=gemini-3.5-flash`) — this is
-not an inferred default, it is the known value that was literally in the source.
-The source replacement always emits bare `os.getenv("VAR")` with **no second
-argument** in both cases.
+**Rule 1 — User-edit safety for `.env.example`.** The writer classifies
+every existing entry before touching anything, and only rewrites lines
+it can prove it authored. Concretely:
+
+| Existing entry looks like | Source now provides | Action |
+|---|---|---|
+| Missing | any | **append** with resolved default (or TODO) |
+| A line the skill wrote (has `# extracted-by:extract-env-vars` marker) with `<TODO: update-this-value>` value | a REAL default (not placeholder-shape) | **upgrade in place** |
+| Same as above | no default OR a placeholder-shape default | **skip** (would be TODO → TODO churn) |
+| Bare `VAR=<TODO: update-this-value>` line with **no marker AND no inline comment** — a v1-era TODO | a REAL default | **upgrade in place** (v1 → v2 migration) |
+| A line the skill wrote with a REAL value | source has any value (even different) | **skip** (never overwrite skill-authored values on drift) |
+| Anything else (user typed value, user-authored comment, non-standard formatting) | any | **skip — never touched** |
+
+Golden rule underneath all of this: **fail closed**. If the classifier
+can't confidently prove a line was skill-authored or is a bare v1 TODO,
+it's `USER_OWNED` and untouchable. If the rewriter finds a line whose
+structure it doesn't understand (quoted value, backslash continuation,
+duplicate declarations), it refuses and warns rather than guessing. And
+before any write, the assembled file is re-parsed to verify every
+planned upgrade re-parses as a skill-authored real value — a bug in the
+rewriter cannot silently corrupt `.env.example`.
+
+To force regeneration of a line the skill would otherwise skip, delete
+the line and re-run.
+
+*Rationale for extracting defaults (v2) and upgrading stale TODOs
+(v2.1): a value hidden inside a Python file that a user must know about
+but has no reason to look at is, in practice, undocumented.
+`.env.example` is the documented configuration surface. Surfacing what
+the author already committed to in code — and updating a stale TODO
+once source can supply a real default — makes the configuration
+discoverable without inventing anything new. The value in source WAS
+the value; we're only lifting it into view.*
 
 **Rule 2 — Additive-only for Python files.** The skill never writes new
 `os.environ.setdefault(...)` bootstrap lines into any Python file.
-Pre-existing `os.environ.setdefault(...)` calls or
+Pre-existing `os.environ.setdefault(...)` or
 `os.getenv("VAR", "default")` calls that a recipe author wrote by hand
 are LEFT UNTOUCHED. The skill's only writes to Python files are:
 - Adding the `from dotenv import load_dotenv` + `load_dotenv()` snippet
   (once, only if not already present).
+- Appending `# noqa: E402` to trailing relative imports that would
+  otherwise trip Ruff after the env-bootstrap block.
 - Replacing hardcoded model literals with bare `os.getenv(...)` calls.
 
-Rationale: default values are the maintainer's decision, not the
-skill's. Persisting an inferred default (in `.env.example` or in a new
-Python bootstrap line) is presumptuous — it makes the recipe look like
-it works when the value is really the maintainer's job to fill in.
-Pre-existing lines are the maintainer's own committed choice; the
-skill respects that and doesn't rewrite them.
+Note that scanning `os.environ.setdefault(...)` and lifting its value
+into `.env.example` (v2) does NOT violate Rule 2 — the skill READS from
+Python source (unchanged behaviour) and WRITES only to `.env.example`.
 
 ---
 
@@ -204,9 +263,36 @@ to read — this is especially important for `--dry-run` output. For each variab
 or model string, include a column with the source file where it was found
 (locate it in the recipe's Python source; ignore `.env` and `.env.example`).
 
+For added variables, surface the **resolved default** and **its provenance**
+so the maintainer knows which value the skill chose and where it came from:
+
+| Variable | Value written to .env.example | Source |
+|----------|-------------------------------|--------|
+| `GOOGLE_CLOUD_PROJECT` | `<TODO: update-this-value>` *(downgraded — source had `"my-project-id"`)* | `agent.py` (setdefault) |
+| `GOOGLE_GENAI_USE_VERTEXAI` | `TRUE` | `__init__.py` (setdefault) |
+| `LOG_LEVEL` | `INFO` | `logging_setup.py` (getenv fallback) |
+| `API_KEY` | `<TODO: update-this-value>` *(no default in source)* | `client.py` (getenv, no fallback) |
+
+If the script reports **upgrades** (stale TODO entries rewritten in
+place with real defaults from source), surface those in a separate table
+so the maintainer can eyeball each one:
+
+| Variable | Was | Now | Source |
+|----------|-----|-----|--------|
+| `USE_VERTEX` | `<TODO: update-this-value>` | `TRUE` | `__init__.py` (setdefault) |
+
+If the script logged `[WARN] Refused to upgrade …` for any variable,
+surface that too — the line's structure was ambiguous and was left
+untouched deliberately.
+
 Once the script finishes successfully, summarise what changed:
 
-- Which variables were added to `.env.example` (or confirm it was already up to date).
+- Which variables were **added** to `.env.example` (with resolved value +
+  source) or confirm it was already up to date.
+- Which existing TODOs were **upgraded** in place (v2.1) with real
+  defaults from source.
+- Any values that were **downgraded to `<TODO>` because they looked like
+  placeholders** — the maintainer should fix the source too.
 - Whether `load_dotenv()` was injected or was already present.
 - Whether `python-dotenv` was added to `pyproject.toml` or was already there.
 

--- a/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
@@ -1112,6 +1112,73 @@ def _docstring_node_ids(tree: ast.AST) -> set[int]:
     return ids
 
 
+def _getenv_default_node_ids(tree: ast.AST) -> set[int]:
+    """
+    Return the id() of every ast.Constant that is the DEFAULT argument of
+    an ``os.getenv``, ``os.environ.get``, or ``os.environ.setdefault`` call.
+
+    Excluding these is a correctness requirement for the model-replacement
+    path. A string like ``"gemini-3.5-flash"`` inside
+    ``os.getenv("MODEL_NAME_GENERATED_1", "gemini-3.5-flash")`` is NOT a
+    "raw hardcoded literal that needs promotion" — it's already serving
+    as the default value of an env-var read. Replacing it with a bare
+    ``os.getenv("MODEL_NAME")`` (which returns ``None`` when unset) would:
+
+      * Break the type contract (``str`` becomes ``str | None``).
+      * Cause runtime failures for callers that assume a string
+        (``Gemini(model=None)``, ``.startswith(...)``, etc.).
+      * Add nested-getenv complexity for zero benefit — the var was
+        already environment-configurable.
+
+    Both positional (``getenv("V", "default")``) and keyword
+    (``getenv("V", default="d")``) default forms are recognised, in
+    every function shape our extractor supports.
+    """
+    ids: set[int] = set()
+
+    def _mark_default(call: ast.Call) -> None:
+        """Add the id() of a string-literal default argument, if present."""
+        default_node: ast.expr | None = None
+        if len(call.args) > 1 and isinstance(call.args[1], ast.Constant):
+            default_node = call.args[1]
+        else:
+            for kw in call.keywords:
+                if kw.arg == "default" and isinstance(kw.value, ast.Constant):
+                    default_node = kw.value
+                    break
+        if default_node is not None and isinstance(
+            default_node.value, str
+        ):
+            ids.add(id(default_node))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # os.getenv(...)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "getenv"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "os"
+            and node.args
+        ):
+            _mark_default(node)
+            continue
+        # os.environ.get(...) / os.environ.setdefault(...)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("get", "setdefault")
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "environ"
+            and isinstance(node.func.value.value, ast.Name)
+            and node.func.value.value.id == "os"
+            and node.args
+        ):
+            _mark_default(node)
+
+    return ids
+
+
 def _flat_offset(lines: list[str], lineno: int, col: int) -> int:
     """Convert a 1-based lineno + 0-based col_offset to a flat char offset."""
     return sum(len(ln) for ln in lines[: lineno - 1]) + col
@@ -1571,7 +1638,17 @@ def extract_hardcoded_models(
 
     Uses AST to walk string constants and checks whether the value starts with
     any known model prefix (same list as python-validate-recipe.yml).
-    Docstring nodes are excluded to avoid false positives from documentation.
+
+    Two classes of nodes are excluded to prevent false positives / incorrect
+    rewrites:
+
+      * Docstrings (see :func:`_docstring_node_ids`) — a model name
+        mentioned in prose must not be replaced with an ``os.getenv`` call.
+      * String literals sitting inside an ``os.getenv``/``os.environ.get``/
+        ``os.environ.setdefault`` call as the DEFAULT argument (see
+        :func:`_getenv_default_node_ids`) — those are already serving as
+        env-var defaults; replacing them would silently regress the type
+        from ``str`` to ``str | None`` and could break at runtime.
 
     Returns:
       {file_path: [(line_number, model_string), ...]}
@@ -1585,12 +1662,12 @@ def extract_hardcoded_models(
         except (SyntaxError, UnicodeDecodeError):
             continue
 
-        docstring_ids = _docstring_node_ids(tree)
+        excluded_ids = _docstring_node_ids(tree) | _getenv_default_node_ids(tree)
 
         for node in ast.walk(tree):
             if not isinstance(node, ast.Constant):
                 continue
-            if id(node) in docstring_ids:
+            if id(node) in excluded_ids:
                 continue
             if not isinstance(node.value, str):
                 continue
@@ -1651,17 +1728,22 @@ def assign_model_var_names(
 
 def _model_replacement(
     node: ast.AST,
-    docstring_ids: set[int],
+    excluded_ids: set[int],
     name_map: dict[str, str],
     lines: list[str],
 ) -> tuple[int, int, str, str, str] | None:
     """
     Return (start, end, new_text, model_str, var_name) if node is a
     replaceable hardcoded model string, else None.
+
+    ``excluded_ids`` combines docstring nodes AND string literals that
+    are already serving as ``os.getenv``/``environ.get``/``setdefault``
+    default arguments. The latter must NOT be replaced — see
+    :func:`_getenv_default_node_ids` for the correctness rationale.
     """
     if not isinstance(node, ast.Constant):
         return None
-    if id(node) in docstring_ids:
+    if id(node) in excluded_ids:
         return None
     if not isinstance(node.value, str):
         return None
@@ -1713,7 +1795,13 @@ def replace_hardcoded_models(
         except (SyntaxError, UnicodeDecodeError):
             continue
 
-        docstring_ids = _docstring_node_ids(tree)
+        # Combined exclusion set: docstrings + getenv-default string
+        # literals. Both must never be rewritten by the model-replacement
+        # path (docstrings would corrupt documentation; getenv defaults
+        # would silently regress the return type from str to str | None).
+        excluded_ids = (
+            _docstring_node_ids(tree) | _getenv_default_node_ids(tree)
+        )
         lines = source.splitlines(keepends=True)
 
         # Collect (start_offset, end_offset, replacement_text) for each hit.
@@ -1725,7 +1813,7 @@ def replace_hardcoded_models(
         file_substituted: dict[str, str] = {}
         for node in ast.walk(tree):
             replacement = _model_replacement(
-                node, docstring_ids, name_map, lines
+                node, excluded_ids, name_map, lines
             )
             if replacement is None:
                 continue

--- a/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
@@ -290,16 +290,34 @@ SKIP_DIRS: frozenset[str] = frozenset(
     }
 )
 
+# Reserved filenames that always represent test / tooling infrastructure,
+# regardless of where they live in the recipe. These are skipped in addition
+# to the ``SKIP_DIRS`` check — needed because pytest's ``conftest.py`` is
+# commonly placed at the repo/recipe ROOT (not inside a ``tests/`` dir), so
+# the directory-based exclusion misses it. Surfacing env vars from
+# ``conftest.py`` (e.g. ``INTEGRATION_TEST`` gating integration-test
+# collection) into ``.env.example`` would silently invite users to set
+# test-mode toggles they should not touch.
+SKIP_FILES: frozenset[str] = frozenset(
+    {
+        "conftest.py",  # pytest reserved name — always test infrastructure
+    }
+)
+
 
 def find_python_files(recipe_dir: Path) -> list[Path]:
     """
-    Return all .py files under recipe_dir, skipping directories that are not
-    part of the recipe's own source (see SKIP_DIRS).
+    Return all .py files under recipe_dir, skipping:
+      * directories that are not part of the recipe's own source (see
+        ``SKIP_DIRS``); and
+      * files whose basename is a reserved test/tooling filename (see
+        ``SKIP_FILES``) regardless of directory.
     """
     return [
         p
         for p in sorted(recipe_dir.rglob("*.py"))
         if not SKIP_DIRS.intersection(p.relative_to(recipe_dir).parts)
+        and p.name not in SKIP_FILES
     ]
 
 

--- a/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
@@ -1872,9 +1872,7 @@ def _splice_and_ensure_os_import(
         mod_lines = modified.splitlines(keepends=True)
         idx = _post_header_index(mod_lines)
         # Avoid double blank lines if the line at idx is already blank.
-        suffix = (
-            "\n" if idx < len(mod_lines) and mod_lines[idx].strip() else ""
-        )
+        suffix = "\n" if idx < len(mod_lines) and mod_lines[idx].strip() else ""
         mod_lines.insert(idx, f"import os\n{suffix}")
         modified = "".join(mod_lines)
     return modified

--- a/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
@@ -213,6 +213,12 @@ def _write_text_atomic(path: Path, content: str, encoding: str = "utf-8") -> Non
     filesystem), a crash or disk-full error mid-write leaves the original
     file untouched — the worst outcome is an orphaned ``.tmp`` file.
 
+    ``newline=""`` disables Python's universal-newlines translation on
+    write, so any ``\\r\\n`` sequences in *content* land on disk verbatim
+    rather than being expanded by the platform. Callers that want to
+    preserve a file's original line endings must also disable universal
+    newlines on read (see :func:`_read_text_preserving_newlines`).
+
     Raises ``OSError`` on any I/O failure; callers are responsible for
     catching and reporting it.
     """
@@ -221,7 +227,7 @@ def _write_text_atomic(path: Path, content: str, encoding: str = "utf-8") -> Non
     try:
         fd, tmp_name = tempfile.mkstemp(dir=dir_, suffix=".tmp")
         tmp_path = Path(tmp_name)
-        with open(fd, "w", encoding=encoding) as fh:
+        with open(fd, "w", encoding=encoding, newline="") as fh:
             fh.write(content)
         tmp_path.replace(path)
     except OSError:
@@ -232,6 +238,20 @@ def _write_text_atomic(path: Path, content: str, encoding: str = "utf-8") -> Non
             except OSError:
                 pass
         raise
+
+
+def _read_text_preserving_newlines(path: Path) -> str:
+    """Read *path* WITHOUT converting CRLF/CR to LF.
+
+    ``Path.read_text()`` uses universal-newlines mode by default, which
+    silently rewrites ``\\r\\n`` to ``\\n`` in memory. That's fine for
+    parsing but catastrophic if the caller round-trips the file back to
+    disk — it will replace every ``\\r\\n`` with ``\\n``, mutating the
+    user's file in a way they didn't ask for. This helper opens with
+    ``newline=""`` so the bytes come through unchanged.
+    """
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        return fh.read()
 
 
 # ---------------------------------------------------------------------------
@@ -315,7 +335,21 @@ def _extract_var_from_node(
             else None
         )
 
-    # os.getenv("VAR") / os.getenv("VAR", "default")
+    def _default_from_call(call: ast.Call) -> str | None:
+        """Extract the ``default`` argument from a getenv/get/setdefault call.
+
+        Checks the second positional argument first, then falls back to
+        the ``default=`` keyword form (``os.getenv("X", default="y")``).
+        Non-string-literal defaults return None so the caller emits TODO.
+        """
+        if len(call.args) > 1:
+            return _str_const(call.args[1])
+        for kw in call.keywords:
+            if kw.arg == "default":
+                return _str_const(kw.value)
+        return None
+
+    # os.getenv("VAR") / os.getenv("VAR", "default") / os.getenv("VAR", default="d")
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -325,11 +359,12 @@ def _extract_var_from_node(
         and node.args
     ):
         var_name = _str_const(node.args[0])
-        default = _str_const(node.args[1]) if len(node.args) > 1 else None
+        default = _default_from_call(node)
         return var_name, "getenv", default
 
     # os.environ.get("VAR") / os.environ.get("VAR", "default")
     # os.environ.setdefault("VAR", "default")
+    # Keyword-form default= is also honoured for both.
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -341,7 +376,7 @@ def _extract_var_from_node(
         and node.args
     ):
         var_name = _str_const(node.args[0])
-        default = _str_const(node.args[1]) if len(node.args) > 1 else None
+        default = _default_from_call(node)
         kind = "environ_get" if node.func.attr == "get" else "setdefault"
         return var_name, kind, default
 
@@ -874,8 +909,13 @@ def update_env_example(
 
     # Build the new content. Line-by-line rewrites are applied to the
     # existing content; new entries are appended at the end.
+    #
+    # CRLF-preservation matters here: if we read the file with universal
+    # newlines mode (the default), Windows-authored .env.example files
+    # would silently lose their \r\n endings on every skill run. Reading
+    # + writing with newline="" keeps the bytes stable.
     if env_example.exists():
-        current = env_example.read_text(encoding="utf-8")
+        current = _read_text_preserving_newlines(env_example)
     else:
         current = ""
     lines = current.splitlines(keepends=True)

--- a/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
@@ -205,7 +205,9 @@ load_dotenv()"""
 # ---------------------------------------------------------------------------
 
 
-def _write_text_atomic(path: Path, content: str, encoding: str = "utf-8") -> None:
+def _write_text_atomic(
+    path: Path, content: str, encoding: str = "utf-8"
+) -> None:
     """Write *content* to *path* atomically via a sibling temp file.
 
     Writes to a temporary file in the same directory as *path*, then renames
@@ -250,7 +252,7 @@ def _read_text_preserving_newlines(path: Path) -> str:
     user's file in a way they didn't ask for. This helper opens with
     ``newline=""`` so the bytes come through unchanged.
     """
-    with open(path, "r", encoding="utf-8", newline="") as fh:
+    with open(path, encoding="utf-8", newline="") as fh:
         return fh.read()
 
 
@@ -512,9 +514,7 @@ def resolve_default(sources: list[Source]) -> ResolvedDefault:
         with_defaults,
         key=lambda s: (_KIND_PRIORITY.get(s.kind, 99), str(s.file), s.line),
     )
-    conflicts = sum(
-        1 for s in with_defaults if s.default != winner.default
-    )
+    conflicts = sum(1 for s in with_defaults if s.default != winner.default)
     return ResolvedDefault(
         value=winner.default, winner=winner, conflict_count=conflicts
     )
@@ -879,6 +879,103 @@ def _plan_updates(
     return to_append, to_upgrade
 
 
+def _build_updated_content(
+    env_example: Path,
+    to_append: dict[str, str],
+    to_upgrade: dict[str, tuple[int, str]],
+    added_names: list[str],
+    upgraded_names: list[str],
+) -> tuple[str, list[str]]:
+    """Assemble the new ``.env.example`` content in memory.
+
+    Reads the existing file (CRLF-preservingly), applies in-place upgrades
+    line-by-line via :func:`_rewrite_var_line` (with WARN on refusal),
+    ensures a trailing newline, and appends new entries in a marker block.
+
+    Returns ``(new_content, actually_upgraded)`` where ``actually_upgraded``
+    is the subset of ``upgraded_names`` that the fail-closed rewriter did
+    not refuse. The caller runs the round-trip safety check on the result
+    and decides whether to actually write.
+    """
+    if env_example.exists():
+        current = _read_text_preserving_newlines(env_example)
+    else:
+        current = ""
+    lines = current.splitlines(keepends=True)
+
+    actually_upgraded: list[str] = []
+    for var in upgraded_names:
+        _line_idx, new_body = to_upgrade[var]
+        if _rewrite_var_line(lines, var, new_body):
+            actually_upgraded.append(var)
+        else:
+            print(
+                f"[WARN] Refused to upgrade {var} in .env.example — "
+                "the existing line's structure was ambiguous (quoted "
+                "value, multiple matches, or line continuation). "
+                "Leaving it as-is. Delete the line and re-run to force "
+                "regeneration.",
+                file=sys.stderr,
+            )
+
+    # Ensure a trailing newline before appending fresh entries.
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] = lines[-1] + "\n"
+
+    if to_append:
+        block_header = (
+            "\n# Environment variables extracted by"
+            " extract-python-environment-variables\n"
+        )
+        lines.append(block_header)
+        for var in added_names:
+            lines.append(to_append[var] + "\n")
+
+    return "".join(lines), actually_upgraded
+
+
+def _passes_round_trip_check(
+    new_content: str,
+    actually_upgraded: list[str],
+    added_names: list[str],
+) -> bool:
+    """Re-parse ``new_content`` and verify every planned change looks right.
+
+    Every var in ``actually_upgraded`` must now classify as ``SKILL_REAL``;
+    every var in ``added_names`` must be present. Any deviation means our
+    rewrite produced something the classifier doesn't understand — a
+    rewriter bug — and the caller must REFUSE to write to preserve the
+    file's current on-disk contents.
+
+    Emits ``[ERROR]`` on stderr for the first mismatch it finds and
+    returns False. Returns True when everything re-parses cleanly.
+    """
+    reparsed = _parse_env_content(new_content)
+    for var in actually_upgraded:
+        entry = reparsed.get(var)
+        if (
+            entry is None
+            or entry.classification != EntryClassification.SKILL_REAL
+        ):
+            print(
+                f"[ERROR] Round-trip safety check failed for {var} — the "
+                "rewritten line would not re-parse as a skill-authored real "
+                "value. Refusing to write; .env.example was NOT modified.",
+                file=sys.stderr,
+            )
+            return False
+    for var in added_names:
+        if var not in reparsed:
+            print(
+                f"[ERROR] Round-trip safety check failed for appended {var} "
+                "— entry did not re-parse. Refusing to write; .env.example "
+                "was NOT modified.",
+                file=sys.stderr,
+            )
+            return False
+    return True
+
+
 def update_env_example(
     env_example: Path,
     env_vars: dict[str, list[Source]],
@@ -925,78 +1022,15 @@ def update_env_example(
     if dry_run:
         return added_names, upgraded_names
 
-    # Build the new content. Line-by-line rewrites are applied to the
-    # existing content; new entries are appended at the end.
-    #
-    # CRLF-preservation matters here: if we read the file with universal
-    # newlines mode (the default), Windows-authored .env.example files
-    # would silently lose their \r\n endings on every skill run. Reading
-    # + writing with newline="" keeps the bytes stable.
-    if env_example.exists():
-        current = _read_text_preserving_newlines(env_example)
-    else:
-        current = ""
-    lines = current.splitlines(keepends=True)
-
-    # Apply in-place upgrades. Any refusal (fail-closed rewriter) drops
-    # the var from the upgrade list.
-    actually_upgraded: list[str] = []
-    for var in upgraded_names:
-        _line_idx, new_body = to_upgrade[var]
-        if _rewrite_var_line(lines, var, new_body):
-            actually_upgraded.append(var)
-        else:
-            print(
-                f"[WARN] Refused to upgrade {var} in .env.example — "
-                "the existing line's structure was ambiguous (quoted "
-                "value, multiple matches, or line continuation). "
-                "Leaving it as-is. Delete the line and re-run to force "
-                "regeneration.",
-                file=sys.stderr,
-            )
-
-    # Ensure a trailing newline before appending fresh entries.
-    if lines and not lines[-1].endswith("\n"):
-        lines[-1] = lines[-1] + "\n"
-
-    if to_append:
-        block_header = (
-            "\n# Environment variables extracted by"
-            " extract-python-environment-variables\n"
-        )
-        lines.append(block_header)
-        for var in added_names:
-            lines.append(to_append[var] + "\n")
-
-    new_content = "".join(lines)
-
-    # Round-trip safety check: re-parse the new content and confirm
-    # every planned upgrade now shows as SKILL_REAL. If any doesn't,
-    # our rewrite produced something we don't understand — refuse to
-    # write and log an ERROR. Belt-and-braces backstop against a
-    # rewriter bug corrupting the file.
-    reparsed = _parse_env_content(new_content)
-    for var in actually_upgraded:
-        entry = reparsed.get(var)
-        if entry is None or entry.classification != EntryClassification.SKILL_REAL:
-            print(
-                f"[ERROR] Round-trip safety check failed for {var} — the "
-                "rewritten line would not re-parse as a skill-authored real "
-                "value. Refusing to write; .env.example was NOT modified.",
-                file=sys.stderr,
-            )
-            return [], []
-    # Also verify every appended entry re-parses. Missing → bug in the
-    # formatter or the append path.
-    for var in added_names:
-        if var not in reparsed:
-            print(
-                f"[ERROR] Round-trip safety check failed for appended {var} "
-                "— entry did not re-parse. Refusing to write; .env.example "
-                "was NOT modified.",
-                file=sys.stderr,
-            )
-            return [], []
+    # Build new content in memory (line-by-line rewrites + trailing
+    # appends), then run the round-trip safety check before writing.
+    new_content, actually_upgraded = _build_updated_content(
+        env_example, to_append, to_upgrade, added_names, upgraded_names
+    )
+    if not _passes_round_trip_check(
+        new_content, actually_upgraded, added_names
+    ):
+        return [], []
 
     try:
         _write_text_atomic(env_example, new_content)
@@ -1164,9 +1198,7 @@ def _getenv_default_node_ids(tree: ast.AST) -> set[int]:
                 if kw.arg == "default" and isinstance(kw.value, ast.Constant):
                     default_node = kw.value
                     break
-        if default_node is not None and isinstance(
-            default_node.value, str
-        ):
+        if default_node is not None and isinstance(default_node.value, str):
             ids.add(id(default_node))
 
     for node in ast.walk(tree):
@@ -1680,7 +1712,9 @@ def extract_hardcoded_models(
         except (SyntaxError, UnicodeDecodeError):
             continue
 
-        excluded_ids = _docstring_node_ids(tree) | _getenv_default_node_ids(tree)
+        excluded_ids = _docstring_node_ids(tree) | _getenv_default_node_ids(
+            tree
+        )
 
         for node in ast.walk(tree):
             if not isinstance(node, ast.Constant):
@@ -1780,6 +1814,72 @@ def _model_replacement(
     return start, end, f'os.getenv("{var_name}")', node.value, var_name
 
 
+def _collect_model_replacements(
+    tree: ast.AST, source: str, name_map: dict[str, str]
+) -> tuple[list[tuple[int, int, str]], dict[str, str]]:
+    """Walk ``tree`` and collect model-string replacement plans.
+
+    Returns ``(replacements, file_substituted)`` where:
+      * ``replacements`` is a list of ``(start_offset, end_offset,
+        replacement_text)`` triples suitable for a reverse-order splice.
+      * ``file_substituted`` maps ``{model_string: env_var_name}`` for
+        every replacement planned in this file — merged into the caller's
+        aggregate ONLY after the write succeeds, so a failed syntax check
+        or OSError never causes ``.env.example`` to record a substitution
+        that didn't actually land.
+
+    The combined exclusion set (docstrings + getenv defaults) protects
+    against corrupting documentation OR silently regressing the return
+    type of a call like ``os.getenv("V", "gemini-3.5-flash")`` from
+    ``str`` to ``str | None``.
+    """
+    excluded_ids = _docstring_node_ids(tree) | _getenv_default_node_ids(tree)
+    lines = source.splitlines(keepends=True)
+    replacements: list[tuple[int, int, str]] = []
+    file_substituted: dict[str, str] = {}
+    for node in ast.walk(tree):
+        replacement = _model_replacement(node, excluded_ids, name_map, lines)
+        if replacement is None:
+            continue
+        start, end, new_text, model_str, var_name = replacement
+        replacements.append((start, end, new_text))
+        file_substituted[model_str] = var_name
+    return replacements, file_substituted
+
+
+def _splice_and_ensure_os_import(
+    source: str, replacements: list[tuple[int, int, str]]
+) -> str:
+    """Apply the collected ``replacements`` to ``source`` and inject
+    ``import os`` if missing.
+
+    Splices in reverse order so earlier offsets stay valid. Injects
+    ``import os`` (AST-checked so a stray occurrence in a comment or
+    docstring doesn't suppress the real import) after any leading license
+    + module-docstring header, with a trailing blank line for readability.
+    """
+    replacements.sort(key=lambda x: x[0], reverse=True)
+    chars = list(source)
+    for start, end, new_text in replacements:
+        chars[start:end] = list(new_text)
+    modified = "".join(chars)
+
+    try:
+        already_imports_os = _imports_os(ast.parse(modified))
+    except SyntaxError:
+        already_imports_os = "import os" in modified
+    if not already_imports_os:
+        mod_lines = modified.splitlines(keepends=True)
+        idx = _post_header_index(mod_lines)
+        # Avoid double blank lines if the line at idx is already blank.
+        suffix = (
+            "\n" if idx < len(mod_lines) and mod_lines[idx].strip() else ""
+        )
+        mod_lines.insert(idx, f"import os\n{suffix}")
+        modified = "".join(mod_lines)
+    return modified
+
+
 def replace_hardcoded_models(
     py_files: list[Path],
     hits: dict[Path, list[tuple[int, str]]],
@@ -1813,32 +1913,9 @@ def replace_hardcoded_models(
         except (SyntaxError, UnicodeDecodeError):
             continue
 
-        # Combined exclusion set: docstrings + getenv-default string
-        # literals. Both must never be rewritten by the model-replacement
-        # path (docstrings would corrupt documentation; getenv defaults
-        # would silently regress the return type from str to str | None).
-        excluded_ids = (
-            _docstring_node_ids(tree) | _getenv_default_node_ids(tree)
+        replacements, file_substituted = _collect_model_replacements(
+            tree, source, name_map
         )
-        lines = source.splitlines(keepends=True)
-
-        # Collect (start_offset, end_offset, replacement_text) for each hit.
-        # Track per-file substitutions separately — they are only merged into
-        # `substituted` after a confirmed successful write, so a syntax-check
-        # failure or OSError never causes .env.example to be updated for a
-        # file whose source was not actually modified.
-        replacements: list[tuple[int, int, str]] = []
-        file_substituted: dict[str, str] = {}
-        for node in ast.walk(tree):
-            replacement = _model_replacement(
-                node, excluded_ids, name_map, lines
-            )
-            if replacement is None:
-                continue
-            start, end, new_text, model_str, var_name = replacement
-            replacements.append((start, end, new_text))
-            file_substituted[model_str] = var_name
-
         if not replacements:
             continue
 
@@ -1847,31 +1924,7 @@ def replace_hardcoded_models(
             substituted.update(file_substituted)
             continue
 
-        # Apply in reverse order so earlier offsets stay valid
-        replacements.sort(key=lambda x: x[0], reverse=True)
-        chars = list(source)
-        for start, end, new_text in replacements:
-            chars[start:end] = list(new_text)
-        modified = "".join(chars)
-
-        # Ensure `import os` is present, placed after license + docstring.
-        # AST-based so "import os" appearing only in a comment or docstring
-        # does not suppress the real import (which would leave the injected
-        # os.getenv(...) calls raising NameError at runtime).
-        # Include a trailing blank line so the import block is well-formatted.
-        try:
-            already_imports_os = _imports_os(ast.parse(modified))
-        except SyntaxError:
-            already_imports_os = "import os" in modified
-        if not already_imports_os:
-            mod_lines = modified.splitlines(keepends=True)
-            idx = _post_header_index(mod_lines)
-            # Avoid double blank lines if the line at idx is already blank
-            suffix = (
-                "\n" if idx < len(mod_lines) and mod_lines[idx].strip() else ""
-            )
-            mod_lines.insert(idx, f"import os\n{suffix}")
-            modified = "".join(mod_lines)
+        modified = _splice_and_ensure_os_import(source, replacements)
 
         # Syntax check before writing — refuse to write if the modified
         # source no longer parses. This catches edge cases like a model

--- a/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/scripts/extract_env_vars.py
@@ -16,8 +16,13 @@
 extract_env_vars.py
 
 Scans a Python recipe directory and:
-  1. Detects all environment variable reads in non-test Python files.
-  2. Creates or updates .env.example with any missing variables.
+  1. Detects all environment variable accesses in non-test Python files
+     — including ``os.environ.setdefault("V", "d")``, whose "d" would
+     otherwise be a hidden default that a user editing .env.example has
+     no way to discover.
+  2. Creates or updates .env.example with any missing variables, writing
+     the extracted default value when the author committed to one and
+     falling back to a TODO placeholder otherwise (see rule below).
   3. Injects the load_dotenv() bootstrap snippet into the package __init__.py.
   4. Ensures python-dotenv>=1.0.0 is listed in pyproject.toml dependencies.
   5. Detects hardcoded model name strings and replaces them with
@@ -25,26 +30,41 @@ Scans a Python recipe directory and:
 
 Two hard rules the script NEVER breaks:
 
-  (1) NO INFERRED DEFAULTS FOR REGULAR ENV VARS. Every new .env.example
-      entry for a variable read via os.getenv/os.environ is written with
-      the TODO placeholder, regardless of any os.getenv("VAR", "fallback")
-      the source may have. Exception: hardcoded model strings that are
-      replaced in source ARE written as their actual value in .env.example
-      (e.g. MODEL_NAME_GENERATED_1=gemini-3.5-flash) because the value is
-      known and correct, not inferred. The source replacement always emits
-      bare os.getenv("VAR") with no default argument.
+  (1) IDEMPOTENCY / USER-EDIT SAFETY FOR .env.example. Existing lines
+      in .env.example are NEVER modified. If a variable is already
+      declared — with any value, whether the skill wrote it on a previous
+      run or the maintainer typed it — the skill skips it. Delete the
+      line to force regeneration. This is what makes re-running the
+      skill safe on a recipe whose maintainer has customised .env.example.
+
+      When ADDING a new line, the writer uses the resolved default
+      extracted from source (setdefault > getenv/environ.get fallback,
+      alphabetical file tie-break). Placeholder-shaped values (e.g.
+      "my-project-id", "changeme", "<...>") are downgraded to the TODO
+      placeholder AND the source string is preserved in the marker
+      comment so the maintainer sees what was in source and can fix it.
+      Every generated line carries a ``# extracted-by:extract-env-vars``
+      marker.
+
+      Hardcoded model strings replaced in source ARE written as their
+      actual value in .env.example (e.g. MODEL_NAME_GENERATED_1=
+      gemini-3.5-flash) — same as before v2.
 
   (2) ADDITIVE-ONLY FOR PYTHON FILES. The script never writes new
       os.environ.setdefault(...) bootstrap lines into any Python file.
       Pre-existing os.environ.setdefault(...) or
       os.getenv("VAR", "default") calls that a recipe author wrote by
       hand are LEFT UNTOUCHED — the script's only writes to Python
-      files are (a) the load_dotenv snippet and (b) the model-literal
-      replacement.
+      files are (a) the load_dotenv snippet, (b) trailing-import E402
+      suppression, and (c) the model-literal replacement.
 
-Rationale: default values are the maintainer's decision, not the
-script's. Persisting inferred defaults or writing new bootstrap
-setdefault() calls would be presumptuous.
+Rationale for the v2 change (extracting setdefault/getenv defaults instead
+of always writing TODO): a value hidden inside a Python file that a user
+must know about but has no reason to look at is, in practice, undocumented.
+.env.example is the documented configuration surface. Surfacing what the
+author already committed to in code makes the configuration discoverable
+without inventing anything new — the value in source WAS the value; we're
+only lifting it into view.
 """
 
 import argparse
@@ -53,6 +73,7 @@ import re
 import sys
 import tempfile
 from pathlib import Path
+from typing import NamedTuple
 
 if sys.version_info < (3, 11):
     sys.exit(
@@ -68,6 +89,90 @@ import tomllib
 # ---------------------------------------------------------------------------
 
 PLACEHOLDER = "<TODO: update-this-value>"
+
+# Stable substring embedded in every .env.example line the skill writes.
+# Used by the writer to distinguish skill-authored lines from user-authored
+# ones on subsequent runs. Also useful for maintainers grepping to find
+# "what did the skill do?".
+EXTRACTED_MARKER = "extracted-by:extract-env-vars"
+
+# Kinds of AST-level env var access, in descending order of "how strongly
+# does the author commit to this default value?".
+#
+#   'setdefault' — os.environ.setdefault("V", "x"). Mutates the process
+#      environment; the value becomes visible to every subsequent read.
+#      Strongest signal that the author has chosen this as the canonical
+#      default.
+#   'getenv' / 'environ_get' — os.getenv("V", "x") / os.environ.get(...).
+#      Per-read fallback; does not mutate os.environ. Weaker commitment,
+#      but still an authored value.
+#   'environ_sub' — os.environ["V"]. Never carries a default.
+_KIND_PRIORITY: dict[str, int] = {
+    "setdefault": 0,
+    "getenv": 1,
+    "environ_get": 1,
+    "environ_sub": 2,
+}
+
+
+class Source(NamedTuple):
+    """One AST-level read/write of an env var, with provenance for reporting.
+
+    ``default`` is the string literal passed as the second argument, or None
+    when the call had no default (or the default was not a string literal —
+    non-string defaults cannot be surfaced in ``.env.example``).
+    """
+
+    file: Path
+    kind: str  # one of _KIND_PRIORITY's keys
+    default: str | None
+    line: int
+
+
+# Values that look like placeholders the author never intended as real
+# defaults (e.g. `os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "my-project-id")`
+# used as a "reminder to fill in" bootstrap). When the extracted value matches
+# any of these, the writer downgrades the .env.example entry to the TODO
+# placeholder AND includes the source string in the marker comment so the
+# maintainer sees what was found and can fix the source too.
+#
+# Kept CONSERVATIVE on purpose: false-downgrading a real default is more
+# damaging than letting a placeholder through (the placeholder still ends up
+# in .env.example, just without the shape warning — same as the pre-v2
+# behaviour).
+_PLACEHOLDER_EXACT: frozenset[str] = frozenset(
+    {"changeme", "change-me", "todo", "xxx", "xxxxx", "foo", "bar", "baz"}
+)
+_PLACEHOLDER_PREFIXES: tuple[str, ...] = (
+    "your-",
+    "your_",
+    "my-",
+    "my_",
+)
+# Compiled once; case-insensitive because placeholders often mix casing.
+_ANGLE_WRAPPED_RE = re.compile(r"^<.*>$")
+
+
+def looks_like_placeholder(value: str) -> str | None:
+    """Return a short reason string if ``value`` looks like a placeholder.
+
+    Returns None when the value looks like a real default and should be
+    written to .env.example as-is. See ``_PLACEHOLDER_EXACT`` /
+    ``_PLACEHOLDER_PREFIXES`` for the (deliberately conservative) rule set.
+    """
+    if value == "":
+        return "empty string"
+    lowered = value.lower()
+    if _ANGLE_WRAPPED_RE.match(value):
+        return "angle-wrapped placeholder"
+    if lowered in _PLACEHOLDER_EXACT:
+        return "generic placeholder token"
+    if any(lowered.startswith(p) for p in _PLACEHOLDER_PREFIXES):
+        return "starts with your-/my- (looks like a stub)"
+    if "example.com" in lowered:
+        return "contains example.com"
+    return None
+
 
 # Model name prefixes that indicate a hardcoded model identifier.
 # Kept in sync with python-validate-recipe.yml.
@@ -185,11 +290,22 @@ def find_python_files(recipe_dir: Path) -> list[Path]:
 
 def _extract_var_from_node(
     node: ast.AST,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, str | None]:
     """
-    Return (var_name, default) if node is an env-var read, else (None, None).
+    Return ``(var_name, kind, default)`` if node is an env-var access,
+    else ``(None, None, None)``.
 
-    Handles: os.getenv(), os.environ.get(), os.environ[].
+    Handles four forms:
+      * ``os.getenv("V")`` / ``os.getenv("V", "d")``               → kind='getenv'
+      * ``os.environ.get("V")`` / ``os.environ.get("V", "d")``     → kind='environ_get'
+      * ``os.environ["V"]``                                        → kind='environ_sub'
+      * ``os.environ.setdefault("V", "d")``                        → kind='setdefault'
+
+    Note that ``setdefault`` is included even though it MUTATES the process
+    environment rather than reading from it — semantically it declares
+    "if VAR is not set, VAR IS d". That declaration is the author's
+    committed default, and the whole point of surfacing it in .env.example
+    is that a user cannot discover it otherwise.
     """
 
     def _str_const(n: ast.expr) -> str | None:
@@ -210,13 +326,14 @@ def _extract_var_from_node(
     ):
         var_name = _str_const(node.args[0])
         default = _str_const(node.args[1]) if len(node.args) > 1 else None
-        return var_name, default
+        return var_name, "getenv", default
 
     # os.environ.get("VAR") / os.environ.get("VAR", "default")
+    # os.environ.setdefault("VAR", "default")
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "get"
+        and node.func.attr in ("get", "setdefault")
         and isinstance(node.func.value, ast.Attribute)
         and node.func.value.attr == "environ"
         and isinstance(node.func.value.value, ast.Name)
@@ -225,7 +342,8 @@ def _extract_var_from_node(
     ):
         var_name = _str_const(node.args[0])
         default = _str_const(node.args[1]) if len(node.args) > 1 else None
-        return var_name, default
+        kind = "environ_get" if node.func.attr == "get" else "setdefault"
+        return var_name, kind, default
 
     # os.environ["VAR"]
     if (
@@ -235,20 +353,23 @@ def _extract_var_from_node(
         and isinstance(node.value.value, ast.Name)
         and node.value.value.id == "os"
     ):
-        return _str_const(node.slice), None
+        return _str_const(node.slice), "environ_sub", None
 
-    return None, None
+    return None, None, None
 
 
-def extract_env_vars(py_files: list[Path]) -> dict[str, str | None]:
+def extract_env_vars(py_files: list[Path]) -> dict[str, list[Source]]:
     """
-    Walk each file's AST and collect env var names + optional inline defaults.
+    Walk each file's AST and collect every env-var access site.
 
     Returns:
-      {VAR_NAME: default_value_or_None}
-      When a variable appears multiple times, a non-None default wins.
+      {VAR_NAME: [Source(file, kind, default, line), ...]}
+
+    The returned list preserves every occurrence — the resolver
+    (:func:`resolve_default`) is responsible for picking a winning default
+    when a variable has multiple sources with different defaults.
     """
-    found: dict[str, str | None] = {}
+    found: dict[str, list[Source]] = {}
     skipped: set[str] = set()
 
     for py_file in py_files:
@@ -262,12 +383,16 @@ def extract_env_vars(py_files: list[Path]) -> dict[str, str | None]:
             continue
 
         for node in ast.walk(tree):
-            var_name, default = _extract_var_from_node(node)
-            if not var_name:
+            var_name, kind, default = _extract_var_from_node(node)
+            if not var_name or not kind:
                 continue
             if re.match(r"^[A-Z_][A-Z0-9_]*$", var_name):
-                if var_name not in found or found[var_name] is None:
-                    found[var_name] = default
+                lineno = getattr(node, "lineno", 0)
+                found.setdefault(var_name, []).append(
+                    Source(
+                        file=py_file, kind=kind, default=default, line=lineno
+                    )
+                )
             else:
                 # Not UPPER_SNAKE_CASE — dropped, but surfaced so the
                 # maintainer isn't left wondering why it never appeared in
@@ -287,78 +412,545 @@ def extract_env_vars(py_files: list[Path]) -> dict[str, str | None]:
 
 
 # ---------------------------------------------------------------------------
-# Step 3: Create / update .env.example
+# Default resolution + .env.example line formatting
 # ---------------------------------------------------------------------------
 
 
-def read_defined_vars(env_example: Path) -> set[str]:
-    """Return the set of variable names already declared in .env.example."""
-    if not env_example.exists():
-        return set()
+class ResolvedDefault(NamedTuple):
+    """The winning default for an env var, chosen from its Source list.
 
-    defined: set[str] = set()
-    for line in env_example.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
+    ``value`` is None when no source supplied a string-literal default;
+    the caller should emit a TODO placeholder in that case.
+
+    ``winner`` is the specific ``Source`` the value came from — used to
+    build the provenance comment in .env.example.
+
+    ``conflict_count`` is the number of OTHER sources that supplied a
+    DIFFERENT string-literal default. Zero means every default agreed
+    (or there was only one default at all). A non-zero conflict count is
+    surfaced in the provenance comment so the maintainer can reconcile.
+    """
+
+    value: str | None
+    winner: Source | None
+    conflict_count: int
+
+
+def resolve_default(sources: list[Source]) -> ResolvedDefault:
+    """Pick the winning default for a variable from all its access sites.
+
+    Priority: ``setdefault`` beats ``getenv`` / ``environ_get`` fallbacks
+    (see the ``_KIND_PRIORITY`` docstring for why). Within a tier, the
+    source whose file sorts first alphabetically wins, then the earliest
+    line within that file — both purely for determinism.
+
+    Sources that have no string-literal default (``environ_sub``, bare
+    ``getenv("V")``, or a non-string default like ``os.getenv("N", 5)``)
+    do not contribute a value but DO count against the total when
+    computing conflicts — actually no, they don't: they didn't propose a
+    default at all, so they cannot conflict with the winner. Only
+    string-literal defaults that DIFFER from the winner are conflicts.
+    """
+    with_defaults = [s for s in sources if s.default is not None]
+    if not with_defaults:
+        return ResolvedDefault(value=None, winner=None, conflict_count=0)
+
+    winner = min(
+        with_defaults,
+        key=lambda s: (_KIND_PRIORITY.get(s.kind, 99), str(s.file), s.line),
+    )
+    conflicts = sum(
+        1 for s in with_defaults if s.default != winner.default
+    )
+    return ResolvedDefault(
+        value=winner.default, winner=winner, conflict_count=conflicts
+    )
+
+
+def _relpath_or_name(path: Path, base: Path | None) -> str:
+    """Return ``path`` relative to ``base`` if possible, else its name.
+
+    Used only for human-readable provenance comments — never for logic.
+    """
+    if base is None:
+        return path.name
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return path.name
+
+
+def format_env_entry(
+    var_name: str,
+    sources: list[Source],
+    recipe_dir: Path | None = None,
+) -> str:
+    """Return one ``.env.example`` line (no trailing newline) for ``var_name``.
+
+    Format:
+      ``VAR=<value>  # <EXTRACTED_MARKER>; <provenance>``
+
+    Where ``<value>`` is one of:
+      * the resolved default, if a source supplied one and it doesn't look
+        like a placeholder;
+      * :data:`PLACEHOLDER` (``<TODO: update-this-value>``) otherwise.
+
+    The provenance section always names the source (file + kind) when a
+    default was found — including the case where we downgraded a
+    placeholder-shaped value to TODO, so the maintainer can find and fix
+    the source too. If multiple sources supplied conflicting defaults, the
+    conflict count is included.
+    """
+    resolved = resolve_default(sources)
+
+    if resolved.value is None:
+        # No string-literal default anywhere — safest to ask the maintainer.
+        return (
+            f"{var_name}={PLACEHOLDER}"
+            f"  # {EXTRACTED_MARKER}; no default in source"
+        )
+
+    assert resolved.winner is not None  # narrow for type-checkers
+    where = _relpath_or_name(resolved.winner.file, recipe_dir)
+    provenance = f"from {resolved.winner.kind} in {where}"
+    if resolved.conflict_count:
+        provenance += (
+            f" (differs from {resolved.conflict_count} other source(s))"
+        )
+
+    reason = looks_like_placeholder(resolved.value)
+    if reason is not None:
+        # Downgrade to TODO but keep the source string visible so the
+        # maintainer can find and fix the source too.
+        return (
+            f"{var_name}={PLACEHOLDER}  # {EXTRACTED_MARKER}; {provenance};"
+            f' source had "{resolved.value}" — {reason}, please fix source too'
+        )
+
+    return f"{var_name}={resolved.value}  # {EXTRACTED_MARKER}; {provenance}"
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Create / update .env.example
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Classification of existing entries in .env.example
+#
+# When re-running the skill against a recipe whose .env.example already has
+# entries, we can't apply a blanket "if present, skip" rule — that would
+# leave v1-era TODO placeholders in place forever, even after source-side
+# defaults become available. But we also can't blanket-overwrite, because
+# any line the maintainer typed by hand is theirs.
+#
+# So every existing entry is classified into one of these buckets. The
+# writer's action table (see `update_env_example`) depends on the bucket
+# AND on what the current source scan produced.
+#
+# Golden rule: fail closed. If we can't confidently prove a line was
+# skill-authored (has our marker) OR is a bare v1 TODO with no user
+# annotations, we treat it as USER_OWNED and leave it alone. The cost
+# of a missed upgrade is small; the cost of clobbering user intent
+# is unrecoverable without a git checkout.
+# ---------------------------------------------------------------------------
+
+
+class EntryClassification:
+    """String tags for the five states an existing .env.example entry can be in."""
+
+    USER_OWNED = "user_owned"  # never touch
+    V1_TODO = "v1_todo"  # unmarked bare TODO from pre-v2 skill; upgradable
+    SKILL_TODO = "skill_todo"  # marker present + value is v2 PLACEHOLDER
+    SKILL_REAL = "skill_real"  # marker present + non-placeholder value
+    # (MISSING is not a state of an existing entry — it's the absence of one.)
+
+
+class ExistingEntry(NamedTuple):
+    """One env-var entry parsed out of an existing .env.example file.
+
+    ``line_index`` is 0-based into the raw ``lines`` list (splitlines with
+    keepends), so the rewriter can address the exact physical line.
+
+    ``raw_line`` is the untouched line as it appeared on disk (including
+    trailing newline), preserved so a refusal-to-rewrite leaves everything
+    byte-identical.
+
+    ``value`` is the value portion (after ``=``, before any inline
+    comment), stripped of surrounding whitespace. Quoted values are
+    returned WITH their quotes so the classifier / rewriter can detect
+    and refuse them.
+    """
+
+    line_index: int
+    raw_line: str
+    value: str
+    classification: str  # one of EntryClassification's constants
+
+
+# Regex for a well-formed bare (unquoted) env line. Multiple things must
+# ALL hold for us to consider a line safely rewritable later:
+#   * Optional `export ` prefix
+#   * VAR name is UPPER_SNAKE_CASE
+#   * Single `=` (the rest of the line goes to the value + optional comment)
+#   * Value up to the first `#` (comment start) or end-of-line
+#
+# Anything that doesn't match this shape is treated as USER_OWNED — the
+# skill only rewrites lines whose structure it understands unambiguously.
+_ENV_LINE_RE = re.compile(
+    r"""
+    ^
+    [ \t]*                                  # optional leading whitespace
+                                            # (python-dotenv permits it;
+                                            # the old parser did too)
+    (?:export[ \t]+)?                       # optional 'export '
+    (?P<name>[A-Z_][A-Z0-9_]*)              # VAR name
+    [ \t]*=[ \t]*
+    (?P<value>[^#\n]*?)                     # value (up to first `#` or EOL)
+    [ \t]*
+    (?P<comment>\#.*)?                      # optional inline comment
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+def _classify_entry(raw_line: str, value: str, comment: str | None) -> str:
+    """Classify one parsed entry.
+
+    ``value`` is the value portion with surrounding whitespace stripped;
+    ``comment`` is the inline comment (including its leading ``#``) or
+    None if the line had no inline comment.
+
+    Fail-closed: anything we can't confidently prove is skill-authored or
+    a bare v1 TODO becomes USER_OWNED.
+    """
+    has_marker = comment is not None and EXTRACTED_MARKER in comment
+
+    if has_marker:
+        # Skill wrote this line; we own it and can rewrite it.
+        return (
+            EntryClassification.SKILL_TODO
+            if value == PLACEHOLDER
+            else EntryClassification.SKILL_REAL
+        )
+
+    # No marker. To qualify as an upgradable v1 TODO the line must be
+    # BOTH the exact PLACEHOLDER value AND have NO inline comment at
+    # all — because a user inline comment (e.g. "# my project is prj-foo,
+    # use gcloud config get project") is real user intent even next to
+    # a TODO literal, and we must respect it.
+    if value == PLACEHOLDER and comment is None:
+        return EntryClassification.V1_TODO
+
+    return EntryClassification.USER_OWNED
+
+
+def _parse_env_content(content: str) -> dict[str, ExistingEntry]:
+    """Parse .env.example content into name -> ExistingEntry.
+
+    Lines that don't look like a well-formed env declaration (blank,
+    comment-only, non-matching, malformed) are skipped and not returned —
+    they'll be preserved as-is when the writer rewrites the file, because
+    the writer touches lines by index, never by text-replace.
+
+    If the same var appears more than once in the file, only the FIRST
+    occurrence is returned. This mirrors dotenv precedence (first wins)
+    and means the writer will only ever attempt to rewrite that first
+    occurrence — safer than trying to handle duplicates.
+    """
+    entries: dict[str, ExistingEntry] = {}
+    lines = content.splitlines(keepends=True)
+    for i, raw in enumerate(lines):
+        stripped_for_match = raw.rstrip("\n").rstrip("\r")
+        m = _ENV_LINE_RE.match(stripped_for_match)
+        if not m:
             continue
-        # Strip optional 'export ' prefix
-        stripped = re.sub(r"^export\s+", "", stripped)
-        m = re.match(r"^([A-Z_][A-Z0-9_]*)\s*=", stripped)
-        if m:
-            defined.add(m.group(1))
-    return defined
+        name = m.group("name")
+        if name in entries:
+            continue  # first-occurrence wins
+        value = m.group("value") or ""
+        comment = m.group("comment")  # includes leading '#' or None
+        classification = _classify_entry(raw, value, comment)
+        entries[name] = ExistingEntry(
+            line_index=i,
+            raw_line=raw,
+            value=value,
+            classification=classification,
+        )
+    return entries
+
+
+def parse_env_example(env_example: Path) -> dict[str, ExistingEntry]:
+    """Parse a .env.example file into name -> ExistingEntry.
+
+    Returns an empty dict if the file does not exist.
+    """
+    if not env_example.exists():
+        return {}
+    return _parse_env_content(env_example.read_text(encoding="utf-8"))
+
+
+def read_defined_vars(env_example: Path) -> set[str]:
+    """Return the set of variable names already declared in .env.example.
+
+    Thin wrapper around :func:`parse_env_example` kept for existing
+    callers that only need names (e.g. ``assign_model_var_names``).
+    """
+    return set(parse_env_example(env_example).keys())
+
+
+def _rewrite_var_line(
+    lines: list[str], var_name: str, new_line_body: str
+) -> bool:
+    """Rewrite the ONE line in ``lines`` that declares ``var_name``.
+
+    ``new_line_body`` is the desired line WITHOUT trailing newline and
+    WITHOUT any leading ``export `` prefix (the rewriter preserves the
+    original prefix if there was one).
+
+    Returns True on success, False on any of the following (fail-closed):
+      * zero or multiple physical lines declare ``var_name``
+      * the matched line has a value that starts with a quote (``"`` or
+        ``'``) — quoted / multi-line values are ambiguous to rewrite
+      * the matched line ends with a backslash continuation
+      * the matched line's structure doesn't parse as a well-formed env
+        line (``_ENV_LINE_RE`` doesn't match)
+
+    These refusals are the golden-rule enforcement — better to leave a
+    stale TODO in place than to rewrite a line whose semantics we don't
+    understand.
+    """
+    # Regex to capture the "left prefix" — everything before the VAR
+    # name (leading whitespace + optional 'export '). We preserve this
+    # verbatim on rewrite so an indented line stays indented and an
+    # `export`-ed line stays exported.
+    left_prefix_re = re.compile(
+        rf"^(?P<prefix>[ \t]*(?:export[ \t]+)?){re.escape(var_name)}[ \t]*="
+    )
+
+    matches: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        stripped = line.rstrip("\n").rstrip("\r")
+        env_m = _ENV_LINE_RE.match(stripped)
+        if not env_m or env_m.group("name") != var_name:
+            continue
+        prefix_m = left_prefix_re.match(stripped)
+        if prefix_m is None:
+            # Line was recognised by the env regex but the more specific
+            # prefix regex can't extract a prefix — refuse rather than
+            # guess. Should be impossible in practice.
+            return False
+        matches.append((i, prefix_m.group("prefix")))
+
+    if len(matches) != 1:
+        return False  # unique-match requirement failed
+    idx, left_prefix = matches[0]
+    original = lines[idx]
+    stripped = original.rstrip("\n").rstrip("\r")
+
+    # Refuse quoted values — the value part might span multiple physical
+    # lines, contain escaped quotes, or otherwise be more nuanced than
+    # our regex handles safely.
+    env_m = _ENV_LINE_RE.match(stripped)
+    if env_m is None:  # defensive; should be impossible given the loop above
+        return False
+    value = env_m.group("value") or ""
+    if value.startswith(('"', "'")):
+        return False
+
+    # Refuse continuation-line values.
+    if stripped.endswith("\\"):
+        return False
+
+    # Preserve the original line's newline (\n, \r\n, or none).
+    if original.endswith("\r\n"):
+        newline = "\r\n"
+    elif original.endswith("\n"):
+        newline = "\n"
+    else:
+        newline = ""
+
+    # left_prefix captures everything before the VAR name (leading
+    # whitespace + optional 'export '); new_line_body is "VAR=value  #
+    # comment". Concatenation preserves the original indentation and
+    # export status while replacing the value + comment.
+    lines[idx] = left_prefix + new_line_body + newline
+    return True
+
+
+def _plan_updates(
+    existing: dict[str, ExistingEntry],
+    env_vars: dict[str, list[Source]],
+    recipe_dir: Path | None,
+) -> tuple[dict[str, str], dict[str, tuple[int, str]]]:
+    """Decide, per var, whether to append or upgrade in place (or skip).
+
+    Returns ``(to_append, to_upgrade)``:
+      * ``to_append``: {var: new_line_body} for missing entries.
+      * ``to_upgrade``: {var: (line_index, new_line_body)} for existing
+        entries that are safely upgradable AND whose upgrade would
+        produce a REAL (non-placeholder) value.
+
+    Anything not returned in either dict is being intentionally skipped
+    (user-owned, or upgrade would just churn TODO → TODO, etc.).
+    """
+    to_append: dict[str, str] = {}
+    to_upgrade: dict[str, tuple[int, str]] = {}
+
+    for var, sources in env_vars.items():
+        new_body = format_env_entry(var, sources, recipe_dir)
+        entry = existing.get(var)
+
+        if entry is None:
+            # Missing → always append.
+            to_append[var] = new_body
+            continue
+
+        if entry.classification == EntryClassification.USER_OWNED:
+            continue  # ironclad: never touch user-authored lines
+        if entry.classification == EntryClassification.SKILL_REAL:
+            continue  # already has a real value; drift handled elsewhere
+
+        # entry is V1_TODO or SKILL_TODO. Only upgrade if the new body
+        # would actually be a real value — otherwise we'd churn TODO to
+        # TODO, changing the comment but not the value. Detect via the
+        # resolver rather than string-matching the new body.
+        resolved = resolve_default(sources)
+        if resolved.value is None:
+            continue  # no default at all
+        if looks_like_placeholder(resolved.value) is not None:
+            continue  # source has a placeholder-shape value; skip
+
+        to_upgrade[var] = (entry.line_index, new_body)
+
+    return to_append, to_upgrade
 
 
 def update_env_example(
     env_example: Path,
-    env_vars: dict[str, str | None],
+    env_vars: dict[str, list[Source]],
     dry_run: bool = False,
-) -> list[str]:
+    recipe_dir: Path | None = None,
+) -> tuple[list[str], list[str]]:
     """
-    Append variables not yet in .env.example.
-    Returns the list of variable names that were (or would be) added.
+    Update .env.example — appending new entries AND upgrading stale TODOs.
 
-    When dry_run is True, no file is written; the return value still reports
-    which variables would be added.
+    Returns ``(added, upgraded)``:
+      * ``added``   — names appended as new entries.
+      * ``upgraded`` — names whose existing TODO line was rewritten in
+        place with a real default from source.
+
+    SAFETY CONTRACT (the golden rule for this function):
+
+      * A line without our ``EXTRACTED_MARKER`` marker AND whose value
+        is not exactly the v1 :data:`PLACEHOLDER` is considered
+        USER_OWNED — NEVER touched.
+      * A line that is a v1 PLACEHOLDER but has an inline comment on
+        it is treated as USER_OWNED (the comment is real user intent).
+      * A skill-authored line whose value is a real (non-placeholder)
+        value is NEVER re-written on drift — the maintainer may have
+        relied on the persisted value.
+      * A TODO line is only upgraded when source can supply a REAL
+        (non-placeholder-shape) default. TODO → TODO would be pure
+        churn.
+      * Before writing, the assembled content is re-parsed and every
+        planned upgrade must appear as ``SKILL_REAL`` in the result.
+        If not, the write is REFUSED and the file is left untouched.
+
+    When ``dry_run`` is True, no file is written; the return value still
+    reports which variables would be added and upgraded.
     """
-    existing = read_defined_vars(env_example)
-    to_add = {k: v for k, v in env_vars.items() if k not in existing}
+    existing = parse_env_example(env_example)
+    to_append, to_upgrade = _plan_updates(existing, env_vars, recipe_dir)
 
-    if not to_add:
-        return []
+    if not to_append and not to_upgrade:
+        return [], []
+
+    added_names = sorted(to_append.keys())
+    upgraded_names = sorted(to_upgrade.keys())
 
     if dry_run:
-        return sorted(to_add.keys())
+        return added_names, upgraded_names
 
+    # Build the new content. Line-by-line rewrites are applied to the
+    # existing content; new entries are appended at the end.
     if env_example.exists():
         current = env_example.read_text(encoding="utf-8")
-        if not current.endswith("\n"):
-            current += "\n"
     else:
         current = ""
+    lines = current.splitlines(keepends=True)
 
-    block = (
-        "\n# Environment variables extracted by"
-        " extract-python-environment-variables\n"
-    )
-    for var in sorted(to_add):
-        # Deliberately do NOT write extracted defaults from source code into
-        # .env.example. .env.example is a template the human maintainer fills
-        # in, not a place to smuggle inferred defaults. Every value written
-        # here is the PLACEHOLDER, regardless of whether the source code has
-        # an `os.getenv("VAR", "some_default")` fallback.
-        block += f"{var}={PLACEHOLDER}\n"
+    # Apply in-place upgrades. Any refusal (fail-closed rewriter) drops
+    # the var from the upgrade list.
+    actually_upgraded: list[str] = []
+    for var in upgraded_names:
+        _line_idx, new_body = to_upgrade[var]
+        if _rewrite_var_line(lines, var, new_body):
+            actually_upgraded.append(var)
+        else:
+            print(
+                f"[WARN] Refused to upgrade {var} in .env.example — "
+                "the existing line's structure was ambiguous (quoted "
+                "value, multiple matches, or line continuation). "
+                "Leaving it as-is. Delete the line and re-run to force "
+                "regeneration.",
+                file=sys.stderr,
+            )
+
+    # Ensure a trailing newline before appending fresh entries.
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] = lines[-1] + "\n"
+
+    if to_append:
+        block_header = (
+            "\n# Environment variables extracted by"
+            " extract-python-environment-variables\n"
+        )
+        lines.append(block_header)
+        for var in added_names:
+            lines.append(to_append[var] + "\n")
+
+    new_content = "".join(lines)
+
+    # Round-trip safety check: re-parse the new content and confirm
+    # every planned upgrade now shows as SKILL_REAL. If any doesn't,
+    # our rewrite produced something we don't understand — refuse to
+    # write and log an ERROR. Belt-and-braces backstop against a
+    # rewriter bug corrupting the file.
+    reparsed = _parse_env_content(new_content)
+    for var in actually_upgraded:
+        entry = reparsed.get(var)
+        if entry is None or entry.classification != EntryClassification.SKILL_REAL:
+            print(
+                f"[ERROR] Round-trip safety check failed for {var} — the "
+                "rewritten line would not re-parse as a skill-authored real "
+                "value. Refusing to write; .env.example was NOT modified.",
+                file=sys.stderr,
+            )
+            return [], []
+    # Also verify every appended entry re-parses. Missing → bug in the
+    # formatter or the append path.
+    for var in added_names:
+        if var not in reparsed:
+            print(
+                f"[ERROR] Round-trip safety check failed for appended {var} "
+                "— entry did not re-parse. Refusing to write; .env.example "
+                "was NOT modified.",
+                file=sys.stderr,
+            )
+            return [], []
 
     try:
-        _write_text_atomic(env_example, current + block)
+        _write_text_atomic(env_example, new_content)
     except OSError as exc:
         print(
             f"[ERROR] Could not write {env_example}: {exc} — "
             ".env.example was NOT modified.",
             file=sys.stderr,
         )
-        return []
-    return sorted(to_add.keys())
+        return [], []
+
+    return added_names, actually_upgraded
 
 
 def write_model_vars_to_env_example(
@@ -1187,23 +1779,65 @@ def run_step_env_vars(
     if env_vars:
         print(f"\n[INFO] Detected {len(env_vars)} environment variable(s):")
         for var in sorted(env_vars):
-            default = env_vars[var]
-            suffix = f"  (default: {default!r})" if default is not None else ""
+            resolved = resolve_default(env_vars[var])
+            if resolved.value is None:
+                suffix = ""
+            else:
+                reason = looks_like_placeholder(resolved.value)
+                assert resolved.winner is not None
+                where = _relpath_or_name(resolved.winner.file, recipe_dir)
+                if reason is None:
+                    suffix = (
+                        f"  (default: {resolved.value!r}"
+                        f" from {resolved.winner.kind} in {where})"
+                    )
+                else:
+                    suffix = (
+                        f"  (default: {resolved.value!r}"
+                        f" from {resolved.winner.kind} in {where}"
+                        f" — downgraded to TODO: {reason})"
+                    )
+                if resolved.conflict_count:
+                    suffix = suffix[:-1] + (
+                        f"; differs from {resolved.conflict_count}"
+                        " other source(s))"
+                    )
             print(f"       {var}{suffix}")
     else:
         print("\n[INFO] No environment variable reads detected.")
 
     env_example = recipe_dir / ".env.example"
-    added = update_env_example(env_example, env_vars, dry_run=dry_run)
+    added, upgraded = update_env_example(
+        env_example, env_vars, dry_run=dry_run, recipe_dir=recipe_dir
+    )
     if added:
         verb = "Would add" if dry_run else "Added"
         print(
             f"\n[{_tag(dry_run)}] {verb} {len(added)} variable(s) to "
             ".env.example: " + ", ".join(added)
         )
-    else:
+    if upgraded:
+        verb = "Would upgrade" if dry_run else "Upgraded"
+        # Show the resolved value + provenance so the maintainer can
+        # eyeball each upgrade — this is a stronger action than an
+        # append and deserves visible detail.
+        lines_out = [
+            f"\n[{_tag(dry_run)}] {verb} {len(upgraded)} stale TODO"
+            " entr(y/ies) with real default(s) from source:"
+        ]
+        for var in upgraded:
+            resolved = resolve_default(env_vars[var])
+            assert resolved.winner is not None  # planner guarantees this
+            where = _relpath_or_name(resolved.winner.file, recipe_dir)
+            lines_out.append(
+                f"       {var} -> {resolved.value!r}"
+                f" (from {resolved.winner.kind} in {where})"
+            )
+        print("\n".join(lines_out))
+    if not added and not upgraded:
         print(
-            "\n[PASS] .env.example is already up to date — no variables added."
+            "\n[PASS] .env.example is already up to date — no variables added"
+            " or upgraded."
         )
 
     return env_example

--- a/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
@@ -93,7 +93,10 @@ def test_find_python_files_skips_conftest_py_at_any_level(tmp_path):
     # `INTEGRATION_TEST` guarding integration-test collection) would leak
     # into .env.example — silently inviting users to set test-mode toggles.
     _write(tmp_path / "app" / "agent.py")
-    _write(tmp_path / "conftest.py", "import os\nos.environ.get('INTEGRATION_TEST')\n")
+    _write(
+        tmp_path / "conftest.py",
+        "import os\nos.environ.get('INTEGRATION_TEST')\n",
+    )
     _write(tmp_path / "app" / "conftest.py", "# also skipped\n")
     _write(
         tmp_path / "some_subpkg" / "conftest.py",
@@ -140,7 +143,9 @@ def test_extract_env_vars_ignores_conftest_py_content(tmp_path):
 # which are always the same in these tests.
 def _kd(result):
     """Return {var: [(kind, default), ...]} from an extract_env_vars result."""
-    return {v: [(s.kind, s.default) for s in srcs] for v, srcs in result.items()}
+    return {
+        v: [(s.kind, s.default) for s in srcs] for v, srcs in result.items()
+    }
 
 
 def test_extract_env_vars_all_forms(tmp_path):
@@ -300,7 +305,9 @@ def test_extract_env_vars_kwarg_default_captured(tmp_path):
     assert result["VAR_C"][0].default == "kw-sd-default"
 
 
-def test_extract_env_vars_positional_wins_over_kwarg_when_both_present(tmp_path):
+def test_extract_env_vars_positional_wins_over_kwarg_when_both_present(
+    tmp_path,
+):
     # Defensive: `os.getenv("X", "positional", default="kw")` is a
     # SyntaxError in Python (can't have both positional and kw for the
     # same param), but writers of weird code aside, our extractor should
@@ -539,9 +546,7 @@ def test_update_env_example_writes_setdefault_value(tmp_path):
     # commitment. The value MUST land in .env.example so users can find it.
     env = tmp_path / ".env.example"
 
-    m.update_env_example(
-        env, {"USE_VERTEX": _srcs(("setdefault", "TRUE"))}
-    )
+    m.update_env_example(env, {"USE_VERTEX": _srcs(("setdefault", "TRUE"))})
 
     content = env.read_text(encoding="utf-8")
     assert "USE_VERTEX=TRUE" in content
@@ -579,8 +584,7 @@ def test_update_env_example_preserves_user_edits_never_overwrites(tmp_path):
     # real values into .env.example.
     env = _write(
         tmp_path / ".env.example",
-        "# hand-tuned by maintainer\n"
-        "GOOGLE_CLOUD_PROJECT=my-real-project\n",
+        "# hand-tuned by maintainer\nGOOGLE_CLOUD_PROJECT=my-real-project\n",
     )
     before = env.read_text(encoding="utf-8")
 
@@ -628,7 +632,9 @@ def test_classify_v1_todo_with_user_comment_is_user_owned():
 def test_classify_marker_with_placeholder_is_skill_todo():
     # A line the skill itself wrote with a TODO — marker present, value
     # is exactly PLACEHOLDER.
-    line = f"VAR={m.PLACEHOLDER}  # {m.EXTRACTED_MARKER}; no default in source\n"
+    line = (
+        f"VAR={m.PLACEHOLDER}  # {m.EXTRACTED_MARKER}; no default in source\n"
+    )
     assert _classify(line) == m.EntryClassification.SKILL_TODO
 
 
@@ -652,11 +658,7 @@ def test_parse_env_example_returns_line_index_for_rewrite(tmp_path):
     # the rewriter can address it precisely.
     env = _write(
         tmp_path / ".env.example",
-        "# header\n"
-        "A=1\n"
-        "\n"
-        f"B={m.PLACEHOLDER}\n"
-        "C=3\n",
+        f"# header\nA=1\n\nB={m.PLACEHOLDER}\nC=3\n",
     )
     entries = m.parse_env_example(env)
     # Zero-based line indices.
@@ -689,9 +691,7 @@ def test_classify_export_prefix_v1_todo():
 
 
 def test_classify_export_prefix_marker_real():
-    line = (
-        f"export FOO=real-value  # {m.EXTRACTED_MARKER}; from setdefault in x.py\n"
-    )
+    line = f"export FOO=real-value  # {m.EXTRACTED_MARKER}; from setdefault in x.py\n"
     assert _classify(line) == m.EntryClassification.SKILL_REAL
 
 
@@ -724,12 +724,7 @@ def test_parse_env_example_skips_blank_and_comment_only_lines(tmp_path):
     # end up in the returned dict.
     env = _write(
         tmp_path / ".env.example",
-        "\n"
-        "# just a comment\n"
-        "\n"
-        "REAL=1\n"
-        "   # indented comment\n"
-        "\n",
+        "\n# just a comment\n\nREAL=1\n   # indented comment\n\n",
     )
     entries = m.parse_env_example(env)
     assert set(entries.keys()) == {"REAL"}
@@ -1053,8 +1048,7 @@ def test_upgrade_and_append_can_happen_in_one_pass(tmp_path):
     # some are missing (appendable), some are user-owned (skip).
     env = _write(
         tmp_path / ".env.example",
-        f"UPGRADABLE={m.PLACEHOLDER}\n"
-        "USER_OWNED_VAR=my-real-value\n",
+        f"UPGRADABLE={m.PLACEHOLDER}\nUSER_OWNED_VAR=my-real-value\n",
     )
 
     added, upgraded = m.update_env_example(
@@ -1084,7 +1078,7 @@ def test_upgrade_is_idempotent(tmp_path):
         f"V={m.PLACEHOLDER}\n",
     )
 
-    added1, upgraded1 = m.update_env_example(
+    _added1, upgraded1 = m.update_env_example(
         env, {"V": _srcs(("setdefault", "real"))}
     )
     content_after_first = env.read_text(encoding="utf-8")
@@ -1107,7 +1101,7 @@ def test_upgrade_dry_run_reports_but_does_not_write(tmp_path):
     )
     before = env.read_text(encoding="utf-8")
 
-    added, upgraded = m.update_env_example(
+    _added, upgraded = m.update_env_example(
         env, {"V": _srcs(("setdefault", "TRUE"))}, dry_run=True
     )
 
@@ -1122,14 +1116,13 @@ def test_upgrade_refuses_ambiguous_line_and_warns(tmp_path, capsys):
     # same var) must not be rewritten. Instead, warn and leave it alone.
     env = _write(
         tmp_path / ".env.example",
-        f"V={m.PLACEHOLDER}\n"
-        f"V={m.PLACEHOLDER}\n",
+        f"V={m.PLACEHOLDER}\nV={m.PLACEHOLDER}\n",
     )
     before = env.read_text(encoding="utf-8")
 
     # Parser gives us the first V (V1_TODO), so we plan to upgrade.
     # Rewriter finds two matches, refuses, and warns.
-    added, upgraded = m.update_env_example(
+    _added, upgraded = m.update_env_example(
         env, {"V": _srcs(("setdefault", "TRUE"))}
     )
 
@@ -1153,9 +1146,7 @@ def test_upgrade_preserves_ordering_and_surrounding_lines(tmp_path):
         "OTHER=leave-me-alone\n",
     )
 
-    m.update_env_example(
-        env, {"UPGRADABLE": _srcs(("setdefault", "TRUE"))}
-    )
+    m.update_env_example(env, {"UPGRADABLE": _srcs(("setdefault", "TRUE"))})
 
     content = env.read_text(encoding="utf-8")
     lines = content.splitlines()
@@ -1165,9 +1156,7 @@ def test_upgrade_preserves_ordering_and_surrounding_lines(tmp_path):
     upgradable_idx = next(
         i for i, ln in enumerate(lines) if ln.startswith("UPGRADABLE=")
     )
-    other_idx = next(
-        i for i, ln in enumerate(lines) if ln.startswith("OTHER=")
-    )
+    other_idx = next(i for i, ln in enumerate(lines) if ln.startswith("OTHER="))
     assert upgradable_idx < other_idx
     # Other var untouched.
     assert "OTHER=leave-me-alone" in lines
@@ -1183,7 +1172,9 @@ def test_update_env_example_noop_when_env_vars_empty(tmp_path):
     assert env.read_text(encoding="utf-8") == before
 
 
-def test_update_env_example_noop_when_no_changes_needed_does_not_touch_file(tmp_path):
+def test_update_env_example_noop_when_no_changes_needed_does_not_touch_file(
+    tmp_path,
+):
     # Every var already declared + no upgrades required → the file must
     # not be re-written at all (would show as a spurious modification in
     # git status / re-run diff).
@@ -1251,7 +1242,7 @@ def test_update_env_example_preserves_crlf_line_endings(tmp_path):
     # after an in-place upgrade — mixed endings in one file are ugly
     # and can break naive tools.
     env = tmp_path / ".env.example"
-    env.write_bytes(f"V={m.PLACEHOLDER}\r\n".encode("utf-8"))
+    env.write_bytes(f"V={m.PLACEHOLDER}\r\n".encode())
 
     m.update_env_example(env, {"V": _srcs(("setdefault", "real"))})
 
@@ -1483,7 +1474,9 @@ def test_resolve_default_setdefault_wins_over_environ_get():
     # setdefault is tier 0; environ_get is tier 1. setdefault always wins.
     sources = [
         m.Source(Path("z.py"), "setdefault", "sd-value", 1),
-        m.Source(Path("a.py"), "environ_get", "get-value", 1),  # earlier alphabetically!
+        m.Source(
+            Path("a.py"), "environ_get", "get-value", 1
+        ),  # earlier alphabetically!
     ]
     resolved = m.resolve_default(sources)
     # Priority beats alphabetical.
@@ -1561,7 +1554,9 @@ def test_format_env_entry_uses_basename_when_no_recipe_dir(tmp_path):
     assert str(tmp_path) not in line  # no absolute path leaked
 
 
-def test_format_env_entry_uses_basename_when_file_not_under_recipe_dir(tmp_path):
+def test_format_env_entry_uses_basename_when_file_not_under_recipe_dir(
+    tmp_path,
+):
     # If the source file is somewhere else on disk (unusual), we fall
     # back to basename rather than emitting an absolute path.
     src_file = Path("/tmp/somewhere/else.py")
@@ -1790,7 +1785,7 @@ def test_inject_load_dotenv_marks_late_relative_import_when_already_bootstrapped
     # (load_dotenv + os.environ.setdefault + trailing `from .agent`) without
     # a noqa marker on the relative import. When we run against such a file
     # we must NOT inject anything (load_dotenv is already there) but MUST
-    # still add `# noqa: E402` to the trailing relative import — otherwise
+    # still add a "noqa E402" marker to the trailing relative import — otherwise
     # ruff (Phase 4 in prepare-python-recipe) flags E402 for a pattern the
     # skill is aware of and could have suppressed.
     init = _write(
@@ -2133,10 +2128,7 @@ def test_extract_hardcoded_models_skips_getenv_kwarg_default(tmp_path):
 
 def test_extract_hardcoded_models_skips_environ_get_default(tmp_path):
     # os.environ.get("X", "d") — same protection.
-    src = (
-        "import os\n"
-        "M = os.environ.get('MODEL_NAME', 'gemini-3.5-flash')\n"
-    )
+    src = "import os\nM = os.environ.get('MODEL_NAME', 'gemini-3.5-flash')\n"
     py = _write(tmp_path / "mod.py", src)
 
     hits = m.extract_hardcoded_models([py])
@@ -2145,10 +2137,7 @@ def test_extract_hardcoded_models_skips_environ_get_default(tmp_path):
 
 def test_extract_hardcoded_models_skips_environ_setdefault_default(tmp_path):
     # os.environ.setdefault("X", "d") — same protection.
-    src = (
-        "import os\n"
-        "os.environ.setdefault('MODEL_NAME', 'gemini-3.5-flash')\n"
-    )
+    src = "import os\nos.environ.setdefault('MODEL_NAME', 'gemini-3.5-flash')\n"
     py = _write(tmp_path / "mod.py", src)
 
     hits = m.extract_hardcoded_models([py])
@@ -2219,7 +2208,9 @@ def test_replace_hardcoded_models_does_not_touch_getenv_defaults(tmp_path):
     # itself would still skip via the same exclusion. Simulate that here:
     forced_hits = {py: [(2, "gemini-3.5-flash"), (3, "gemini-3.5-flash")]}
     name_map = m.assign_model_var_names({"gemini-3.5-flash"})
-    substituted = m.replace_hardcoded_models(py_files=[py], hits=forced_hits, name_map=name_map)
+    substituted = m.replace_hardcoded_models(
+        py_files=[py], hits=forced_hits, name_map=name_map
+    )
     # No substitution happened because both hits were getenv defaults.
     assert substituted == {}
     # File byte-identical.
@@ -2411,12 +2402,12 @@ def test_run_step_pyproject_pass_when_already_present(tmp_path, capsys):
 def _make_sample_recipe(root: Path) -> Path:
     """A minimal recipe exercising all v2 code paths:
 
-      * MY_API_KEY — bare os.getenv, no default → TODO
-      * LOG_LEVEL — getenv with a real fallback → extracted verbatim
-      * USE_VERTEX — setdefault with a real value → extracted verbatim
-      * GOOGLE_CLOUD_PROJECT — setdefault with a stub value → downgraded
-        to TODO with the source string preserved in the comment
-      * MODEL — hardcoded model literal → replaced with os.getenv
+    * MY_API_KEY — bare os.getenv, no default → TODO
+    * LOG_LEVEL — getenv with a real fallback → extracted verbatim
+    * USE_VERTEX — setdefault with a real value → extracted verbatim
+    * GOOGLE_CLOUD_PROJECT — setdefault with a stub value → downgraded
+      to TODO with the source string preserved in the comment
+    * MODEL — hardcoded model literal → replaced with os.getenv
     """
     recipe = root / "my-recipe"
     pkg = recipe / "my_recipe"
@@ -2620,7 +2611,9 @@ def test_main_recipe_with_unparseable_env_example_line_does_not_crash(
     assert "NEW_VAR=" in content
 
 
-def test_main_second_run_after_migration_is_byte_identical(tmp_path, monkeypatch):
+def test_main_second_run_after_migration_is_byte_identical(
+    tmp_path, monkeypatch
+):
     # Cross-cutting idempotency: a full run that DOES modify things,
     # followed by an identical second run, must produce zero further
     # modifications. This is the strongest end-to-end guarantee that
@@ -2648,9 +2641,11 @@ def test_main_second_run_after_migration_is_byte_identical(tmp_path, monkeypatch
 # ---------------------------------------------------------------------------
 
 
-def test_invariant_user_owned_lines_byte_identical_after_any_writer_run(tmp_path):
+def test_invariant_user_owned_lines_byte_identical_after_any_writer_run(
+    tmp_path,
+):
     # Sweep across many scenarios (var missing / v1_todo / skill_todo /
-    # skill_real / user_owned × source has real value / no default /
+    # skill_real / user_owned x source has real value / no default /
     # placeholder-shape default). At the end of ALL of them, every line
     # we classified as USER_OWNED must be byte-identical to what it
     # was before.
@@ -2793,6 +2788,13 @@ def test_invariant_appended_entries_are_skill_owned(tmp_path):
     )
 
     entries = m.parse_env_example(env)
-    assert entries["WITH_DEFAULT"].classification == m.EntryClassification.SKILL_REAL
-    assert entries["NO_DEFAULT"].classification == m.EntryClassification.SKILL_TODO
-    assert entries["DOWNGRADED"].classification == m.EntryClassification.SKILL_TODO
+    assert (
+        entries["WITH_DEFAULT"].classification
+        == m.EntryClassification.SKILL_REAL
+    )
+    assert (
+        entries["NO_DEFAULT"].classification == m.EntryClassification.SKILL_TODO
+    )
+    assert (
+        entries["DOWNGRADED"].classification == m.EntryClassification.SKILL_TODO
+    )

--- a/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
@@ -84,6 +84,51 @@ def test_find_python_files_skips_venv_and_cache_dirs(tmp_path):
         assert "more.py" != p.name
 
 
+def test_find_python_files_skips_conftest_py_at_any_level(tmp_path):
+    # REGRESSION: pytest's `conftest.py` is a reserved filename used only
+    # for test collection/fixture setup — never for application code.
+    # A common pattern is to put it at the recipe ROOT (not inside a
+    # `tests/` dir) so it applies to the whole project. The tests/ dir
+    # exclusion misses it there, and env vars in conftest.py (e.g.
+    # `INTEGRATION_TEST` guarding integration-test collection) would leak
+    # into .env.example — silently inviting users to set test-mode toggles.
+    _write(tmp_path / "app" / "agent.py")
+    _write(tmp_path / "conftest.py", "import os\nos.environ.get('INTEGRATION_TEST')\n")
+    _write(tmp_path / "app" / "conftest.py", "# also skipped\n")
+    _write(
+        tmp_path / "some_subpkg" / "conftest.py",
+        "import os\nos.environ.get('ANOTHER_TEST_VAR')\n",
+    )
+
+    found = m.find_python_files(tmp_path)
+    names = {p.name for p in found}
+
+    # Only the recipe's actual application source is returned.
+    assert names == {"agent.py"}
+    # Belt-and-braces: no returned file is named conftest.py.
+    assert not any(p.name == "conftest.py" for p in found)
+
+
+def test_extract_env_vars_ignores_conftest_py_content(tmp_path):
+    # End-to-end: env vars declared inside conftest.py never surface in
+    # the aggregated extract_env_vars() result, because the scanner never
+    # opens the file in the first place.
+    _write(
+        tmp_path / "conftest.py",
+        "import os\nX = os.getenv('INTEGRATION_TEST')\n",
+    )
+    _write(
+        tmp_path / "app.py",
+        "import os\nY = os.getenv('REAL_APP_VAR', 'v')\n",
+    )
+
+    py_files = m.find_python_files(tmp_path)
+    result = m.extract_env_vars(py_files)
+
+    assert "INTEGRATION_TEST" not in result  # conftest content excluded
+    assert "REAL_APP_VAR" in result  # app content still scanned
+
+
 # ---------------------------------------------------------------------------
 # extract_env_vars / _extract_var_from_node
 # ---------------------------------------------------------------------------

--- a/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
@@ -2053,6 +2053,134 @@ def test_extract_hardcoded_models_detects_and_skips_docstrings(tmp_path):
     assert found_strings == ["gemini-3.5-flash"]  # docstring not included
 
 
+def test_extract_hardcoded_models_skips_getenv_positional_default(tmp_path):
+    # REGRESSION: a string literal serving as the DEFAULT argument of an
+    # existing os.getenv() call must NOT be treated as a "raw hardcoded
+    # literal that needs promotion." The maintainer already made the var
+    # env-configurable and picked this string as the fallback; replacing
+    # it with bare os.getenv("MODEL_NAME") (which returns None) would
+    # silently regress the type from str to str | None and break at
+    # runtime when both env vars are unset.
+    src = (
+        "import os\n"
+        "MODEL = os.getenv('MODEL_NAME_GENERATED_1', 'gemini-3.5-flash')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+
+    # Nothing to replace — the model literal was already serving as a
+    # getenv default, so it's already env-var-controlled.
+    assert py not in hits
+
+
+def test_extract_hardcoded_models_skips_getenv_kwarg_default(tmp_path):
+    # Same protection for the keyword form: os.getenv("X", default="y").
+    src = (
+        "import os\n"
+        "M = os.getenv('MODEL_NAME_GENERATED_1', default='gemini-3.5-flash')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+    assert py not in hits
+
+
+def test_extract_hardcoded_models_skips_environ_get_default(tmp_path):
+    # os.environ.get("X", "d") — same protection.
+    src = (
+        "import os\n"
+        "M = os.environ.get('MODEL_NAME', 'gemini-3.5-flash')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+    assert py not in hits
+
+
+def test_extract_hardcoded_models_skips_environ_setdefault_default(tmp_path):
+    # os.environ.setdefault("X", "d") — same protection.
+    src = (
+        "import os\n"
+        "os.environ.setdefault('MODEL_NAME', 'gemini-3.5-flash')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+    assert py not in hits
+
+
+def test_extract_hardcoded_models_still_detects_true_hardcoded_kwarg(tmp_path):
+    # Negative: the SECOND arg of a NON-getenv call is fair game. This is
+    # exactly the case the model-replacement path was designed for:
+    #   Agent(name="x", model="gemini-3.5-flash")
+    # The string is truly hardcoded here and SHOULD be extracted.
+    src = 'agent = Agent(name="x", model="gemini-3.5-flash")\n'
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+    assert py in hits
+    assert [s for _l, s in hits[py]] == ["gemini-3.5-flash"]
+
+
+def test_extract_hardcoded_models_still_detects_direct_assignment(tmp_path):
+    # Negative: a plain assignment like `MODEL = "gemini-3.5-flash"` is
+    # still a hardcoded literal (not inside any getenv call). Detected.
+    src = 'MODEL = "gemini-3.5-flash"\n'
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+    assert py in hits
+    assert [s for _l, s in hits[py]] == ["gemini-3.5-flash"]
+
+
+def test_extract_hardcoded_models_mixed_hardcoded_and_getenv_defaults(tmp_path):
+    # A file with BOTH a true hardcoded literal AND a getenv-default literal.
+    # Only the true hardcoded one is picked up.
+    src = (
+        "import os\n"
+        'HARDCODED = "gemini-3.5-flash"\n'
+        'FROM_ENV = os.getenv("VAR", "gemini-3.5-flash")\n'
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    hits = m.extract_hardcoded_models([py])
+    # Only ONE hit — the direct assignment. The getenv default is skipped.
+    assert py in hits
+    assert len(hits[py]) == 1
+    _lineno, model_str = hits[py][0]
+    assert model_str == "gemini-3.5-flash"
+
+
+def test_replace_hardcoded_models_does_not_touch_getenv_defaults(tmp_path):
+    # End-to-end regression: the write path must respect the exclusion too,
+    # even if a caller somehow constructed a `hits` dict that included a
+    # getenv-default node. Concretely: run the whole pipeline against a
+    # file that has ONLY getenv-default model literals, and verify the file
+    # is byte-identical after the run.
+    src = (
+        "import os\n"
+        "M1 = os.getenv('MODEL_NAME_GENERATED_1', 'gemini-3.5-flash')\n"
+        'M2 = os.environ.get("MODEL_NAME_GENERATED_2", "gemini-3.5-flash")\n'
+    )
+    py = _write(tmp_path / "mod.py", src)
+    before = py.read_bytes()
+
+    hits = m.extract_hardcoded_models([py])
+    # extract_hardcoded_models returns empty → nothing to substitute →
+    # no name_map entries → no write attempt.
+    assert hits == {}
+    # But if a caller (or a bug) DID try to replace, the replacement path
+    # itself would still skip via the same exclusion. Simulate that here:
+    forced_hits = {py: [(2, "gemini-3.5-flash"), (3, "gemini-3.5-flash")]}
+    name_map = m.assign_model_var_names({"gemini-3.5-flash"})
+    substituted = m.replace_hardcoded_models(py_files=[py], hits=forced_hits, name_map=name_map)
+    # No substitution happened because both hits were getenv defaults.
+    assert substituted == {}
+    # File byte-identical.
+    assert py.read_bytes() == before
+
+
 # ---------------------------------------------------------------------------
 # replace_hardcoded_models
 # ---------------------------------------------------------------------------

--- a/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
@@ -89,6 +89,15 @@ def test_find_python_files_skips_venv_and_cache_dirs(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+# Helper to compress the new richer return type down to something tests
+# can assert against concisely. Each var maps to a list of (kind, default)
+# tuples — the fields that matter for correctness — dropping file/line
+# which are always the same in these tests.
+def _kd(result):
+    """Return {var: [(kind, default), ...]} from an extract_env_vars result."""
+    return {v: [(s.kind, s.default) for s in srcs] for v, srcs in result.items()}
+
+
 def test_extract_env_vars_all_forms(tmp_path):
     src = (
         "import os\n"
@@ -97,18 +106,22 @@ def test_extract_env_vars_all_forms(tmp_path):
         "c = os.environ.get('ENVIRON_GET')\n"
         "d = os.environ.get('ENVIRON_GET_DEFAULT', 'x')\n"
         "e = os.environ['ENVIRON_SUBSCRIPT']\n"
+        "os.environ.setdefault('SETDEFAULT_VAR', 'sd_default')\n"
     )
     py = _write(tmp_path / "mod.py", src)
 
     result = m.extract_env_vars([py])
 
-    assert result == {
-        "GETENV_PLAIN": None,
-        "GETENV_DEFAULT": "dflt",
-        "ENVIRON_GET": None,
-        "ENVIRON_GET_DEFAULT": "x",
-        "ENVIRON_SUBSCRIPT": None,
+    assert _kd(result) == {
+        "GETENV_PLAIN": [("getenv", None)],
+        "GETENV_DEFAULT": [("getenv", "dflt")],
+        "ENVIRON_GET": [("environ_get", None)],
+        "ENVIRON_GET_DEFAULT": [("environ_get", "x")],
+        "ENVIRON_SUBSCRIPT": [("environ_sub", None)],
+        "SETDEFAULT_VAR": [("setdefault", "sd_default")],
     }
+    # Every Source records the file it came from.
+    assert all(s.file == py for srcs in result.values() for s in srcs)
 
 
 def test_extract_env_vars_ignores_non_uppercase_names(tmp_path):
@@ -117,7 +130,7 @@ def test_extract_env_vars_ignores_non_uppercase_names(tmp_path):
 
     result = m.extract_env_vars([py])
 
-    assert result == {"OK_NAME": None}
+    assert _kd(result) == {"OK_NAME": [("getenv", None)]}
 
 
 def test_extract_env_vars_warns_on_non_uppercase_names(tmp_path, capsys):
@@ -128,20 +141,24 @@ def test_extract_env_vars_warns_on_non_uppercase_names(tmp_path, capsys):
 
     result = m.extract_env_vars([py])
 
-    assert result == {"OK_NAME": None}
+    assert _kd(result) == {"OK_NAME": [("getenv", None)]}
     err = capsys.readouterr().err
     assert "lower_case" in err
     assert "UPPER_SNAKE_CASE" in err
 
 
-def test_extract_env_vars_non_none_default_wins(tmp_path):
-    # Same var appears first without a default, then with one.
-    src = "import os\na = os.getenv('DUP')\nb = os.getenv('DUP', 'winner')\n"
+def test_extract_env_vars_records_all_occurrences(tmp_path):
+    # v2: extract_env_vars keeps every occurrence rather than collapsing to
+    # a single (var, default). The resolver picks the winner separately.
+    src = "import os\na = os.getenv('DUP')\nb = os.getenv('DUP', 'x')\n"
     py = _write(tmp_path / "mod.py", src)
 
     result = m.extract_env_vars([py])
 
-    assert result == {"DUP": "winner"}
+    # Two sources for the same var: one bare, one with a default.
+    assert len(result["DUP"]) == 2
+    kinds_defaults = {(s.kind, s.default) for s in result["DUP"]}
+    assert kinds_defaults == {("getenv", None), ("getenv", "x")}
 
 
 def test_extract_env_vars_skips_unparseable_file(tmp_path, capsys):
@@ -150,7 +167,7 @@ def test_extract_env_vars_skips_unparseable_file(tmp_path, capsys):
 
     result = m.extract_env_vars([bad, good])
 
-    assert result == {"GOOD": None}
+    assert _kd(result) == {"GOOD": [("getenv", None)]}
     assert "Could not parse" in capsys.readouterr().err
 
 
@@ -164,7 +181,10 @@ def test_extract_env_vars_ignores_non_string_defaults(tmp_path):
 
     result = m.extract_env_vars([py])
 
-    assert result == {"PORT": None, "FLAG": None}
+    assert _kd(result) == {
+        "PORT": [("getenv", None)],
+        "FLAG": [("getenv", None)],
+    }
 
 
 def test_extract_env_vars_ignores_binary_files(tmp_path):
@@ -175,7 +195,38 @@ def test_extract_env_vars_ignores_binary_files(tmp_path):
 
     result = m.extract_env_vars([binary, good])
 
-    assert result == {"GOOD": None}
+    assert _kd(result) == {"GOOD": [("getenv", None)]}
+
+
+def test_extract_env_vars_setdefault_captured_with_default(tmp_path):
+    # v2: os.environ.setdefault("V", "d") is now scanned — the "d" would
+    # otherwise be a hidden default a user editing .env.example has no way
+    # to discover.
+    src = (
+        "import os\n"
+        "os.environ.setdefault('GOOGLE_GENAI_USE_VERTEXAI', 'TRUE')\n"
+        "os.environ.setdefault('NO_DEFAULT_HERE', 'x')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert result["GOOGLE_GENAI_USE_VERTEXAI"][0].kind == "setdefault"
+    assert result["GOOGLE_GENAI_USE_VERTEXAI"][0].default == "TRUE"
+    assert result["NO_DEFAULT_HERE"][0].kind == "setdefault"
+    assert result["NO_DEFAULT_HERE"][0].default == "x"
+
+
+def test_extract_env_vars_records_line_number(tmp_path):
+    # Provenance line numbers are captured so provenance comments can point
+    # to a specific location if we ever surface them.
+    src = "import os\n\n\nX = os.getenv('LINE_TEST', 'v')\n"
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    # The getenv call is on line 4.
+    assert result["LINE_TEST"][0].line == 4
 
 
 # ---------------------------------------------------------------------------
@@ -206,41 +257,80 @@ def test_read_defined_vars_parses_and_handles_export_and_comments(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def _srcs(*items, file=None) -> list:
+    """Build a list[Source] from concise (kind, default) tuples for tests.
+
+    Every Source shares the same synthetic file (defaulting to a fake
+    path — tests that care about file provenance override it).
+    """
+    fake = file if file is not None else Path("agent.py")
+    return [
+        m.Source(file=fake, kind=kind, default=default, line=1)
+        for kind, default in items
+    ]
+
+
 def test_update_env_example_creates_file_when_absent(tmp_path):
+    # v2: when a getenv/setdefault default is available in source, it IS
+    # written to .env.example (with the marker comment). A var with no
+    # source-side default still gets the TODO placeholder.
     env = tmp_path / ".env.example"
 
-    added = m.update_env_example(env, {"NEW_VAR": "val", "NO_DEFAULT": None})
+    added, upgraded = m.update_env_example(
+        env,
+        {
+            "NEW_VAR": _srcs(("getenv", "val")),
+            "NO_DEFAULT": _srcs(("getenv", None)),
+        },
+    )
 
     assert added == ["NEW_VAR", "NO_DEFAULT"]
+    assert upgraded == []
     content = env.read_text(encoding="utf-8")
-    # Hard rule: every entry gets PLACEHOLDER, even when the source-code
-    # default ("val" here) is passed in. See update_env_example's inline
-    # comment for the rationale.
-    assert f"NEW_VAR={m.PLACEHOLDER}" in content
+    # v2: real default extracted, with marker.
+    assert "NEW_VAR=val" in content
+    assert m.EXTRACTED_MARKER in content
+    # No default in source → TODO placeholder with a "no default" note.
     assert f"NO_DEFAULT={m.PLACEHOLDER}" in content
-    assert "NEW_VAR=val" not in content
+    assert "no default in source" in content
 
 
 def test_update_env_example_appends_only_missing(tmp_path):
     env = _write(tmp_path / ".env.example", "EXISTING=1\n")
 
-    added = m.update_env_example(env, {"EXISTING": None, "FRESH": "2"})
+    added, upgraded = m.update_env_example(
+        env,
+        {
+            "EXISTING": _srcs(("getenv", None)),
+            "FRESH": _srcs(("getenv", "2")),
+        },
+    )
 
     assert added == ["FRESH"]
+    # EXISTING is USER_OWNED (no marker, value != v1 PLACEHOLDER) → not
+    # touched, not counted as upgraded.
+    assert upgraded == []
     content = env.read_text(encoding="utf-8")
+    # Idempotency: the pre-existing EXISTING line is left exactly as it
+    # was — NOT re-written, even though the skill now has a source for it.
     assert content.count("EXISTING") == 1
-    # Passed-in "2" is ignored; every entry gets PLACEHOLDER.
-    assert f"FRESH={m.PLACEHOLDER}" in content
-    assert "FRESH=2" not in content
+    assert "EXISTING=1\n" in content
+    # The new FRESH line uses the extracted default (v2 behaviour).
+    assert "FRESH=2" in content
+    assert m.EXTRACTED_MARKER in content
 
 
 def test_update_env_example_noop_when_all_present(tmp_path):
     env = _write(tmp_path / ".env.example", "A=1\nB=2\n")
     before = env.read_text(encoding="utf-8")
 
-    added = m.update_env_example(env, {"A": None, "B": None})
+    added, upgraded = m.update_env_example(
+        env,
+        {"A": _srcs(("getenv", None)), "B": _srcs(("getenv", None))},
+    )
 
     assert added == []
+    assert upgraded == []
     assert env.read_text(encoding="utf-8") == before
 
 
@@ -248,24 +338,671 @@ def test_update_env_example_handles_missing_trailing_newline(tmp_path):
     # No trailing newline on the existing content must not merge lines.
     env = _write(tmp_path / ".env.example", "A=1")
 
-    m.update_env_example(env, {"B": "2"})
+    m.update_env_example(env, {"B": _srcs(("getenv", "2"))})
 
     lines = env.read_text(encoding="utf-8").splitlines()
     assert "A=1" in lines
-    # Passed-in "2" is ignored; every entry gets PLACEHOLDER.
-    assert f"B={m.PLACEHOLDER}" in lines
-    assert "B=2" not in lines
+    # v2: extracted default is written verbatim (with marker comment).
+    assert any(ln.startswith("B=2") for ln in lines)
 
 
 def test_update_env_example_dry_run_reports_but_does_not_write(tmp_path):
     env = tmp_path / ".env.example"
 
-    added = m.update_env_example(env, {"NEW": "1"}, dry_run=True)
+    added, upgraded = m.update_env_example(
+        env, {"NEW": _srcs(("getenv", "1"))}, dry_run=True
+    )
 
     # Reports what it would add ...
     assert added == ["NEW"]
+    assert upgraded == []
     # ... but writes nothing (file not even created).
     assert not env.exists()
+
+
+def test_update_env_example_writes_setdefault_value(tmp_path):
+    # v2: os.environ.setdefault("V", "d") is the strongest form of author
+    # commitment. The value MUST land in .env.example so users can find it.
+    env = tmp_path / ".env.example"
+
+    m.update_env_example(
+        env, {"USE_VERTEX": _srcs(("setdefault", "TRUE"))}
+    )
+
+    content = env.read_text(encoding="utf-8")
+    assert "USE_VERTEX=TRUE" in content
+    # Provenance comment names the kind.
+    assert "setdefault" in content
+    assert m.EXTRACTED_MARKER in content
+
+
+def test_update_env_example_downgrades_placeholder_shaped_defaults(tmp_path):
+    # v2: an obvious stub like "my-project-id" is a common pattern for
+    # setdefault-as-reminder-to-fill-in. Writing it verbatim would give
+    # users a value that runs but is wrong. Downgrade to TODO, but keep
+    # the original string in the provenance comment so the maintainer
+    # sees what was in source and can fix it.
+    env = tmp_path / ".env.example"
+
+    m.update_env_example(
+        env,
+        {"GOOGLE_CLOUD_PROJECT": _srcs(("setdefault", "my-project-id"))},
+    )
+
+    content = env.read_text(encoding="utf-8")
+    # Downgraded to TODO ...
+    assert f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}" in content
+    # ... with the original value preserved in the marker comment.
+    assert '"my-project-id"' in content
+    # ... and no line that would resolve to the placeholder as-if-real.
+    assert "GOOGLE_CLOUD_PROJECT=my-project-id" not in content
+
+
+def test_update_env_example_preserves_user_edits_never_overwrites(tmp_path):
+    # Golden rule: any USER_OWNED line — one without our marker AND a
+    # value that isn't the v1 PLACEHOLDER — is left untouched. This is
+    # what makes re-running the skill safe when a maintainer has typed
+    # real values into .env.example.
+    env = _write(
+        tmp_path / ".env.example",
+        "# hand-tuned by maintainer\n"
+        "GOOGLE_CLOUD_PROJECT=my-real-project\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    added, upgraded = m.update_env_example(
+        env,
+        {"GOOGLE_CLOUD_PROJECT": _srcs(("setdefault", "something-else"))},
+    )
+
+    assert added == []
+    assert upgraded == []
+    # File not modified at all.
+    assert env.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# _classify_entry / parse_env_example — 5-bucket classification
+# ---------------------------------------------------------------------------
+
+
+def _classify(raw_line: str):
+    """Parse one line and return its classification (for concise assertions)."""
+    entries = m._parse_env_content(raw_line)
+    # Every test line here declares exactly one var.
+    assert len(entries) == 1, f"expected one entry, got {list(entries)}"
+    return next(iter(entries.values())).classification
+
+
+def test_classify_bare_v1_todo_is_upgradable():
+    # v1 skill wrote: `VAR=<TODO: update-this-value>` with no inline
+    # comment. Recognisable as v1 by exact value match + no comment.
+    line = f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}\n"
+    assert _classify(line) == m.EntryClassification.V1_TODO
+
+
+def test_classify_v1_todo_with_user_comment_is_user_owned():
+    # Golden rule: even a TODO literal becomes USER_OWNED if the user
+    # attached their own inline comment — that comment is real intent.
+    line = (
+        f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}"
+        "  # my project is prj-foo, use gcloud config get project\n"
+    )
+    assert _classify(line) == m.EntryClassification.USER_OWNED
+
+
+def test_classify_marker_with_placeholder_is_skill_todo():
+    # A line the skill itself wrote with a TODO — marker present, value
+    # is exactly PLACEHOLDER.
+    line = f"VAR={m.PLACEHOLDER}  # {m.EXTRACTED_MARKER}; no default in source\n"
+    assert _classify(line) == m.EntryClassification.SKILL_TODO
+
+
+def test_classify_marker_with_real_value_is_skill_real():
+    line = f"VAR=real-value  # {m.EXTRACTED_MARKER}; from setdefault in x.py\n"
+    assert _classify(line) == m.EntryClassification.SKILL_REAL
+
+
+def test_classify_user_typed_real_value_is_user_owned():
+    line = "GOOGLE_API_KEY=YOUR_AI_STUDIO_API_KEY_HERE\n"
+    assert _classify(line) == m.EntryClassification.USER_OWNED
+
+
+def test_classify_user_typed_value_with_inline_comment_is_user_owned():
+    line = "REGION=us-central1  # our default region\n"
+    assert _classify(line) == m.EntryClassification.USER_OWNED
+
+
+def test_parse_env_example_returns_line_index_for_rewrite(tmp_path):
+    # The parser must record which physical line each entry is on, so
+    # the rewriter can address it precisely.
+    env = _write(
+        tmp_path / ".env.example",
+        "# header\n"
+        "A=1\n"
+        "\n"
+        f"B={m.PLACEHOLDER}\n"
+        "C=3\n",
+    )
+    entries = m.parse_env_example(env)
+    # Zero-based line indices.
+    assert entries["A"].line_index == 1
+    assert entries["B"].line_index == 3
+    assert entries["C"].line_index == 4
+
+
+def test_parse_env_example_first_occurrence_wins(tmp_path):
+    # A malformed .env.example with duplicate declarations of the same
+    # var is common enough to defend against. First occurrence wins —
+    # matches dotenv precedence AND means the rewriter has one
+    # deterministic target.
+    env = _write(
+        tmp_path / ".env.example",
+        f"DUP={m.PLACEHOLDER}\nDUP=second-value\n",
+    )
+    entries = m.parse_env_example(env)
+    assert entries["DUP"].line_index == 0
+    # First occurrence's classification carries — the second is ignored.
+    assert entries["DUP"].classification == m.EntryClassification.V1_TODO
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_var_line — safety-hardened in-place rewriter
+# ---------------------------------------------------------------------------
+
+
+def test_rewriter_replaces_the_matching_line_only():
+    lines = ["A=1\n", "TARGET=old\n", "B=2\n"]
+    ok = m._rewrite_var_line(lines, "TARGET", "TARGET=new  # marker")
+    assert ok is True
+    assert lines[0] == "A=1\n"
+    assert lines[1] == "TARGET=new  # marker\n"
+    assert lines[2] == "B=2\n"
+
+
+def test_rewriter_preserves_export_prefix():
+    # If the original had `export VAR=`, the rewrite keeps the prefix.
+    lines = [f"export FOO={m.PLACEHOLDER}\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=real")
+    assert ok is True
+    assert lines[0] == "export FOO=real\n"
+
+
+def test_rewriter_preserves_leading_indentation():
+    # Golden rule: an indented line stays indented after rewrite. Some
+    # .env.example files are hand-formatted with leading whitespace on
+    # certain entries; the skill must not silently strip that.
+    lines = [f"  FOO={m.PLACEHOLDER}\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=real")
+    assert ok is True
+    assert lines[0] == "  FOO=real\n"
+
+
+def test_rewriter_preserves_indent_and_export_together():
+    lines = [f"\texport FOO={m.PLACEHOLDER}\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=real")
+    assert ok is True
+    assert lines[0] == "\texport FOO=real\n"
+
+
+def test_rewriter_refuses_quoted_value():
+    # Quoted values could span lines / contain escapes / include the
+    # `#` character verbatim — anything the classifier's simple regex
+    # doesn't handle unambiguously. Fail closed.
+    lines = ['FOO="quoted value"\n']
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=new")
+    assert ok is False
+    # File-analog left untouched.
+    assert lines[0] == 'FOO="quoted value"\n'
+
+
+def test_rewriter_refuses_line_continuation():
+    # Backslash-continuation is not standard dotenv but some parsers
+    # accept it. If we see it, we can't safely rewrite one physical line.
+    lines = ["FOO=part_one\\\n", "part_two\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=new")
+    assert ok is False
+
+
+def test_rewriter_refuses_multiple_matches():
+    # If the file has two lines declaring FOO, we don't know which one
+    # is the "real" declaration. Refuse rather than guess.
+    lines = ["FOO=1\n", "FOO=2\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=3")
+    assert ok is False
+    # Both original lines untouched.
+    assert lines == ["FOO=1\n", "FOO=2\n"]
+
+
+def test_rewriter_refuses_when_var_absent():
+    lines = ["A=1\n", "B=2\n"]
+    ok = m._rewrite_var_line(lines, "NOT_HERE", "NOT_HERE=x")
+    assert ok is False
+
+
+def test_rewriter_preserves_crlf_newlines():
+    # Windows line endings survive rewriting verbatim.
+    lines = ["FOO=old\r\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=new")
+    assert ok is True
+    assert lines[0] == "FOO=new\r\n"
+
+
+# ---------------------------------------------------------------------------
+# update_env_example — v2.1 upgrade paths (in-place TODO -> real value)
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_v1_todo_to_real_setdefault_value(tmp_path):
+    # The headline case: recipe was processed by v1 (line has PLACEHOLDER,
+    # no marker), source now has a setdefault with a real value. The v1
+    # TODO should be rewritten in place to the real value.
+    env = _write(
+        tmp_path / ".env.example",
+        "# Environment variables extracted by extract-python-environment-variables\n"
+        f"USE_VERTEX={m.PLACEHOLDER}\n",
+    )
+
+    added, upgraded = m.update_env_example(
+        env, {"USE_VERTEX": _srcs(("setdefault", "TRUE"))}
+    )
+
+    assert added == []
+    assert upgraded == ["USE_VERTEX"]
+    content = env.read_text(encoding="utf-8")
+    assert "USE_VERTEX=TRUE" in content
+    assert m.EXTRACTED_MARKER in content
+    # v1 header comment is preserved (rewriter touches one line, not the
+    # surrounding block).
+    assert (
+        "Environment variables extracted by extract-python-environment-variables"
+        in content
+    )
+    # No stray TODO for this var left behind.
+    assert f"USE_VERTEX={m.PLACEHOLDER}" not in content
+
+
+def test_upgrade_skill_todo_to_real_value(tmp_path):
+    # v2 skill previously wrote a TODO (because source had no default at
+    # the time). Now source has a real default — upgrade.
+    env = _write(
+        tmp_path / ".env.example",
+        f"USE_VERTEX={m.PLACEHOLDER}  # {m.EXTRACTED_MARKER}; no default in source\n",
+    )
+
+    added, upgraded = m.update_env_example(
+        env, {"USE_VERTEX": _srcs(("setdefault", "TRUE"))}
+    )
+
+    assert added == []
+    assert upgraded == ["USE_VERTEX"]
+    content = env.read_text(encoding="utf-8")
+    assert "USE_VERTEX=TRUE" in content
+
+
+def test_do_not_upgrade_when_source_default_is_placeholder_shape(tmp_path):
+    # Correctness: source has "my-project-id" (placeholder-shaped). Even
+    # though the existing entry is a v1 TODO, upgrading it would produce
+    # another TODO — pure churn. Skip.
+    env = _write(
+        tmp_path / ".env.example",
+        f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    added, upgraded = m.update_env_example(
+        env,
+        {"GOOGLE_CLOUD_PROJECT": _srcs(("setdefault", "my-project-id"))},
+    )
+
+    assert added == []
+    assert upgraded == []
+    # File byte-for-byte unchanged.
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_do_not_upgrade_when_source_has_no_default(tmp_path):
+    # Source only has bare os.getenv("V") — no string default to upgrade
+    # TO. Leave the TODO alone (upgrading to another TODO is churn).
+    env = _write(
+        tmp_path / ".env.example",
+        f"NO_DEFAULT={m.PLACEHOLDER}\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    added, upgraded = m.update_env_example(
+        env, {"NO_DEFAULT": _srcs(("getenv", None))}
+    )
+
+    assert added == []
+    assert upgraded == []
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_do_not_upgrade_v1_todo_with_inline_comment(tmp_path):
+    # Golden rule: an inline comment on a TODO line means the user has
+    # engaged with it. Never touch, even if source has a real default.
+    env = _write(
+        tmp_path / ".env.example",
+        f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}  # my note about this var\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    added, upgraded = m.update_env_example(
+        env,
+        {"GOOGLE_CLOUD_PROJECT": _srcs(("setdefault", "real-project"))},
+    )
+
+    assert added == []
+    assert upgraded == []
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_do_not_upgrade_skill_real_on_source_drift(tmp_path):
+    # Skill previously wrote a real value. Source now says something
+    # different. Skip refresh — the maintainer may have relied on the
+    # persisted value; drift is a separate concern (surface via WARN
+    # elsewhere).
+    env = _write(
+        tmp_path / ".env.example",
+        f"LOG_LEVEL=INFO  # {m.EXTRACTED_MARKER}; from getenv in x.py\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    added, upgraded = m.update_env_example(
+        env, {"LOG_LEVEL": _srcs(("getenv", "DEBUG"))}
+    )
+
+    assert added == []
+    assert upgraded == []
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_upgrade_and_append_can_happen_in_one_pass(tmp_path):
+    # Realistic mixed case: some vars exist as v1 TODOs (upgradable),
+    # some are missing (appendable), some are user-owned (skip).
+    env = _write(
+        tmp_path / ".env.example",
+        f"UPGRADABLE={m.PLACEHOLDER}\n"
+        "USER_OWNED_VAR=my-real-value\n",
+    )
+
+    added, upgraded = m.update_env_example(
+        env,
+        {
+            "UPGRADABLE": _srcs(("setdefault", "TRUE")),
+            "USER_OWNED_VAR": _srcs(("setdefault", "should-not-win")),
+            "APPEND_ME": _srcs(("getenv", "hello")),
+        },
+    )
+
+    assert added == ["APPEND_ME"]
+    assert upgraded == ["UPGRADABLE"]
+    content = env.read_text(encoding="utf-8")
+    assert "UPGRADABLE=TRUE" in content
+    assert "APPEND_ME=hello" in content
+    # User-owned entry untouched.
+    assert "USER_OWNED_VAR=my-real-value" in content
+    assert "should-not-win" not in content
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    # Golden rule: running the skill twice in a row must produce zero
+    # additional changes on the second run.
+    env = _write(
+        tmp_path / ".env.example",
+        f"V={m.PLACEHOLDER}\n",
+    )
+
+    added1, upgraded1 = m.update_env_example(
+        env, {"V": _srcs(("setdefault", "real"))}
+    )
+    content_after_first = env.read_text(encoding="utf-8")
+
+    added2, upgraded2 = m.update_env_example(
+        env, {"V": _srcs(("setdefault", "real"))}
+    )
+    content_after_second = env.read_text(encoding="utf-8")
+
+    assert upgraded1 == ["V"]
+    assert upgraded2 == []  # already upgraded → SKILL_REAL → skip
+    assert added2 == []
+    assert content_after_first == content_after_second
+
+
+def test_upgrade_dry_run_reports_but_does_not_write(tmp_path):
+    env = _write(
+        tmp_path / ".env.example",
+        f"V={m.PLACEHOLDER}\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    added, upgraded = m.update_env_example(
+        env, {"V": _srcs(("setdefault", "TRUE"))}, dry_run=True
+    )
+
+    assert upgraded == ["V"]
+    # File left untouched.
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_upgrade_refuses_ambiguous_line_and_warns(tmp_path, capsys):
+    # Golden rule: an existing entry classified as V1_TODO but whose
+    # line is structurally ambiguous (here: two matching lines for the
+    # same var) must not be rewritten. Instead, warn and leave it alone.
+    env = _write(
+        tmp_path / ".env.example",
+        f"V={m.PLACEHOLDER}\n"
+        f"V={m.PLACEHOLDER}\n",
+    )
+    before = env.read_text(encoding="utf-8")
+
+    # Parser gives us the first V (V1_TODO), so we plan to upgrade.
+    # Rewriter finds two matches, refuses, and warns.
+    added, upgraded = m.update_env_example(
+        env, {"V": _srcs(("setdefault", "TRUE"))}
+    )
+
+    assert upgraded == []
+    err = capsys.readouterr().err
+    assert "Refused to upgrade V" in err
+    # File not clobbered.
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_upgrade_preserves_ordering_and_surrounding_lines(tmp_path):
+    # Regression guard: rewriting one line must not touch anything else
+    # in the file — blank lines, comment blocks, order.
+    env = _write(
+        tmp_path / ".env.example",
+        "# Section 1\n"
+        "# User's careful comment above the TODO\n"
+        f"UPGRADABLE={m.PLACEHOLDER}\n"
+        "\n"
+        "# Section 2\n"
+        "OTHER=leave-me-alone\n",
+    )
+
+    m.update_env_example(
+        env, {"UPGRADABLE": _srcs(("setdefault", "TRUE"))}
+    )
+
+    content = env.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    # The user's comment above the TODO is preserved verbatim.
+    assert "# User's careful comment above the TODO" in lines
+    # Order of surrounding sections preserved.
+    upgradable_idx = next(
+        i for i, ln in enumerate(lines) if ln.startswith("UPGRADABLE=")
+    )
+    other_idx = next(
+        i for i, ln in enumerate(lines) if ln.startswith("OTHER=")
+    )
+    assert upgradable_idx < other_idx
+    # Other var untouched.
+    assert "OTHER=leave-me-alone" in lines
+
+
+# ---------------------------------------------------------------------------
+# looks_like_placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_looks_like_placeholder_detects_empty_string():
+    assert m.looks_like_placeholder("") is not None
+
+
+def test_looks_like_placeholder_detects_angle_wrapped():
+    assert m.looks_like_placeholder("<TODO>") is not None
+    assert m.looks_like_placeholder("<your-key-here>") is not None
+
+
+def test_looks_like_placeholder_detects_generic_tokens():
+    # Exact-match tokens are always placeholders.
+    for token in ("changeme", "change-me", "TODO", "todo", "xxx", "foo"):
+        assert m.looks_like_placeholder(token) is not None, token
+
+
+def test_looks_like_placeholder_detects_your_and_my_prefixes():
+    assert m.looks_like_placeholder("your-api-key") is not None
+    assert m.looks_like_placeholder("YOUR_PROJECT") is not None
+    assert m.looks_like_placeholder("my-project-id") is not None
+    assert m.looks_like_placeholder("MY_KEY") is not None
+
+
+def test_looks_like_placeholder_detects_example_com():
+    assert m.looks_like_placeholder("https://api.example.com") is not None
+
+
+def test_looks_like_placeholder_passes_real_looking_values():
+    # Values that look like plausible real config MUST NOT be flagged, or
+    # the writer downgrades a real default to TODO — worse than doing
+    # nothing.
+    for value in (
+        "TRUE",
+        "INFO",
+        "us-central1",
+        "gemini-3.5-flash",  # a real model id
+        "1234567890",
+        "https://api.acme.corp/v1",
+        "postgresql://localhost:5432/db",
+    ):
+        assert m.looks_like_placeholder(value) is None, value
+
+
+# ---------------------------------------------------------------------------
+# resolve_default
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_returns_none_when_no_string_default():
+    # A var read only via os.environ["V"] / bare os.getenv("V") has no
+    # string default anywhere — resolve should return None to signal
+    # "write TODO".
+    sources = _srcs(("environ_sub", None), ("getenv", None))
+    resolved = m.resolve_default(sources)
+    assert resolved.value is None
+    assert resolved.winner is None
+    assert resolved.conflict_count == 0
+
+
+def test_resolve_default_setdefault_beats_getenv_fallback():
+    # Priority: setdefault (author committed to a process-wide default)
+    # wins over per-read getenv fallback.
+    sources = [
+        m.Source(Path("a.py"), "getenv", "from-getenv", 1),
+        m.Source(Path("b.py"), "setdefault", "from-setdefault", 1),
+    ]
+    resolved = m.resolve_default(sources)
+    assert resolved.value == "from-setdefault"
+    assert resolved.winner is not None
+    assert resolved.winner.kind == "setdefault"
+    # They disagreed, so the getenv default counts as one conflict.
+    assert resolved.conflict_count == 1
+
+
+def test_resolve_default_alphabetical_file_tiebreak_within_tier():
+    # Two setdefault sources with different values: earlier-file wins.
+    sources = [
+        m.Source(Path("zzz.py"), "setdefault", "z-value", 1),
+        m.Source(Path("aaa.py"), "setdefault", "a-value", 1),
+    ]
+    resolved = m.resolve_default(sources)
+    assert resolved.value == "a-value"
+    assert resolved.winner is not None
+    assert resolved.winner.file == Path("aaa.py")
+
+
+def test_resolve_default_conflict_count_ignores_agreeing_sources():
+    # Two sources with the same default are not a conflict.
+    sources = [
+        m.Source(Path("a.py"), "getenv", "shared", 1),
+        m.Source(Path("b.py"), "getenv", "shared", 1),
+    ]
+    resolved = m.resolve_default(sources)
+    assert resolved.value == "shared"
+    assert resolved.conflict_count == 0
+
+
+def test_resolve_default_ignores_sources_without_string_default():
+    # A bare os.getenv("V") alongside an os.getenv("V", "x") should not
+    # be counted as a conflict — it doesn't propose a value.
+    sources = [
+        m.Source(Path("a.py"), "getenv", None, 1),
+        m.Source(Path("b.py"), "getenv", "the-value", 1),
+    ]
+    resolved = m.resolve_default(sources)
+    assert resolved.value == "the-value"
+    assert resolved.conflict_count == 0
+
+
+# ---------------------------------------------------------------------------
+# format_env_entry
+# ---------------------------------------------------------------------------
+
+
+def test_format_env_entry_writes_todo_when_no_default():
+    # No source supplied a string-literal default.
+    line = m.format_env_entry("API_KEY", _srcs(("getenv", None)))
+    assert line.startswith(f"API_KEY={m.PLACEHOLDER}")
+    assert m.EXTRACTED_MARKER in line
+    assert "no default in source" in line
+
+
+def test_format_env_entry_writes_real_value_with_provenance(tmp_path):
+    # Extracted default becomes the value; provenance names the kind and
+    # (relative) file path.
+    src_file = tmp_path / "sub" / "agent.py"
+    sources = [m.Source(src_file, "setdefault", "TRUE", 3)]
+    line = m.format_env_entry("USE_X", sources, recipe_dir=tmp_path)
+    assert line.startswith("USE_X=TRUE")
+    assert "setdefault" in line
+    assert "sub/agent.py" in line
+    assert m.EXTRACTED_MARKER in line
+
+
+def test_format_env_entry_downgrades_placeholder_shaped_value(tmp_path):
+    # A stub-shaped value → TODO with the source string preserved in the
+    # comment so the maintainer can find and fix the source too.
+    src_file = tmp_path / "agent.py"
+    sources = [m.Source(src_file, "setdefault", "my-project-id", 1)]
+    line = m.format_env_entry("PROJECT", sources, recipe_dir=tmp_path)
+    assert line.startswith(f"PROJECT={m.PLACEHOLDER}")
+    assert '"my-project-id"' in line
+    # And there's a hint that says please fix source.
+    assert "fix source" in line
+
+
+def test_format_env_entry_records_conflict_in_comment(tmp_path):
+    # Two conflicting sources → note the conflict so maintainer reconciles.
+    sources = [
+        m.Source(tmp_path / "a.py", "setdefault", "TRUE", 1),
+        m.Source(tmp_path / "b.py", "setdefault", "FALSE", 1),
+    ]
+    line = m.format_env_entry("FLAG", sources, recipe_dir=tmp_path)
+    # Alphabetical tie-break within setdefault tier picks a.py's TRUE.
+    assert line.startswith("FLAG=TRUE")
+    assert "differs from 1 other source" in line
 
 
 # ---------------------------------------------------------------------------
@@ -969,15 +1706,25 @@ def test_run_step_pyproject_pass_when_already_present(tmp_path, capsys):
 
 
 def _make_sample_recipe(root: Path) -> Path:
-    """A minimal recipe: a package that reads an env var and hardcodes a
-    model, plus a pyproject.toml without python-dotenv and no .env.example."""
+    """A minimal recipe exercising all v2 code paths:
+
+      * MY_API_KEY — bare os.getenv, no default → TODO
+      * LOG_LEVEL — getenv with a real fallback → extracted verbatim
+      * USE_VERTEX — setdefault with a real value → extracted verbatim
+      * GOOGLE_CLOUD_PROJECT — setdefault with a stub value → downgraded
+        to TODO with the source string preserved in the comment
+      * MODEL — hardcoded model literal → replaced with os.getenv
+    """
     recipe = root / "my-recipe"
     pkg = recipe / "my_recipe"
     pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text("", encoding="utf-8")
     (pkg / "agent.py").write_text(
         "import os\n"
+        "os.environ.setdefault('USE_VERTEX', 'TRUE')\n"
+        "os.environ.setdefault('GOOGLE_CLOUD_PROJECT', 'my-project-id')\n"
         'KEY = os.getenv("MY_API_KEY")\n'
+        'LEVEL = os.getenv("LOG_LEVEL", "INFO")\n'
         'MODEL = "gemini-3.5-flash"\n',
         encoding="utf-8",
     )
@@ -1021,18 +1768,57 @@ def test_main_real_run_applies_changes(tmp_path, monkeypatch):
     agent_py = recipe / "my_recipe" / "agent.py"
     pyproject = recipe / "pyproject.toml"
 
+    # Simulate an existing .env.example with:
+    #   * a v1-shape TODO line for USE_VERTEX — should be upgraded to TRUE
+    #     (source has setdefault("USE_VERTEX", "TRUE"))
+    #   * a v1-shape TODO for GOOGLE_CLOUD_PROJECT — should NOT be upgraded
+    #     (source's setdefault value is placeholder-shaped "my-project-id")
+    #   * a user-owned real value for LOG_LEVEL — should NOT be touched
+    #     even though source has getenv("LOG_LEVEL", "INFO")
+    (recipe / ".env.example").write_text(
+        f"USE_VERTEX={m.PLACEHOLDER}\n"
+        f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}\n"
+        "LOG_LEVEL=WARN  # user set this deliberately\n",
+        encoding="utf-8",
+    )
+
     _run_main(monkeypatch, recipe)
 
-    # .env.example created with the detected env var and the extracted model.
     env_text = (recipe / ".env.example").read_text(encoding="utf-8")
-    assert "MY_API_KEY=" in env_text
-    assert "MODEL_NAME=" in env_text
+
+    # v2.1 end-to-end assertions covering the pre-existing entry cases:
+    #
+    # 1. USE_VERTEX was a v1 TODO in .env.example; source has a real
+    #    setdefault value → upgraded in place.
+    assert "USE_VERTEX=TRUE" in env_text
+    assert f"USE_VERTEX={m.PLACEHOLDER}" not in env_text
+    # 2. GOOGLE_CLOUD_PROJECT was a v1 TODO; source has a placeholder-shape
+    #    setdefault value → NOT upgraded (would be TODO → TODO churn).
+    assert f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}" in env_text
+    # 3. LOG_LEVEL had a user-typed real value + comment → USER_OWNED,
+    #    never touched, even though source has getenv("LOG_LEVEL", "INFO").
+    assert "LOG_LEVEL=WARN  # user set this deliberately" in env_text
+    assert "LOG_LEVEL=INFO" not in env_text
+    # 4. Bare os.getenv (no default) for a new var → TODO placeholder
+    #    with the "no default in source" marker comment.
+    assert f"MY_API_KEY={m.PLACEHOLDER}" in env_text
+    # 5. Hardcoded model literal → env var + value written to .env.example.
+    assert "MODEL_NAME=gemini-3.5-flash" in env_text
+
     # load_dotenv injected, python-dotenv added, model string replaced.
     assert "load_dotenv" in init_py.read_text(encoding="utf-8")
     assert "python-dotenv" in pyproject.read_text(encoding="utf-8")
     agent_text = agent_py.read_text(encoding="utf-8")
-    # Hard rule: the replacement is BARE os.getenv("MODEL_NAME") — no inferred
-    # default is written, even though the original model string is known.
+    # Rule 2: the replacement is BARE os.getenv("MODEL_NAME") — no inferred
+    # default is written into Python source, even though the model string
+    # is known and correct.
     assert 'os.getenv("MODEL_NAME")' in agent_text
     assert 'os.getenv("MODEL_NAME", ' not in agent_text
     assert "gemini-3.5-flash" not in agent_text
+    # Rule 2: pre-existing setdefault calls are LEFT UNTOUCHED — we read
+    # them but don't rewrite them.
+    assert "os.environ.setdefault('USE_VERTEX', 'TRUE')" in agent_text
+    assert (
+        "os.environ.setdefault('GOOGLE_CLOUD_PROJECT', 'my-project-id')"
+        in agent_text
+    )

--- a/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
+++ b/.agents/skills/extract-python-environment-variables/tests/test_extract_env_vars.py
@@ -230,6 +230,135 @@ def test_extract_env_vars_records_line_number(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# AST detection edge cases — the scanner must find TRUE positives and skip
+# TRUE negatives cleanly. False positives here would pollute .env.example;
+# false negatives would silently fail to surface a var to the user.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_env_vars_kwarg_default_captured(tmp_path):
+    # `os.getenv("VAR", default="d")` — kwarg form. Rare but valid.
+    # The scanner must capture "d" so the discoverability guarantee
+    # holds regardless of calling style.
+    src = (
+        "import os\n"
+        "a = os.getenv('VAR_A', default='kw-default')\n"
+        "b = os.environ.get('VAR_B', default='kw-get-default')\n"
+        "os.environ.setdefault('VAR_C', default='kw-sd-default')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert result["VAR_A"][0].default == "kw-default"
+    assert result["VAR_B"][0].default == "kw-get-default"
+    assert result["VAR_C"][0].default == "kw-sd-default"
+
+
+def test_extract_env_vars_positional_wins_over_kwarg_when_both_present(tmp_path):
+    # Defensive: `os.getenv("X", "positional", default="kw")` is a
+    # SyntaxError in Python (can't have both positional and kw for the
+    # same param), but writers of weird code aside, our extractor should
+    # prefer the positional when it comes to picking a source. Since
+    # Python's own semantics reject this case at call time, we mainly
+    # verify our code doesn't crash and picks something deterministic.
+    #
+    # Practically we test only the disambiguation shape our helper picks:
+    # positional first, then kwarg. See _default_from_call.
+    src = "import os\nx = os.getenv('X', 'pos')\n"
+    py = _write(tmp_path / "mod.py", src)
+    assert m.extract_env_vars([py])["X"][0].default == "pos"
+
+
+def test_extract_env_vars_aliased_os_import_not_matched(tmp_path):
+    # `import os as o` then `o.getenv(...)` — the AST walker only fires
+    # on `os.getenv` (Attribute of Name('os')). This is intentional: we
+    # can't reliably track aliases across a whole codebase, so we accept
+    # a small false-negative rate on unusual import styles rather than
+    # a false-positive rate on look-alike names.
+    src = "import os as o\nx = o.getenv('SHOULD_NOT_MATCH', 'x')\n"
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert result == {}
+
+
+def test_extract_env_vars_from_import_getenv_not_matched(tmp_path):
+    # `from os import getenv` then `getenv(...)` — bare-name call. Same
+    # reasoning as the aliased-import case: we require the `os.` prefix.
+    src = "from os import getenv\nx = getenv('SHOULD_NOT_MATCH')\n"
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert result == {}
+
+
+def test_extract_env_vars_similar_but_wrong_attribute_not_matched(tmp_path):
+    # A non-os object with a `getenv` method must NOT match.
+    src = (
+        "class MyThing:\n"
+        "    def getenv(self, key): return None\n"
+        "obj = MyThing()\n"
+        "x = obj.getenv('NOT_A_REAL_ENV_VAR')\n"
+    )
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert result == {}
+
+
+def test_extract_env_vars_nested_getenv_captures_inner(tmp_path):
+    # `os.getenv(os.getenv("INNER", "def"), "outer-def")` — the inner
+    # call is captured; the outer's var_name is None (its first arg is
+    # not a string literal) so it doesn't contribute.
+    src = "import os\nx = os.getenv(os.getenv('INNER', 'def'), 'outer')\n"
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert "INNER" in result
+    assert result["INNER"][0].default == "def"
+    # The outer call had a non-string first arg → no entry produced.
+    # (There's nothing to assert absent by name — we just verify no
+    # spurious UPPER_SNAKE_CASE var appeared.)
+    assert len(result) == 1
+
+
+def test_extract_env_vars_setdefault_without_default_still_captured(tmp_path):
+    # `os.environ.setdefault("X")` is technically valid Python (returns
+    # None if X isn't set; setting an env var to None then coerces to
+    # "None" — nonsensical, but we still surface the var name).
+    src = "import os\nos.environ.setdefault('LONELY_VAR')\n"
+    py = _write(tmp_path / "mod.py", src)
+
+    result = m.extract_env_vars([py])
+
+    assert "LONELY_VAR" in result
+    assert result["LONELY_VAR"][0].kind == "setdefault"
+    assert result["LONELY_VAR"][0].default is None
+
+
+def test_extract_env_vars_multiple_files_aggregated(tmp_path):
+    # A var referenced in multiple files aggregates all sources into
+    # one list (preserving per-file provenance for the resolver).
+    f1 = _write(tmp_path / "a.py", "import os\nos.getenv('SHARED', 'from-a')\n")
+    f2 = _write(tmp_path / "b.py", "import os\nos.getenv('SHARED', 'from-b')\n")
+
+    result = m.extract_env_vars([f1, f2])
+
+    assert len(result["SHARED"]) == 2
+    files = {s.file for s in result["SHARED"]}
+    assert files == {f1, f2}
+
+
+def test_extract_env_vars_empty_file_list_is_empty_result():
+    assert m.extract_env_vars([]) == {}
+
+
+# ---------------------------------------------------------------------------
 # read_defined_vars
 # ---------------------------------------------------------------------------
 
@@ -506,6 +635,94 @@ def test_parse_env_example_first_occurrence_wins(tmp_path):
     assert entries["DUP"].classification == m.EntryClassification.V1_TODO
 
 
+def test_classify_export_prefix_v1_todo():
+    # `export VAR=<TODO: ...>` with no marker and no inline comment
+    # should still classify as V1_TODO (export is orthogonal to the
+    # classification signal).
+    line = f"export FOO={m.PLACEHOLDER}\n"
+    assert _classify(line) == m.EntryClassification.V1_TODO
+
+
+def test_classify_export_prefix_marker_real():
+    line = (
+        f"export FOO=real-value  # {m.EXTRACTED_MARKER}; from setdefault in x.py\n"
+    )
+    assert _classify(line) == m.EntryClassification.SKILL_REAL
+
+
+def test_classify_empty_value_is_user_owned():
+    # `FOO=` (empty value) is user-owned — the user may have deliberately
+    # set an empty default. It is NOT V1_TODO (that requires the exact
+    # PLACEHOLDER string).
+    line = "FOO=\n"
+    assert _classify(line) == m.EntryClassification.USER_OWNED
+
+
+def test_classify_value_with_whitespace_padding_still_v1_todo():
+    # Whitespace around the value must be stripped before comparison —
+    # otherwise `FOO=<TODO: update-this-value>   ` fails to classify
+    # correctly and blocks the upgrade path.
+    line = f"FOO=  {m.PLACEHOLDER}  \n"
+    assert _classify(line) == m.EntryClassification.V1_TODO
+
+
+def test_classify_indented_line_still_recognised():
+    # Leading whitespace on a var line is valid per python-dotenv. The
+    # classifier must not reject it — otherwise a well-formed but
+    # indented .env.example would get spurious appends.
+    line = f"  FOO={m.PLACEHOLDER}\n"
+    assert _classify(line) == m.EntryClassification.V1_TODO
+
+
+def test_parse_env_example_skips_blank_and_comment_only_lines(tmp_path):
+    # Blank lines and comment-only lines aren't entries and must not
+    # end up in the returned dict.
+    env = _write(
+        tmp_path / ".env.example",
+        "\n"
+        "# just a comment\n"
+        "\n"
+        "REAL=1\n"
+        "   # indented comment\n"
+        "\n",
+    )
+    entries = m.parse_env_example(env)
+    assert set(entries.keys()) == {"REAL"}
+
+
+def test_parse_env_example_skips_malformed_lines(tmp_path):
+    # A line that doesn't match the env-var shape (no `=`, or wrong
+    # name shape) is ignored — never crashes the parser.
+    env = _write(
+        tmp_path / ".env.example",
+        "GOOD=1\n"
+        "just a random line without equals\n"
+        "lowercase_var=2\n"  # not UPPER_SNAKE_CASE
+        "9NUMERIC_START=3\n"  # invalid identifier
+        "ALSO_GOOD=4\n",
+    )
+    entries = m.parse_env_example(env)
+    assert set(entries.keys()) == {"GOOD", "ALSO_GOOD"}
+
+
+def test_parse_env_example_missing_file_returns_empty_dict(tmp_path):
+    # No file → empty dict, not an exception. Downstream code relies
+    # on this so it can be called unconditionally.
+    entries = m.parse_env_example(tmp_path / "does-not-exist.env")
+    assert entries == {}
+
+
+def test_read_defined_vars_stays_backwards_compatible(tmp_path):
+    # read_defined_vars is now a thin wrapper around parse_env_example.
+    # Existing callers (assign_model_var_names) rely on the same return
+    # shape — verify it still returns just names.
+    env = _write(
+        tmp_path / ".env.example",
+        "A=1\nB=2\n# comment\n",
+    )
+    assert m.read_defined_vars(env) == {"A", "B"}
+
+
 # ---------------------------------------------------------------------------
 # _rewrite_var_line — safety-hardened in-place rewriter
 # ---------------------------------------------------------------------------
@@ -543,6 +760,74 @@ def test_rewriter_preserves_indent_and_export_together():
     ok = m._rewrite_var_line(lines, "FOO", "FOO=real")
     assert ok is True
     assert lines[0] == "\texport FOO=real\n"
+
+
+def test_rewriter_empty_lines_list_returns_false():
+    # No lines to match against → False, no crash.
+    lines: list[str] = []
+    assert m._rewrite_var_line(lines, "FOO", "FOO=x") is False
+
+
+def test_rewriter_does_not_match_similar_prefixed_var_names():
+    # `FOO` must not match `FOO_BAR` or `FOO_BAZ`. The regex uses
+    # re.escape + anchored end, so this is regression-guarded.
+    lines = [
+        "FOO_BAR=1\n",
+        "FOO_BAZ=2\n",
+        "FOO=target\n",
+    ]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=new")
+    assert ok is True
+    # Only the FOO line changed.
+    assert lines[0] == "FOO_BAR=1\n"
+    assert lines[1] == "FOO_BAZ=2\n"
+    assert lines[2] == "FOO=new\n"
+
+
+def test_rewriter_leaves_all_non_matching_lines_byte_identical():
+    # Regression guard: replacing one line must never mutate any other
+    # line — including whitespace, comments, encoding, or ordering.
+    lines = [
+        "# License block\n",
+        "# ------------\n",
+        "\n",
+        "ALPHA=1\n",
+        "\r\n",  # CRLF blank
+        "BETA=2  # a user note\n",
+        f"TARGET={m.PLACEHOLDER}\n",
+        "GAMMA=3\n",
+        "\n",
+    ]
+    snapshot = list(lines)
+    ok = m._rewrite_var_line(lines, "TARGET", "TARGET=real")
+    assert ok is True
+    for i, original in enumerate(snapshot):
+        if i == 6:  # the TARGET line
+            assert lines[i] != original
+            assert lines[i] == "TARGET=real\n"
+        else:
+            assert lines[i] == original, f"line {i} unexpectedly changed"
+
+
+def test_rewriter_handles_tab_around_equals():
+    # `FOO\t=\tvalue` — legal per python-dotenv (which permits
+    # whitespace around `=`). Our regex allows [ \t]* on both sides.
+    lines = [f"FOO\t=\t{m.PLACEHOLDER}\n"]
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=real")
+    assert ok is True
+    # We use the standard shape on output (single `=`, no tabs).
+    # Preserved: nothing about the whitespace within the line.
+    assert lines[0] == "FOO=real\n"
+
+
+def test_rewriter_no_newline_on_last_line():
+    # Last line of file might have no trailing newline. The rewriter
+    # must preserve that — adding a newline could subtly change tools
+    # that care (git diff noise, some parsers).
+    lines = [f"FOO={m.PLACEHOLDER}"]  # no trailing newline
+    ok = m._rewrite_var_line(lines, "FOO", "FOO=real")
+    assert ok is True
+    assert lines[0] == "FOO=real"
 
 
 def test_rewriter_refuses_quoted_value():
@@ -843,6 +1128,94 @@ def test_upgrade_preserves_ordering_and_surrounding_lines(tmp_path):
     assert "OTHER=leave-me-alone" in lines
 
 
+def test_update_env_example_noop_when_env_vars_empty(tmp_path):
+    # A recipe with zero env-var accesses → nothing to do, no file
+    # touched, no crash.
+    env = _write(tmp_path / ".env.example", "EXISTING=1\n")
+    before = env.read_text(encoding="utf-8")
+    added, upgraded = m.update_env_example(env, {})
+    assert (added, upgraded) == ([], [])
+    assert env.read_text(encoding="utf-8") == before
+
+
+def test_update_env_example_noop_when_no_changes_needed_does_not_touch_file(tmp_path):
+    # Every var already declared + no upgrades required → the file must
+    # not be re-written at all (would show as a spurious modification in
+    # git status / re-run diff).
+    env = _write(tmp_path / ".env.example", "A=user-value\n")
+    original_mtime = env.stat().st_mtime_ns
+    original_bytes = env.read_bytes()
+
+    added, upgraded = m.update_env_example(
+        env, {"A": _srcs(("getenv", "different"))}
+    )
+    assert (added, upgraded) == ([], [])
+    # File content byte-identical.
+    assert env.read_bytes() == original_bytes
+    # (mtime check is best-effort — some filesystems have coarse
+    # resolution — but the byte-equality assertion is the strong one.)
+    _ = original_mtime  # silence unused
+
+
+def test_update_env_example_round_trip_check_refuses_corrupted_rewrite(
+    tmp_path, monkeypatch, capsys
+):
+    # SAFETY BACKSTOP: if a hypothetical bug in the rewriter produced
+    # a line that doesn't re-parse as SKILL_REAL, the round-trip check
+    # must catch it and refuse to write. This test forces that by
+    # monkeypatching the rewriter to succeed structurally but produce
+    # a corrupt line, and asserts the whole write is rolled back.
+    env = _write(tmp_path / ".env.example", f"V={m.PLACEHOLDER}\n")
+    before = env.read_bytes()
+
+    def _corrupt_rewriter(lines, var_name, new_line_body):
+        # Simulate a rewriter bug: signal success but write garbage
+        # that will never re-parse as a valid entry.
+        lines[0] = "totally not a valid env line !!!\n"
+        return True
+
+    monkeypatch.setattr(m, "_rewrite_var_line", _corrupt_rewriter)
+
+    added, upgraded = m.update_env_example(
+        env, {"V": _srcs(("setdefault", "real"))}
+    )
+    # Writer refused because of the round-trip check.
+    assert (added, upgraded) == ([], [])
+    # File byte-identical.
+    assert env.read_bytes() == before
+    # ERROR was logged so a caller / CI can see it.
+    err = capsys.readouterr().err
+    assert "Round-trip safety check failed" in err
+
+
+def test_update_env_example_upgrade_only_no_append_still_writes(tmp_path):
+    # A recipe where every var is already declared but some need
+    # upgrading — the writer must still update the file (upgrade
+    # path is not gated on there being appends).
+    env = _write(tmp_path / ".env.example", f"V={m.PLACEHOLDER}\n")
+    added, upgraded = m.update_env_example(
+        env, {"V": _srcs(("setdefault", "real"))}
+    )
+    assert added == []
+    assert upgraded == ["V"]
+    assert "V=real" in env.read_text(encoding="utf-8")
+
+
+def test_update_env_example_preserves_crlf_line_endings(tmp_path):
+    # A .env.example authored on Windows should keep its CRLF endings
+    # after an in-place upgrade — mixed endings in one file are ugly
+    # and can break naive tools.
+    env = tmp_path / ".env.example"
+    env.write_bytes(f"V={m.PLACEHOLDER}\r\n".encode("utf-8"))
+
+    m.update_env_example(env, {"V": _srcs(("setdefault", "real"))})
+
+    # Line still ends with CRLF, not LF.
+    content_bytes = env.read_bytes()
+    assert b"\r\n" in content_bytes
+    assert b"V=real" in content_bytes
+
+
 # ---------------------------------------------------------------------------
 # looks_like_placeholder
 # ---------------------------------------------------------------------------
@@ -888,6 +1261,65 @@ def test_looks_like_placeholder_passes_real_looking_values():
         "postgresql://localhost:5432/db",
     ):
         assert m.looks_like_placeholder(value) is None, value
+
+
+def test_looks_like_placeholder_broader_realistic_defaults():
+    # Extended coverage: things that should PASS through. If any of these
+    # get downgraded to TODO, real config will be missed.
+    for value in (
+        "0",
+        "1",
+        "false",
+        "False",
+        "off",
+        "DEBUG",
+        "ERROR",
+        "utf-8",
+        "en_US.UTF-8",
+        "8080",
+        "/tmp/cache",
+        "s3://bucket/prefix/",
+        "redis://cache.local:6379/0",
+        "us-east4-a",
+        "text-embedding-004",
+        "gs://my-bucket/path",
+        "@channel-name",
+        "prod",
+        "staging",
+    ):
+        assert m.looks_like_placeholder(value) is None, value
+
+
+def test_looks_like_placeholder_your_and_my_only_with_delimiter():
+    # We only flag "your-" / "your_" / "my-" / "my_" — not any word
+    # starting with those substrings (e.g. "yours", "yourself", "myth",
+    # "myself"). This prevents false positives on legitimate words.
+    for value in ("yours", "yourself", "myth", "myself", "mysql", "yourfoo"):
+        assert m.looks_like_placeholder(value) is None, value
+
+
+def test_looks_like_placeholder_case_insensitive_prefix_matching():
+    # "your-" prefix check is case-insensitive so YOUR_KEY / your-key /
+    # YoUr-KeY all get flagged.
+    for value in ("YOUR-KEY", "yOUr-key", "MY-project", "Your_secret"):
+        assert m.looks_like_placeholder(value) is not None, value
+
+
+def test_looks_like_placeholder_example_com_in_url_flagged():
+    # example.com anywhere in the value triggers the flag — this is
+    # deliberate. A URL with example.com is documentation-shaped, not
+    # a real endpoint.
+    assert m.looks_like_placeholder("https://api.example.com/v1") is not None
+    assert m.looks_like_placeholder("user@example.com") is not None
+
+
+def test_looks_like_placeholder_returns_reason_string():
+    # The return value must be a non-empty reason string, not just a
+    # truthy sentinel — the writer surfaces it in the marker comment.
+    reason = m.looks_like_placeholder("")
+    assert isinstance(reason, str) and reason
+    reason = m.looks_like_placeholder("changeme")
+    assert isinstance(reason, str) and reason
 
 
 # ---------------------------------------------------------------------------
@@ -956,6 +1388,63 @@ def test_resolve_default_ignores_sources_without_string_default():
     assert resolved.conflict_count == 0
 
 
+def test_resolve_default_empty_sources_returns_none():
+    # Defensive: an empty source list must not crash.
+    resolved = m.resolve_default([])
+    assert resolved.value is None
+    assert resolved.winner is None
+    assert resolved.conflict_count == 0
+
+
+def test_resolve_default_line_number_tiebreak_within_same_file():
+    # Two sources in the SAME file with different defaults: the earlier
+    # line wins (deterministic ordering after (kind, file, line)).
+    sources = [
+        m.Source(Path("x.py"), "setdefault", "later", 50),
+        m.Source(Path("x.py"), "setdefault", "earlier", 5),
+    ]
+    resolved = m.resolve_default(sources)
+    assert resolved.value == "earlier"
+    assert resolved.winner is not None
+    assert resolved.winner.line == 5
+
+
+def test_resolve_default_environ_get_and_getenv_at_same_priority():
+    # environ_get and getenv share the SAME priority tier (1); a
+    # setdefault (tier 0) beats both. Within tier 1, alphabetical
+    # file wins.
+    sources = [
+        m.Source(Path("b.py"), "getenv", "b-value", 1),
+        m.Source(Path("a.py"), "environ_get", "a-value", 1),
+    ]
+    resolved = m.resolve_default(sources)
+    # Alphabetical: "a.py" < "b.py" → a-value wins.
+    assert resolved.value == "a-value"
+
+
+def test_resolve_default_environ_sub_never_contributes_value():
+    # environ_sub sources always have default=None, so they can never
+    # supply a winning value. If ALL sources are environ_sub, the
+    # resolver returns None.
+    sources = [
+        m.Source(Path("a.py"), "environ_sub", None, 1),
+        m.Source(Path("b.py"), "environ_sub", None, 1),
+    ]
+    resolved = m.resolve_default(sources)
+    assert resolved.value is None
+
+
+def test_resolve_default_setdefault_wins_over_environ_get():
+    # setdefault is tier 0; environ_get is tier 1. setdefault always wins.
+    sources = [
+        m.Source(Path("z.py"), "setdefault", "sd-value", 1),
+        m.Source(Path("a.py"), "environ_get", "get-value", 1),  # earlier alphabetically!
+    ]
+    resolved = m.resolve_default(sources)
+    # Priority beats alphabetical.
+    assert resolved.value == "sd-value"
+
+
 # ---------------------------------------------------------------------------
 # format_env_entry
 # ---------------------------------------------------------------------------
@@ -1003,6 +1492,47 @@ def test_format_env_entry_records_conflict_in_comment(tmp_path):
     # Alphabetical tie-break within setdefault tier picks a.py's TRUE.
     assert line.startswith("FLAG=TRUE")
     assert "differs from 1 other source" in line
+
+
+def test_format_env_entry_no_conflict_note_when_sources_agree(tmp_path):
+    # Two sources with the same default → no conflict note in the comment
+    # (the comment should stay clean when nothing needs reconciling).
+    sources = [
+        m.Source(tmp_path / "a.py", "setdefault", "TRUE", 1),
+        m.Source(tmp_path / "b.py", "setdefault", "TRUE", 1),
+    ]
+    line = m.format_env_entry("FLAG", sources, recipe_dir=tmp_path)
+    assert line.startswith("FLAG=TRUE")
+    assert "differs from" not in line
+
+
+def test_format_env_entry_uses_basename_when_no_recipe_dir(tmp_path):
+    # Callers can pass recipe_dir=None (the parameter is optional). When
+    # they do, provenance uses the file's basename, not an absolute path.
+    src_file = tmp_path / "deep" / "nested" / "agent.py"
+    sources = [m.Source(src_file, "setdefault", "value", 1)]
+    line = m.format_env_entry("V", sources)  # recipe_dir omitted
+    assert "agent.py" in line
+    assert str(tmp_path) not in line  # no absolute path leaked
+
+
+def test_format_env_entry_uses_basename_when_file_not_under_recipe_dir(tmp_path):
+    # If the source file is somewhere else on disk (unusual), we fall
+    # back to basename rather than emitting an absolute path.
+    src_file = Path("/tmp/somewhere/else.py")
+    sources = [m.Source(src_file, "setdefault", "value", 1)]
+    line = m.format_env_entry("V", sources, recipe_dir=tmp_path)
+    assert "else.py" in line
+    assert "/tmp/somewhere" not in line
+
+
+def test_format_env_entry_line_contains_no_newlines():
+    # The formatter returns a SINGLE line; callers add the newline. A
+    # returned string with embedded newlines would corrupt .env.example.
+    sources = [m.Source(Path("x.py"), "setdefault", "value", 1)]
+    line = m.format_env_entry("V", sources)
+    assert "\n" not in line
+    assert "\r" not in line
 
 
 # ---------------------------------------------------------------------------
@@ -1822,3 +2352,274 @@ def test_main_real_run_applies_changes(tmp_path, monkeypatch):
         "os.environ.setdefault('GOOGLE_CLOUD_PROJECT', 'my-project-id')"
         in agent_text
     )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end edge cases — main() against unusual recipe shapes
+# ---------------------------------------------------------------------------
+
+
+def test_main_recipe_with_no_python_files_does_not_crash(tmp_path, monkeypatch):
+    # A recipe directory that has a pyproject.toml but no Python files
+    # (empty scaffold, or someone deleted the source). Skill must
+    # complete gracefully.
+    recipe = tmp_path / "empty-recipe"
+    recipe.mkdir()
+    (recipe / "pyproject.toml").write_text(
+        '[project]\nname = "x"\ndependencies = ["python-dotenv>=1.0.0"]\n',
+        encoding="utf-8",
+    )
+
+    # No Python files at all; no crash, no .env.example created (nothing
+    # to write about).
+    _run_main(monkeypatch, recipe)
+
+    # .env.example is NOT created (there were no vars to write).
+    assert not (recipe / ".env.example").exists()
+
+
+def test_main_recipe_with_only_user_owned_env_example_is_noop(
+    tmp_path, monkeypatch
+):
+    # If the maintainer has hand-authored every entry (no markers, no
+    # v1 TODOs), the skill must NOT add or upgrade anything on that
+    # file — and the file must stay byte-identical.
+    recipe = tmp_path / "recipe"
+    pkg = recipe / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "agent.py").write_text(
+        "import os\n"
+        "A = os.getenv('MY_API_KEY', 'default-A')\n"
+        "B = os.getenv('MY_LOG_LEVEL', 'DEBUG')\n",
+        encoding="utf-8",
+    )
+    (recipe / "pyproject.toml").write_text(
+        '[project]\nname = "x"\ndependencies = ["python-dotenv>=1.0.0"]\n',
+        encoding="utf-8",
+    )
+    env_example = recipe / ".env.example"
+    env_example.write_text(
+        "# Fully hand-curated by maintainer\n"
+        "MY_API_KEY=hand-typed-real-value\n"
+        "MY_LOG_LEVEL=INFO  # user override\n",
+        encoding="utf-8",
+    )
+    before = env_example.read_bytes()
+
+    _run_main(monkeypatch, recipe)
+
+    # Byte-identical: nothing was added, nothing was rewritten.
+    assert env_example.read_bytes() == before
+
+
+def test_main_recipe_with_unparseable_env_example_line_does_not_crash(
+    tmp_path, monkeypatch
+):
+    # A .env.example with a malformed / non-declaration line should be
+    # tolerated — the parser skips such lines and the skill continues.
+    recipe = tmp_path / "recipe"
+    pkg = recipe / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "agent.py").write_text(
+        "import os\nKEY = os.getenv('NEW_VAR')\n",
+        encoding="utf-8",
+    )
+    (recipe / "pyproject.toml").write_text(
+        '[project]\nname = "x"\ndependencies = ["python-dotenv>=1.0.0"]\n',
+        encoding="utf-8",
+    )
+    (recipe / ".env.example").write_text(
+        "GOOD_VAR=1\n"
+        "this line is not a valid env declaration at all\n"
+        "ALSO_GOOD=2\n",
+        encoding="utf-8",
+    )
+
+    # Must complete without raising.
+    _run_main(monkeypatch, recipe)
+
+    # The garbage line is preserved verbatim (nothing to do with it).
+    content = (recipe / ".env.example").read_text(encoding="utf-8")
+    assert "this line is not a valid env declaration at all" in content
+    # And NEW_VAR was appended normally.
+    assert "NEW_VAR=" in content
+
+
+def test_main_second_run_after_migration_is_byte_identical(tmp_path, monkeypatch):
+    # Cross-cutting idempotency: a full run that DOES modify things,
+    # followed by an identical second run, must produce zero further
+    # modifications. This is the strongest end-to-end guarantee that
+    # the skill converges.
+    recipe = _make_sample_recipe(tmp_path)
+    (recipe / ".env.example").write_text(
+        f"USE_VERTEX={m.PLACEHOLDER}\n"
+        f"GOOGLE_CLOUD_PROJECT={m.PLACEHOLDER}\n"
+        "LOG_LEVEL=WARN  # user set this deliberately\n",
+        encoding="utf-8",
+    )
+
+    _run_main(monkeypatch, recipe)
+    after_first_run = (recipe / ".env.example").read_bytes()
+
+    _run_main(monkeypatch, recipe)
+    after_second_run = (recipe / ".env.example").read_bytes()
+
+    assert after_first_run == after_second_run
+
+
+# ---------------------------------------------------------------------------
+# Invariant / property-style tests — cut across many code paths at once,
+# guarding the golden rule: user data never mutates, idempotency is total.
+# ---------------------------------------------------------------------------
+
+
+def test_invariant_user_owned_lines_byte_identical_after_any_writer_run(tmp_path):
+    # Sweep across many scenarios (var missing / v1_todo / skill_todo /
+    # skill_real / user_owned × source has real value / no default /
+    # placeholder-shape default). At the end of ALL of them, every line
+    # we classified as USER_OWNED must be byte-identical to what it
+    # was before.
+    env = _write(
+        tmp_path / ".env.example",
+        "# hand-tuned by maintainer\n"
+        "USER_A=real-value-A\n"
+        "USER_B=real-value-B  # inline note\n"
+        "\texport USER_C=real-value-C\n"
+        f"USER_D={m.PLACEHOLDER}  # touched-by-hand, keep as TODO\n"  # V1 TODO + comment → USER_OWNED
+        "\n"
+        "# section 2\n"
+        "USER_E=user-value-E\n",
+    )
+    # Snapshot every line before any run.
+    before_lines = env.read_text(encoding="utf-8").splitlines(keepends=True)
+
+    # Run a mix of scenarios in one call: missing (append), pre-existing
+    # SKILL_TODO getting upgraded, USER_OWNED with source drift.
+    m.update_env_example(
+        env,
+        {
+            # Missing → append (does not touch existing lines).
+            "APPEND_ME": _srcs(("setdefault", "TRUE")),
+            # Every USER_* var also appears in the source scan with a
+            # different value than what the maintainer typed. Golden
+            # rule: skill must never touch these.
+            "USER_A": _srcs(("setdefault", "would-clobber")),
+            "USER_B": _srcs(("setdefault", "would-clobber")),
+            "USER_C": _srcs(("setdefault", "would-clobber")),
+            "USER_D": _srcs(("setdefault", "would-clobber")),
+            "USER_E": _srcs(("setdefault", "would-clobber")),
+        },
+    )
+
+    after_lines = env.read_text(encoding="utf-8").splitlines(keepends=True)
+    # Every ORIGINAL line must still be present, byte-identical.
+    for original_line in before_lines:
+        assert original_line in after_lines, (
+            f"original user-owned line not preserved: {original_line!r}"
+        )
+
+
+def test_invariant_idempotency_across_all_v2_paths(tmp_path):
+    # A single .env.example exercising append, upgrade-v1, upgrade-skill,
+    # skip-user-owned, skip-placeholder-source, skip-drifted-skill-real
+    # in one shot. Run the writer twice; second call must return
+    # ([], []) and file must be byte-identical.
+    env = _write(
+        tmp_path / ".env.example",
+        f"V1_TODO_UPGRADABLE={m.PLACEHOLDER}\n"
+        f"V1_TODO_NO_SOURCE={m.PLACEHOLDER}\n"  # source has no default → skip
+        f"V1_TODO_PLACEHOLDER_SOURCE={m.PLACEHOLDER}\n"  # source has "my-x" → skip
+        f"SKILL_TODO_UPGRADABLE={m.PLACEHOLDER}"
+        f"  # {m.EXTRACTED_MARKER}; no default in source\n"
+        f"SKILL_REAL_DRIFTED=old-value"
+        f"  # {m.EXTRACTED_MARKER}; from setdefault in x.py\n"
+        "USER_OWNED_VAR=user-value\n",
+    )
+
+    env_vars = {
+        "V1_TODO_UPGRADABLE": _srcs(("setdefault", "real")),
+        "V1_TODO_NO_SOURCE": _srcs(("getenv", None)),
+        "V1_TODO_PLACEHOLDER_SOURCE": _srcs(("setdefault", "my-thing")),
+        "SKILL_TODO_UPGRADABLE": _srcs(("setdefault", "TRUE")),
+        "SKILL_REAL_DRIFTED": _srcs(("setdefault", "new-drifted-value")),
+        "USER_OWNED_VAR": _srcs(("setdefault", "would-clobber")),
+        "APPEND_ME": _srcs(("setdefault", "hello")),
+    }
+
+    added1, upgraded1 = m.update_env_example(env, env_vars)
+    content_after_first = env.read_bytes()
+
+    added2, upgraded2 = m.update_env_example(env, env_vars)
+    content_after_second = env.read_bytes()
+
+    # First run: added APPEND_ME; upgraded the two upgradable TODOs.
+    assert set(added1) == {"APPEND_ME"}
+    assert set(upgraded1) == {
+        "V1_TODO_UPGRADABLE",
+        "SKILL_TODO_UPGRADABLE",
+    }
+    # Second run: everything already in its final state.
+    assert added2 == []
+    assert upgraded2 == []
+    assert content_after_first == content_after_second
+
+
+def test_invariant_writer_never_produces_unclassifiable_entries(tmp_path):
+    # Every line the writer touches must re-parse cleanly into one of
+    # the four EntryClassification buckets. This guards against a
+    # malformed line being accidentally emitted (which would then
+    # confuse the classifier on the next run).
+    env = _write(
+        tmp_path / ".env.example",
+        f"V1_TODO={m.PLACEHOLDER}\n",
+    )
+
+    m.update_env_example(
+        env,
+        {
+            "V1_TODO": _srcs(("setdefault", "real")),
+            "APPEND_ME": _srcs(("getenv", "value")),
+            "APPEND_TODO": _srcs(("getenv", None)),
+            "APPEND_DOWNGRADED": _srcs(("setdefault", "my-project-id")),
+        },
+    )
+
+    # Every entry the writer produced must classify as one of the
+    # known buckets. Nothing should be "unclassifiable" (which would
+    # be caught by the round-trip check but is worth belt-and-braces
+    # testing at the invariant level).
+    valid_buckets = {
+        m.EntryClassification.USER_OWNED,
+        m.EntryClassification.V1_TODO,
+        m.EntryClassification.SKILL_TODO,
+        m.EntryClassification.SKILL_REAL,
+    }
+    entries = m.parse_env_example(env)
+    for name, entry in entries.items():
+        assert entry.classification in valid_buckets, (
+            f"{name} classified as unknown bucket: {entry.classification}"
+        )
+
+
+def test_invariant_appended_entries_are_skill_owned(tmp_path):
+    # Every entry APPENDED by the writer must be either SKILL_TODO or
+    # SKILL_REAL — never USER_OWNED (which would mean the skill's own
+    # writes don't carry the marker properly). This closes the loop
+    # so future runs can classify + upgrade correctly.
+    env = tmp_path / ".env.example"
+
+    m.update_env_example(
+        env,
+        {
+            "WITH_DEFAULT": _srcs(("setdefault", "real")),
+            "NO_DEFAULT": _srcs(("getenv", None)),
+            "DOWNGRADED": _srcs(("setdefault", "your-secret")),
+        },
+    )
+
+    entries = m.parse_env_example(env)
+    assert entries["WITH_DEFAULT"].classification == m.EntryClassification.SKILL_REAL
+    assert entries["NO_DEFAULT"].classification == m.EntryClassification.SKILL_TODO
+    assert entries["DOWNGRADED"].classification == m.EntryClassification.SKILL_TODO

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -1,4 +1,4 @@
-name: 🐍 Ruff PR Checks
+name: 🐍 Python Format PR Checks
 
 # Runs Ruff format on changed Python files and posts diff-style
 # suggestion comments via reviewdog. Ruff config lives in the root

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Run pytest
         working-directory: ${{ matrix.recipe }}
-        run: uv run pytest
+        run: uv run pytest --ignore=tests/integration --ignore-glob="**/test_integration.py"
 
   # Final gate. `if: always()` so the required check always reports even when
   # detect-recipes or run-tests were cancelled/skipped/failed — a skipped

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,33 @@
 All agents must follow the guidelines below without being reminded.
 
 ## General
-- Use the term **recipe** instead of **sample**.
-- Do not automatically commit or push changes to github, unless you are explicitly asked to do so.
+- Use the term **recipe** instead of **sample** everywhere — responses,
+  code comments, commit messages, PR descriptions, docs.
+- Recipes live under `core/python/` (curated) or `contrib/` (community).
+  Skills live under `.agents/skills/`. Do NOT mix skill changes and recipe
+  changes in the same PR. If a tool run modifies files outside your task's
+  scope (e.g. a repo-wide ruff sweep touching an unrelated skill), revert
+  those and mention them so the user can decide.
+- When your task is scoped to a specific recipe or skill, stay inside its
+  directory. If you notice similar issues elsewhere, flag them in your
+  response instead of opportunistically fixing them.
+
+## Git
+- Never run `git commit`, `git push`, `git rebase`, `git merge`,
+  `gh pr create`, `gh pr merge`, or any other command that mutates git history
+  or the remote, unless the user's **most recent message** contains an
+  **explicit** request to do that specific action (e.g. "commit this",
+  "push it", "create a PR", "open a PR"). Even a request scoped to the exact
+  paths you have just modified needs the explicit verb.
+- If, after doing the requested work, there are uncommitted changes and you
+  believe they should be committed, **ask first**. Show the diff summary,
+  suggest a commit message, and wait for an explicit "yes, commit" or
+  "yes, push".
+- Safe read-only git commands are always fine: `git status`, `git diff`,
+  `git log`, `git show`, `git branch`, `gh pr view`, `gh pr list`.
+- Reverting your own uncommitted work (`git checkout <path>` on a working-tree
+  change you made in this session) is also fine — it undoes, it doesn't
+  mutate history.
 
 ## Models
 - Do NOT use `gemini-2.0-flash` or `gemini-2.5-flash` — both are deprecated. Use `gemini-3.5-flash` instead.
@@ -12,5 +37,10 @@ All agents must follow the guidelines below without being reminded.
 - Python recipes go under `contrib/` or `core/python`
 - Minimum python version: 3.11
 - Package manager: Use `uv`, not `pip`
-- Formatter: Use `ruff` (line length 80, double quotes)
-- Do not rely on .env being present for the unit tests. However, .env.example files are present for each recipe and the unit tests can rely on those.
+- Formatter/linter: `ruff` — line length 80, double quotes. Config lives
+  in the root `pyproject.toml`; never create a standalone `ruff.toml` or
+  `.ruff.toml` inside a recipe.
+- Test runner: `pytest`.
+- Do not rely on `.env` being present for the unit tests. However,
+  `.env.example` files are present for each recipe and the unit tests can
+  rely on those.

--- a/core/python/ambient-expense-agent/.env.example
+++ b/core/python/ambient-expense-agent/.env.example
@@ -18,11 +18,20 @@ GOOGLE_GENAI_USE_VERTEXAI=False
 # ADK_TRIGGER_MAX_RETRIES=3
 
 # Environment variables extracted by extract-python-environment-variables
-APP_NAME=<TODO: update-this-value>
-BACKEND_URL=<TODO: update-this-value>
-PORT=<TODO: update-this-value>
-PUBSUB_SUBSCRIPTION=<TODO: update-this-value>
-USE_SERVICE_AUTH=<TODO: update-this-value>
+APP_NAME=expense_agent  # extracted-by:extract-env-vars; from environ_get in frontend/main.py
+BACKEND_URL=http://localhost:8080  # extracted-by:extract-env-vars; from environ_get in frontend/main.py
+# PORT is injected automatically by Cloud Run per-container in production
+# and picked up by both services. Do NOT set PORT in .env for local dev:
+# both services read it, so a single PORT value collapses backend + frontend
+# onto one port and they collide. Local defaults (8080 backend, 8081 frontend)
+# are fine as-is. To override the frontend locally, set FRONTEND_PORT below.
+FRONTEND_PORT=8081  # local-only override for the approval UI; ignored in Cloud Run (falls back to PORT)
+PUBSUB_SUBSCRIPTION=test-sub  # extracted-by:extract-env-vars; from environ_get in frontend/main.py
+USE_SERVICE_AUTH=false  # extracted-by:extract-env-vars; from environ_get in frontend/main.py
 
 # Renamed from hardcoded string in source. Rename the variable if needed.
 MODEL_NAME=gemini-3.5-flash
+
+# Environment variables extracted by extract-python-environment-variables
+GOOGLE_CLOUD_LOCATION=global  # extracted-by:extract-env-vars; from setdefault in expense_agent/config.py
+GOOGLE_CLOUD_PROJECT=<TODO: update-this-value>  # extracted-by:extract-env-vars; no default in source

--- a/core/python/ambient-expense-agent/frontend/main.py
+++ b/core/python/ambient-expense-agent/frontend/main.py
@@ -206,8 +206,16 @@ async def approve(request: Request):
 
 
 if __name__ == "__main__":
-    uvicorn.run(
-        app,
-        host="0.0.0.0",
-        port=int(os.environ.get("PORT", "8081")),
+    # Port resolution:
+    #   * Cloud Run injects PORT into every container, so honouring it is
+    #     required for the deployed frontend to receive traffic.
+    #   * Locally, the backend also reads PORT (with default 8080). If both
+    #     services shared a single PORT from .env, they'd collide on one
+    #     port. FRONTEND_PORT is the local-only escape hatch: set it in
+    #     .env alongside a distinct PORT for the backend to keep the two
+    #     services on separate ports. Default 8081 preserves the original
+    #     behaviour for a plain `make dev-frontend` with no env config.
+    port = int(
+        os.environ.get("FRONTEND_PORT") or os.environ.get("PORT", "8081")
     )
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/core/python/deep-search/.env.example
+++ b/core/python/deep-search/.env.example
@@ -17,3 +17,7 @@ GOOGLE_GENAI_USE_VERTEXAI=False
 
 # Renamed from hardcoded string in source. Rename the variable if needed.
 MODEL_NAME=gemini-3.5-flash
+
+# Environment variables extracted by extract-python-environment-variables
+GOOGLE_CLOUD_LOCATION=global  # extracted-by:extract-env-vars; from setdefault in app/__init__.py
+GOOGLE_CLOUD_PROJECT=<TODO: update-this-value>  # extracted-by:extract-env-vars; no default in source

--- a/core/python/genmedia-for-commerce/.env.example
+++ b/core/python/genmedia-for-commerce/.env.example
@@ -1,17 +1,17 @@
 
 # Environment variables extracted by extract-python-environment-variables
-ADK_WEB_UI=<TODO: update-this-value>
+ADK_WEB_UI=false  # extracted-by:extract-env-vars; from getenv in genmedia4commerce/fast_api_app.py
 ALLOW_ORIGINS=<TODO: update-this-value>
-COMMIT_SHA=<TODO: update-this-value>
+COMMIT_SHA=dev  # extracted-by:extract-env-vars; from environ_get in genmedia4commerce/app_utils/telemetry.py
 EMBEDDING_MODEL=<TODO: update-this-value>
 FINETUNE_BASE_MODEL=<TODO: update-this-value>
-FINETUNE_EPOCHS=<TODO: update-this-value>
-FINETUNE_LORA_RANK=<TODO: update-this-value>
-FINETUNE_LR_MULTIPLIER=<TODO: update-this-value>
-FINETUNE_VERSION=<TODO: update-this-value>
-GENAI_LOCATION=<TODO: update-this-value>
-GENAI_TELEMETRY_PATH=<TODO: update-this-value>
-GLOBAL_REGION=<TODO: update-this-value>
+FINETUNE_EPOCHS=10  # extracted-by:extract-env-vars; from getenv in infra/model_training/finetune_gemini_lora.py
+FINETUNE_LORA_RANK=2  # extracted-by:extract-env-vars; from getenv in infra/model_training/finetune_gemini_lora.py
+FINETUNE_LR_MULTIPLIER=0.5  # extracted-by:extract-env-vars; from getenv in infra/model_training/finetune_gemini_lora.py
+FINETUNE_VERSION=1  # extracted-by:extract-env-vars; from getenv in infra/model_training/finetune_gemini_lora.py
+GENAI_LOCATION=europe-west4  # extracted-by:extract-env-vars; from getenv in infra/model_training/eval_gemini_lora.py
+GENAI_TELEMETRY_PATH=completions  # extracted-by:extract-env-vars; from environ_get in genmedia4commerce/app_utils/telemetry.py
+GLOBAL_REGION=global  # extracted-by:extract-env-vars; from getenv in genmedia4commerce/agents/style_advisor_agent/agent.py
 GOOGLE_API_KEY=<TODO: update-this-value>
 # LLM endpoint region. "global" routes to the nearest region automatically.
 # Override with a specific region (e.g. us-central1) if needed.
@@ -21,13 +21,13 @@ GOOGLE_CLOUD_PROJECT=<TODO: update-this-value>
 # (AI Studio), "True" when using Vertex AI. Override only if needed.
 GOOGLE_GENAI_USE_VERTEXAI=True
 LOGS_BUCKET_NAME=<TODO: update-this-value>
-MCP_SERVER_PORT=<TODO: update-this-value>
-MCP_SERVER_URL=<TODO: update-this-value>
+MCP_SERVER_PORT=8081  # extracted-by:extract-env-vars; from getenv in genmedia4commerce/fast_api_app.py
+MCP_SERVER_URL=http://localhost:8081/sse  # extracted-by:extract-env-vars; from getenv in genmedia4commerce/agents/style_advisor_agent/agent.py
 MULTIMODAL_EMBEDDING_MODEL=<TODO: update-this-value>
-OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=<TODO: update-this-value>
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false  # extracted-by:extract-env-vars; from environ_get in genmedia4commerce/app_utils/telemetry.py
 PROJECT_ID=<TODO: update-this-value>
 SHOE_CLASSIFICATION_ENDPOINT=<TODO: update-this-value>
-US_REGION=<TODO: update-this-value>
+US_REGION=us-central1  # extracted-by:extract-env-vars; from getenv in genmedia4commerce/workflows/shared/vector_search.py
 
 # Renamed from hardcoded string in source. Rename the variable if needed.
 MODEL_NAME_GENERATED_1=gemini-2.5-flash
@@ -38,3 +38,10 @@ MODEL_NAME_GENERATED_5=gemini-3.1-flash-image-preview
 MODEL_NAME_GENERATED_6=gemini-embedding-001
 MODEL_NAME_GENERATED_7=gemini-embedding-2-preview
 MODEL_NAME_GENERATED_8=imagen-4.0-upscale-preview
+
+# Environment variables extracted by extract-python-environment-variables
+OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload  # extracted-by:extract-env-vars; from setdefault in genmedia4commerce/app_utils/telemetry.py
+OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH=<TODO: update-this-value>  # extracted-by:extract-env-vars; no default in source
+OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT=jsonl  # extracted-by:extract-env-vars; from setdefault in genmedia4commerce/app_utils/telemetry.py
+OTEL_RESOURCE_ATTRIBUTES=<TODO: update-this-value>  # extracted-by:extract-env-vars; no default in source
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental  # extracted-by:extract-env-vars; from setdefault in genmedia4commerce/app_utils/telemetry.py

--- a/core/python/oauth-user-consent-flow/.env.example
+++ b/core/python/oauth-user-consent-flow/.env.example
@@ -1,8 +1,8 @@
 
-AUTH_ID=<TODO: update-this-value>
-COMMIT_SHA=<TODO: update-this-value>
+AUTH_ID=google-drive-auth  # extracted-by:extract-env-vars; from environ_get in app/auths.py
+COMMIT_SHA=dev  # extracted-by:extract-env-vars; from environ_get in app/app_utils/telemetry.py
 ENDPOINT_LOCATION=<TODO: update-this-value>
-GENAI_TELEMETRY_PATH=<TODO: update-this-value>
+GENAI_TELEMETRY_PATH=completions  # extracted-by:extract-env-vars; from environ_get in app/app_utils/telemetry.py
 GOOGLE_CLOUD_PROJECT=<TODO: update-this-value>
 # LLM endpoint region. "global" routes to the nearest region automatically.
 GOOGLE_CLOUD_LOCATION=global
@@ -11,6 +11,14 @@ GOOGLE_GENAI_USE_VERTEXAI=True
 LOGS_BUCKET_NAME=<TODO: update-this-value>
 OAUTH_CLIENT_ID=<TODO: update-this-value>
 OAUTH_CLIENT_SECRET=<TODO: update-this-value>
-OAUTH_TOKEN_URI=<TODO: update-this-value>
-OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=<TODO: update-this-value>
+OAUTH_TOKEN_URI=https://oauth2.googleapis.com/token  # extracted-by:extract-env-vars; from environ_get in tools/register_oauth.py
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false  # extracted-by:extract-env-vars; from environ_get in app/app_utils/telemetry.py
 MODEL_NAME=gemini-3.5-flash
+
+# Environment variables extracted by extract-python-environment-variables
+GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY=true  # extracted-by:extract-env-vars; from setdefault in app/app_utils/telemetry.py
+OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload  # extracted-by:extract-env-vars; from setdefault in app/app_utils/telemetry.py
+OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH=<TODO: update-this-value>  # extracted-by:extract-env-vars; no default in source
+OTEL_INSTRUMENTATION_GENAI_UPLOAD_FORMAT=jsonl  # extracted-by:extract-env-vars; from setdefault in app/app_utils/telemetry.py
+OTEL_RESOURCE_ATTRIBUTES=<TODO: update-this-value>  # extracted-by:extract-env-vars; no default in source
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental  # extracted-by:extract-env-vars; from setdefault in app/app_utils/telemetry.py

--- a/docs/recipe-guidelines.md
+++ b/docs/recipe-guidelines.md
@@ -91,10 +91,55 @@ uv run validate manifest core/python/my-recipe
 uv run ruff format core/python/my-recipe && uv run ruff check core/python/my-recipe
 ```
 
-To run recipe tests:
+To run recipe tests (mirroring what CI does — integration tests excluded):
 
 ```bash
-cd core/python/my-recipe && uv run pytest
+cd core/python/my-recipe
+uv run pytest --ignore=tests/integration --ignore-glob="**/test_integration.py"
+```
+
+## Tests
+
+### Runnability test (required)
+
+Every Python recipe **must** contain `tests/test_runnability.py`. This is a
+lightweight smoke test that imports the recipe's agent module and asserts that
+`root_agent` is not `None` (and `app is not None` if the recipe defines one).
+It does not make real API calls — import-time side effects such as
+`vertexai.init` and `google.auth.default` are mocked automatically by the
+generated test.
+
+Generate or regenerate it with the `generate-python-runnability-test` skill:
+
+```
+"generate runnability test for core/python/my-recipe"
+```
+
+CI enforces its presence: a recipe without `tests/test_runnability.py` fails
+the `python-tests.yml` check.
+
+### Integration tests (skipped in CI)
+
+The `python-tests.yml` workflow excludes integration tests so the required PR
+check stays fast and credential-free. Two patterns are always excluded:
+
+| Pattern | What is excluded |
+|---------|-----------------|
+| `tests/integration/` | The entire directory and everything beneath it. |
+| `**/test_integration.py` | Any file with that exact name, at any depth. |
+
+Place any test that makes real API calls (Vertex AI, Cloud Storage, etc.) in
+one of those locations. They will not block the PR check but can be run
+locally:
+
+```bash
+cd core/python/my-recipe
+
+# Run only integration tests
+uv run pytest tests/integration
+
+# Run the full suite including integration tests
+uv run pytest
 ```
 
 ## What CI runs
@@ -111,3 +156,8 @@ Two workflows validate every PR that touches a recipe:
   `[project]` metadata check, and the hardcoded-model-name notice.
   Structural checks (folder name, size, required files, manifest schema)
   are NOT re-run here — the structure workflow already handles them.
+- **`python-tests.yml`** — runs `pytest` for every Python recipe touched
+  by the PR (or all recipes on a manual `workflow_dispatch`). Requires
+  `tests/test_runnability.py` to exist. Integration tests under
+  `tests/integration/` and files named `test_integration.py` are
+  automatically excluded.


### PR DESCRIPTION
## Summary

Upgrades the `extract-python-environment-variables` skill from v2.0 to v2.1 and hardens it against real-world edge cases discovered by dry-running it against every Python recipe in `core/python/`. Along the way, fixes 3 categories of skill bugs (all with regression tests) and 1 recipe-level bug, and adds 60 new tests bringing total coverage to 168.

The headline v2.1 feature: **upgrade stale `<TODO>` entries in `.env.example` in place** when source can now supply a real default (v1-era TODOs and skill-authored TODOs alike). This closes the discoverability loop for recipes that were already processed by v1.

## v2.1 skill upgrade

- **In-place upgrade of stale TODOs** — v1-era `<TODO: update-this-value>` entries (no marker, no inline comment) and skill-authored TODOs are now rewritten with the resolved source default. Only upgrades to real values (never TODO → TODO). User-owned lines are still ironclad-preserved.
- **`Source` provenance model** — every AST-level env-var access captures `(file, kind, default, line)` so the resolver can pick a deterministic winner and the writer can put provenance in the marker comment.
- **Fail-closed classifier** (5 buckets: MISSING / USER_OWNED / V1_TODO / SKILL_TODO / SKILL_REAL) — anything ambiguous defaults to USER_OWNED.
- **Fail-closed rewriter** — refuses quoted values, backslash continuation, duplicate declarations. Preserves `export` prefix, indentation, CRLF endings, and byte-identity of all non-touched lines.
- **Round-trip safety check** — after building new file contents, re-parses to verify every planned upgrade classifies as SKILL_REAL. Any mismatch aborts the write.
- **Priority resolver** — `setdefault` (process-wide commitment) beats `getenv`/`environ.get` fallbacks (per-read), with alphabetical file tie-break.
- **Conservative placeholder heuristic** — downgrades obvious stubs (`my-project-id`, `changeme`, `example.com`, etc.) to TODO with the source string preserved in the marker comment.

## Bugs found via real-recipe testing (all fixed + regression-tested)

Each of these was discovered by dry-running the skill against a real recipe and eyeballing the diff — not by any unit test:

1. **Kwarg default extraction gap** — `os.getenv("X", default="y")` silently missed the default. Fixed with a `_default_from_call()` helper that checks positional first, then falls back to `default=` keyword.
2. **CRLF-to-LF silent conversion** — `Path.read_text()` uses universal-newlines mode, which would rewrite every `\r\n` to `\n` on any Windows-authored `.env.example`. Fixed with `_read_text_preserving_newlines()` and `newline=""` on write.
3. **Model-in-getenv-default corruption** (found via genmedia-for-commerce) — the model-replacement path was rewriting string literals that were already serving as `os.getenv(...)` default arguments. Would have corrupted 5 source files by changing `str` return types to `str | None`. Fixed with `_getenv_default_node_ids()` exclusion set.
4. **conftest.py scanned as application code** (found via oauth-user-consent-flow) — root-level `conftest.py` isn't in a `tests/` directory, so the directory-based exclusion missed it. Test-infrastructure env vars like `INTEGRATION_TEST` were leaking into `.env.example`. Fixed with a new `SKIP_FILES` frozenset for reserved pytest filenames.

## Recipe updates included

- **`ambient-expense-agent`** — real recipe-level bug fix (PORT env var was read by both backend and frontend with different defaults; local `make dev` + `make dev-frontend` would collide). Frontend now uses `FRONTEND_PORT` as a local override, falling back to `PORT` for Cloud Run compatibility.
- **`ambient-expense-agent`, `deep-search`, `genmedia-for-commerce`, `oauth-user-consent-flow`** — `.env.example` updates from applying the v2.1 skill (stale TODOs upgraded to real defaults, new OTEL/telemetry vars appended, all user-owned lines preserved byte-perfect).

## Test coverage

**108 → 168 tests (+60), all green.** New tests cover:

- **AST detection edge cases** — kwarg defaults, aliased imports (`import os as o`), from-imports (`from os import getenv`), nested calls, non-`os` objects with `.getenv`, empty file list.
- **Classifier** — all 5 buckets × export prefix × indentation × whitespace padding × empty value × malformed lines × missing file × first-occurrence-wins on duplicates.
- **Rewriter** — empty lines list, similar-prefixed var names (FOO vs FOO_BAR), byte-preservation of non-matching lines, tab-around-`=`, no-trailing-newline, CRLF preservation, quoted-value refusal, continuation-line refusal, multi-match refusal.
- **Round-trip safety** — forced-corruption test (monkeypatch the rewriter to produce garbage, verify the writer refuses to write and file stays byte-identical).
- **Invariants** — user-owned lines byte-identical after any writer run; total idempotency across all v2/v2.1 paths; writer never produces unclassifiable entries; appended entries are always skill-owned.
- **Model-replacement bug regression** — positional/kwarg getenv defaults skipped, environ.get/setdefault defaults skipped, true hardcoded literals still detected.
- **conftest.py exclusion regression** — file skipped at any level, env vars in it never surface.

## Known limitations (deferred; not blocking)

Two patterns surfaced during real-recipe testing that we deliberately chose not to fix in this PR:

- **Commented-out declarations** (seen in `ambient-expense-agent`, `deep-search`): `# VAR=value` lines aren't declarations to the parser, so if source references `VAR` the skill appends a duplicate. Fix would be a `v2.2` feature that recognizes commented-out lines as "maintainer-acknowledged, don't append."
- **Internal test-toggle vars** (seen in `rag-agent-search`, `rag-vector-search`): env vars like `INTEGRATION_TEST` that are read by application code as test-mode switches shouldn't be user-facing config. Fix would be an opt-out mechanism (per-recipe skiplist or naming convention).

Both are known behaviors, documented in the code, and don't produce incorrect output — just UX friction. Building them now would add complexity for a small user base; revisit if the patterns show up on more recipes.

## Testing done

- Full test suite: **168/168 passing** (`pytest .agents/skills/extract-python-environment-variables/tests/`)
- Dry-run + eyeball across `core/python/`: safety-plugins, deep-search, ambient-expense-agent, genmedia-for-commerce, oauth-user-consent-flow, rag-agent-search, rag-vector-search (7 recipes)
- Idempotency verified on every recipe applied (second run produces byte-identical file)
- Recipe tests still pass where applied (e.g. ambient-expense-agent's 5 tests still green after the PORT fix)