### PR TITLE
fix(long-horizon-harness): make the dev startup legible

### DIFF
--- a/core/python/long-horizon-harness/Makefile
+++ b/core/python/long-horizon-harness/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dev dev-backend dev-web dev-local dev-backend-local dev-sandbox dev-backend-sandbox \
-        dev-preflight dev-ready dev-stop \
+        dev-preflight dev-ready dev-web-wait dev-stop \
         setup build-web deploy deploy-web deploy-backend deploy-all destroy commands-catalog help
 
 BACKEND_PORT             ?= 8001
@@ -104,9 +104,13 @@ dev-stop:
 # web server down with it instead of leaving a stack that only looks alive.
 # (`wait -n` would be the one-liner, but /bin/sh here is bash 3.2.)
 dev: dev-preflight
+	@echo ""
+	@echo ">> starting the dev stack — ready in ~30s (a first run installs deps first, so longer)"
+	@echo ">> the web UI starts once the backend is listening on :$(BACKEND_PORT)"
+	@echo ""
 	@trap 'kill 0' INT TERM EXIT; \
 	{ $(MAKE) --no-print-directory $(DEV_BACKEND_TARGET) 2>&1 | sed -u 's/^/[backend] /'; echo "[backend] exited — stopping dev stack"; kill 0; } & \
-	{ $(MAKE) --no-print-directory dev-web               2>&1 | sed -u 's/^/[web]     /'; echo "[web]     exited — stopping dev stack"; kill 0; } & \
+	{ $(MAKE) --no-print-directory dev-web-wait          2>&1 | sed -u 's/^/[web]     /'; echo "[web]     exited — stopping dev stack"; kill 0; } & \
 	$(MAKE) --no-print-directory dev-ready & \
 	wait
 
@@ -120,12 +124,34 @@ dev-ready:
 	while [ $$i -lt 600 ]; do \
 	  if curl -s -o /dev/null http://127.0.0.1:$(BACKEND_PORT) && curl -s -o /dev/null http://127.0.0.1:$(WEB_PORT); then \
 	    echo ""; \
-	    echo ">> ready — open http://localhost:$(WEB_PORT)  (backend http://127.0.0.1:$(BACKEND_PORT))"; \
+	    echo "=================================================================="; \
+	    echo ""; \
+	    echo "   READY — open the web UI:"; \
+	    echo ""; \
+	    echo "       http://localhost:$(WEB_PORT)"; \
+	    echo ""; \
+	    echo "   backend   http://127.0.0.1:$(BACKEND_PORT)"; \
+	    echo "   stop      Ctrl-C"; \
+	    echo ""; \
+	    echo "=================================================================="; \
 	    echo ""; \
 	    exit 0; \
 	  fi; \
 	  i=$$((i+1)); sleep 1; \
 	done
+
+# vite proxies /.well-known, /a2a and /lha to the backend from the moment it
+# boots, so starting it first buries the terminal in ECONNREFUSED stack traces
+# until uvicorn binds. npm install still runs in parallel (the prerequisite);
+# only the server start waits.
+dev-web-wait: web/node_modules
+	@if command -v curl >/dev/null 2>&1; then \
+	  i=0; \
+	  while [ $$i -lt 600 ] && ! curl -s -o /dev/null http://127.0.0.1:$(BACKEND_PORT); do \
+	    i=$$((i+1)); sleep 1; \
+	  done; \
+	fi; \
+	$(MAKE) --no-print-directory dev-web
 
 # .env wins; the -local/-sandbox variants below force a value instead.
 DEV_BACKEND_ENV ?= $${LHA_ENVIRONMENT_BACKEND:-$(LHA_ENVIRONMENT_BACKEND)}

--- a/core/python/long-horizon-harness/README.md
+++ b/core/python/long-horizon-harness/README.md
@@ -52,7 +52,7 @@ Long Horizon shows how to build a long-horizon harness on ADK with capabilities 
 | **Frontend** | Vite 8 + TanStack Router/Query + React 18 |
 | **Surface** | Cloud Run + Cloud SQL + Cloud Scheduler — Cloud Run scales to zero between turns (Cloud SQL bills continuously) |
 
-Custom code earns its keep in a handful of **interfaces** on top of the managed primitives: the tool-guardrail chain, the `Environment` ContextVar sandbox layer, the per-user secret store, the dynamic delegate + HITL resurfacing, the three-tier system-prompt assembler, and the self-improvement loop layered on managed Memory Bank (throttled judge fork, pre-compaction flush, nightly dream-review; see [`docs/memory.md`](docs/memory.md)). Compaction, resumability, and prefix caching are ADK/Vertex knobs Horizon only configures; routines and the scheduler are applications composed from the interfaces. (Those interfaces are the rows in [`AGENTS.md`](AGENTS.md).)
+Custom code earns its keep in a handful of **interfaces** on top of the managed primitives: the tool-guardrail chain, the `Environment` ContextVar sandbox layer, the per-user secret store, the dynamic delegate + HITL resurfacing, the three-tier system-prompt assembler, and the self-improvement loop layered on managed Memory Bank (throttled judge fork, pre-compaction flush, nightly dream-review; see [`docs/memory.md`](docs/memory.md)). Compaction, resumability, and prefix caching are ADK/Agent Platform knobs Horizon only configures; routines and the scheduler are applications composed from the interfaces. (Those interfaces are the rows in [`AGENTS.md`](AGENTS.md).)
 
 Full subsystem walkthrough: [`docs/architecture.md`](docs/architecture.md).
 
@@ -66,12 +66,12 @@ Full subsystem walkthrough: [`docs/architecture.md`](docs/architecture.md).
 
 [uv](https://docs.astral.sh/uv/getting-started/installation/), [google-agents-cli](https://pypi.org/project/google-agents-cli/) (`uv tool install google-agents-cli` — provides the `agents-cli` command), [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), `make`, and Node.js 20.19+ or 22.12+ (Vite 8 — web UI only). On Windows, use WSL.
 
-Plus a **GCP project with billing enabled** — inference runs on Vertex. These are one-time setup; skip any you've already done:
+Plus a **GCP project with billing enabled**. These are one-time setup; skip any you've already done:
 
 ```bash
-gcloud auth application-default login             # local credentials for Vertex
+gcloud auth application-default login             # local credentials for inference
 gcloud config set project YOUR_PROJECT_ID         # skip if your gcloud default is already the right project
-gcloud services enable aiplatform.googleapis.com  # the Vertex AI API
+gcloud services enable aiplatform.googleapis.com  # the API Agent Platform serves from
 ```
 
 ### Setup and run
@@ -86,15 +86,20 @@ cd core/python/long-horizon-harness
 make dev-local
 ```
 
-Open <http://localhost:3000>, or run one-shot from the terminal with `agents-cli run "your prompt"`. To install without starting servers: `make setup`.
+`make dev-local` is the simplest start: tools run on your host, sessions stay in memory, nothing is provisioned in GCP. The trade-off is **no cross-session memory** and **no sandbox isolation** — tools run directly on your machine. Inference goes to Agent Platform either way; there is no local model, `local` only moves *tool execution* to your host.
 
-> **Cost:** the test suites (`tests/unit` / `tests/integration`) run free with no GCP. Everything else calls **Vertex, which is billed per token**, so you need a project with billing enabled. `make deploy` additionally stands up always-on resources (Cloud SQL, Cloud Scheduler) — see [Deploy](#deploy) for teardown.
+Other ways to run it:
 
-`make dev-local` is the simplest way to start: tools run on your host, sessions stay in-process, and no sandbox, Agent Platform Sessions, or Cloud SQL is provisioned. The trade-off is **no cross-session memory** and **no isolated sandbox** (tools run directly on your machine); inference still calls Vertex (there is no local model — `local` only moves **tool execution** to your host). If `GOOGLE_CLOUD_PROJECT` is blank in `.env`, `make dev` falls back to your active `gcloud` project; switch to the Agent Platform sandbox with `LHA_ENVIRONMENT_BACKEND=sandbox` (or `make dev-sandbox`).
+- `agents-cli run "your prompt"` — one shot from the terminal, no web UI
+- `make dev-sandbox` — tools run in the per-user Agent Platform sandbox
+
+`make setup` installs deps and seeds `.env` without starting anything. The project comes from `GOOGLE_CLOUD_PROJECT` in `.env`, falling back to your active `gcloud` project.
+
+> **Cost:** every turn is billed per token; only the test suites (`tests/unit` / `tests/integration`) are free. `make deploy` additionally stands up always-on resources (Cloud SQL, Cloud Scheduler) — see [Deploy](#deploy) for teardown.
 
 ### Testing
 
-Deterministic tests need no GCP; evals hit Vertex and are billed like any other call.
+Deterministic tests need no GCP; evals hit Agent Platform and are billed like any other call.
 
 ```bash
 uv run pytest tests/unit tests/integration   # deterministic — no GCP needed

--- a/core/python/long-horizon-harness/README.md
+++ b/core/python/long-horizon-harness/README.md
@@ -52,7 +52,16 @@ Long Horizon shows how to build a long-horizon harness on ADK with capabilities 
 | **Frontend** | Vite 8 + TanStack Router/Query + React 18 |
 | **Surface** | Cloud Run + Cloud SQL + Cloud Scheduler — Cloud Run scales to zero between turns (Cloud SQL bills continuously) |
 
-Custom code earns its keep in a handful of **interfaces** on top of the managed primitives: the tool-guardrail chain, the `Environment` ContextVar sandbox layer, the per-user secret store, the dynamic delegate + HITL resurfacing, the three-tier system-prompt assembler, and the self-improvement loop layered on managed Memory Bank (throttled judge fork, pre-compaction flush, nightly dream-review; see [`docs/memory.md`](docs/memory.md)). Compaction, resumability, and prefix caching are ADK/Agent Platform knobs Horizon only configures; routines and the scheduler are applications composed from the interfaces. (Those interfaces are the rows in [`AGENTS.md`](AGENTS.md).)
+On top of those managed primitives, Horizon adds a handful of **interfaces** — the rows in [`AGENTS.md`](AGENTS.md):
+
+- the tool-guardrail chain
+- the `Environment` ContextVar sandbox layer
+- the per-user secret store
+- the dynamic delegate + HITL resurfacing
+- the three-tier system-prompt assembler
+- the self-improvement loop over managed Memory Bank — throttled judge fork, pre-compaction flush, nightly dream-review (see [`docs/memory.md`](docs/memory.md))
+
+Compaction, resumability, and prefix caching are ADK/Agent Platform knobs Horizon only configures; routines and the scheduler are applications composed from those interfaces.
 
 Full subsystem walkthrough: [`docs/architecture.md`](docs/architecture.md).
 


### PR DESCRIPTION
## Summary

Follow-up to #2455.

- The web UI now starts only once the backend is listening. vite proxies `/.well-known`, `/a2a` and `/lha` from the moment it boots, so a cold start printed a wall of `ECONNREFUSED` stack traces that reads like a crash. `npm install` still runs in parallel; only the server start waits.
- `make dev` announces the ~30s wait up front, and the ready banner is a block rather than one line that scrolls past.
- README says Agent Platform instead of Vertex, and the three dense paragraphs after the quickstart are condensed — including dropping the line that repeated the URL the banner now prints.

## Testing

Exercised with stubbed servers (backend binding after a delay): vite starts only after the backend answers, the banner fires when both ports respond, and everything dies with the stack via the existing `kill 0` trap. The real Agent Platform-backed stack was not run.
