### PR TITLE
docs(long-horizon-harness): fix quickstart paste error, sparse clone, dev ready banner

### DIFF
--- a/core/python/long-horizon-harness/Makefile
+++ b/core/python/long-horizon-harness/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dev dev-backend dev-web dev-local dev-backend-local dev-sandbox dev-backend-sandbox \
-        dev-preflight dev-stop \
+        dev-preflight dev-ready dev-stop \
         setup build-web deploy deploy-web deploy-backend deploy-all destroy commands-catalog help
 
 BACKEND_PORT             ?= 8001
@@ -107,7 +107,25 @@ dev: dev-preflight
 	@trap 'kill 0' INT TERM EXIT; \
 	{ $(MAKE) --no-print-directory $(DEV_BACKEND_TARGET) 2>&1 | sed -u 's/^/[backend] /'; echo "[backend] exited — stopping dev stack"; kill 0; } & \
 	{ $(MAKE) --no-print-directory dev-web               2>&1 | sed -u 's/^/[web]     /'; echo "[web]     exited — stopping dev stack"; kill 0; } & \
+	$(MAKE) --no-print-directory dev-ready & \
 	wait
+
+# The first run interleaves npm install + uv sync output for minutes, so vite's
+# own URL banner scrolls away long before the stack is usable. Any HTTP reply
+# (404 included) means the port is bound, so plain `curl -s` is the readiness
+# probe. Dies with the stack via `dev`'s `kill 0` trap.
+dev-ready:
+	@command -v curl >/dev/null 2>&1 || exit 0; \
+	i=0; \
+	while [ $$i -lt 600 ]; do \
+	  if curl -s -o /dev/null http://127.0.0.1:$(BACKEND_PORT) && curl -s -o /dev/null http://127.0.0.1:$(WEB_PORT); then \
+	    echo ""; \
+	    echo ">> ready — open http://localhost:$(WEB_PORT)  (backend http://127.0.0.1:$(BACKEND_PORT))"; \
+	    echo ""; \
+	    exit 0; \
+	  fi; \
+	  i=$$((i+1)); sleep 1; \
+	done
 
 # .env wins; the -local/-sandbox variants below force a value instead.
 DEV_BACKEND_ENV ?= $${LHA_ENVIRONMENT_BACKEND:-$(LHA_ENVIRONMENT_BACKEND)}

--- a/core/python/long-horizon-harness/README.md
+++ b/core/python/long-horizon-harness/README.md
@@ -66,20 +66,24 @@ Full subsystem walkthrough: [`docs/architecture.md`](docs/architecture.md).
 
 [uv](https://docs.astral.sh/uv/getting-started/installation/), [google-agents-cli](https://pypi.org/project/google-agents-cli/) (`uv tool install google-agents-cli` — provides the `agents-cli` command), [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), `make`, and Node.js 20.19+ or 22.12+ (Vite 8 — web UI only). On Windows, use WSL.
 
+Plus a **GCP project with billing enabled** — inference runs on Vertex. These are one-time setup; skip any you've already done:
+
+```bash
+gcloud auth application-default login             # local credentials for Vertex
+gcloud config set project YOUR_PROJECT_ID         # skip if your gcloud default is already the right project
+gcloud services enable aiplatform.googleapis.com  # the Vertex AI API
+```
+
 ### Setup and run
 
 ```bash
-# 1. Clone and enter this sample
-git clone https://github.com/google/adk-samples.git
-cd adk-samples/core/python/long-horizon-harness
+# 1. Clone just this sample
+git clone --depth 1 --filter=blob:none --sparse https://github.com/google/adk-samples.git
+cd adk-samples && git sparse-checkout set core/python/long-horizon-harness
+cd core/python/long-horizon-harness
 
-# 2. GCP access for Vertex inference (needs a project with BILLING enabled)
-gcloud auth application-default login
-gcloud config set project <your-project-id>          # or leave your gcloud default
-gcloud services enable aiplatform.googleapis.com     # the Vertex AI API
-
-# 3. Run — the first run installs deps and seeds .env from .env.example
-make dev-local                                 # backend :8001 + web UI :3000
+# 2. Run — the first run installs deps and seeds .env from .env.example
+make dev-local
 ```
 
 Open <http://localhost:3000>, or run one-shot from the terminal with `agents-cli run "your prompt"`. To install without starting servers: `make setup`.


### PR DESCRIPTION
## Summary

- `gcloud config set project <your-project-id>` is a parse error when pasted — the shell reads `<...>` as a redirect pair, so zsh says ``parse error near `\n'`` and bash `syntax error near unexpected token 'newline'`. It aborts the paste, so `gcloud services enable` below it never runs.
- One-time gcloud setup moved into Prerequisites, framed as skippable. Setup and run is now two steps: clone, run.
- Clone via sparse partial clone — 1.9s / 9.6 MB vs 6.4s / 137 MB for `--depth 1` of the whole repo (measured). Needs git 2.27+.
- `make dev` announces the ~30s wait, then prints a full-width READY block with the URL. A first run buried vite's own banner under minutes of install output.
- The web UI now starts only once the backend is listening. vite proxies `/.well-known`, `/a2a`, `/lha` from boot, so a cold start printed a wall of ECONNREFUSED stack traces that read like a crash.
- Post-quickstart prose says Agent Platform, not Vertex, and drops the paragraph repeating the URL the banner now prints.

## Testing

Makefile changes exercised with stubbed servers (backend binding after a delay): vite starts only after the backend answers, the banner fires when both ports respond, and everything dies with the stack via the existing `kill 0` trap. The real Agent Platform-backed stack was not run.
