### PR TITLE
Fix boolean parsing for RAG pipeline flags

### DIFF
--- a/core/rag-vector-search/data_ingestion/data_ingestion_pipeline/submit_pipeline.py
+++ b/core/rag-vector-search/data_ingestion/data_ingestion_pipeline/submit_pipeline.py
@@ -31,6 +31,23 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _str_to_bool(value: str) -> bool:
+    """Parse common string boolean values."""
+
+    if isinstance(value, bool):
+        return value
+
+    normalized_value = value.lower()
+    if normalized_value in ("true", "t", "1", "yes", "y"):
+        return True
+    if normalized_value in ("false", "f", "0", "no", "n"):
+        return False
+
+    raise argparse.ArgumentTypeError(
+        "expected one of: true, false, 1, 0, yes, no"
+    )
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments for pipeline configuration."""
 
@@ -70,9 +87,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--disable-caching",
-        type=bool,
+        type=_str_to_bool,
         default=os.getenv("DISABLE_CACHING", "false").lower() == "true",
-        help="Enable pipeline caching",
+        help="Disable pipeline caching",
     )
     parser.add_argument(
         "--cron-schedule",
@@ -81,7 +98,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--schedule-only",
-        type=bool,
+        type=_str_to_bool,
         default=os.getenv("SCHEDULE_ONLY", "false").lower() == "true",
         help="Schedule only (do not submit)",
     )


### PR DESCRIPTION
## Summary

- parse the RAG vector search pipeline boolean flags explicitly
- keep values like `--disable-caching false` and `--schedule-only false` from being treated as true
- fix the `--disable-caching` help text while touching that option

## Testing

- `python3 -m py_compile core/rag-vector-search/data_ingestion/data_ingestion_pipeline/submit_pipeline.py`
- checked `_str_to_bool` with `false`, `TRUE`, and `0`
