### PR TITLE
docs: move style guide out of docs/ into .github/style.md

### DIFF
--- a/.github/style.md
+++ b/.github/style.md
@@ -84,11 +84,10 @@ Adjust the relative paths for pages under subdirectories
 (e.g. `languages/` uses `../../recipe-checklist.md` and
 `../README.md`).
 
-**Non-handbook docs** (`_STYLE.md`, `recipe-checklist.md`,
+**Non-handbook docs** (`recipe-checklist.md`,
 `recipe-handbook/README.md`, `docs/README.md`) also carry a
 footer for consistency, but link only where it makes sense — the
-handbook README self-links to itself for symmetry; `_STYLE.md`
-uses a checklist + handbook footer.
+handbook README self-links to itself for symmetry.
 
 ## Link text
 
@@ -113,4 +112,4 @@ uses a checklist + handbook footer.
 
 ---
 
-← [Checklist](./recipe-checklist.md) · [Handbook](./recipe-handbook/README.md)
+← [Checklist](../docs/recipe-checklist.md) · [Handbook](../docs/recipe-handbook/README.md)


### PR DESCRIPTION
`docs/_STYLE.md` is an internal contributor document — rules for
writing and editing docs, not a page contributors are meant to read.
Having it sit alongside the public-facing docs in `docs/` made it
more visible than it should be.

## What changed

- `docs/_STYLE.md` → `.github/style.md`
- Two self-references inside the file updated to drop the `_` prefix
- Footer links corrected for the new relative path from `.github/`

No other file linked to `_STYLE.md`, so nothing else needed updating.

## Why `.github/`

`.github/` is the established home for internal repo process files
(`CODEOWNERS`, `policy.yml`, issue templates, workflows). A style
guide for doc contributors fits naturally there. It remains
accessible to anyone who needs it but no longer shows up when
browsing `docs/` on GitHub.