### PR TITLE
fix(long-horizon-harness): drop unreachable gateway state reads in the reminder tool

### DIFF
--- a/core/python/long-horizon-harness/horizon/scheduler/tools.py
+++ b/core/python/long-horizon-harness/horizon/scheduler/tools.py
@@ -22,11 +22,10 @@ A single ``reminder(action=...)`` dispatch over three operations:
 * ``cancel``: same scoping, so user A cannot remove user B's reminder
   even if they guess the id.
 
-Channel + recipient_id come from ``tool_context.state``
-(``gateway_channel`` / ``gateway_recipient_id`` keys, set by the gateway
-on inbound messages). When unset (local CLI / playground use), we fall
-back to ``channel="cli"`` and ``recipient_id=user_id`` so the local
-end-to-end path works without the gateway.
+A row's ``channel`` / ``recipient_id`` are the out-of-band push address
+(``horizon/tools/push_to_user.py``). No inbound gateway exists — alternate
+gateways are out of scope — so they are fixed to ``"cli"`` / ``user_id``;
+delivery the user actually sees is the tagged session the tick creates.
 """
 
 from __future__ import annotations
@@ -42,6 +41,8 @@ from horizon.scheduler.store import (
 )
 
 logger = logging.getLogger(__name__)
+
+_CHANNEL = "cli"
 
 
 def _parse_when(value: str) -> datetime | None:
@@ -76,7 +77,7 @@ def _parse_when(value: str) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
-def _identity(tool_context: Any) -> tuple[str, str, str, str] | None:
+def _identity(tool_context: Any) -> tuple[str, str] | None:
     invocation = getattr(tool_context, "_invocation_context", None)
     if invocation is None:
         return None
@@ -84,12 +85,7 @@ def _identity(tool_context: Any) -> tuple[str, str, str, str] | None:
     app_name = getattr(invocation, "app_name", "") or ""
     if not user_id or not app_name:
         return None
-    state = getattr(tool_context, "state", None)
-    if state is None:
-        state = {}
-    channel = state.get("gateway_channel") or "cli"
-    recipient_id = state.get("gateway_recipient_id") or user_id
-    return user_id, app_name, str(channel), str(recipient_id)
+    return user_id, app_name
 
 
 async def _schedule(
@@ -124,7 +120,7 @@ async def _schedule(
     identity = _identity(tool_context)
     if identity is None:
         return {"success": False, "error": "no active invocation context"}
-    user_id, app_name, channel, recipient_id = identity
+    user_id, app_name = identity
 
     store = get_reminder_store()
     now = datetime.now(UTC)
@@ -132,8 +128,8 @@ async def _schedule(
         id="",
         user_id=user_id,
         app_name=app_name,
-        channel=channel,
-        recipient_id=recipient_id,
+        channel=_CHANNEL,
+        recipient_id=user_id,
         message=message.strip(),
         fire_at=fire_at,
         recurrence=recurrence,  # type: ignore[arg-type]
@@ -145,7 +141,7 @@ async def _schedule(
         "id": rid,
         "fire_at": fire_at.isoformat(),
         "recurrence": recurrence,
-        "channel": channel,
+        "channel": _CHANNEL,
     }
 
 
@@ -153,7 +149,7 @@ async def _list(tool_context: Any) -> dict[str, Any]:
     identity = _identity(tool_context)
     if identity is None:
         return {"success": False, "error": "no active invocation context"}
-    user_id, _app_name, _channel, _recipient_id = identity
+    user_id, _app_name = identity
     store = get_reminder_store()
     items = await store.list_for_user(user_id)
     return {
@@ -178,7 +174,7 @@ async def _cancel(id: str, tool_context: Any) -> dict[str, Any]:
     identity = _identity(tool_context)
     if identity is None:
         return {"success": False, "error": "no active invocation context"}
-    user_id, _app_name, _channel, _recipient_id = identity
+    user_id, _app_name = identity
     store = get_reminder_store()
     ok = await store.cancel(id, user_id)
     if not ok:

--- a/core/python/long-horizon-harness/tests/unit/test_scheduler_tools.py
+++ b/core/python/long-horizon-harness/tests/unit/test_scheduler_tools.py
@@ -19,9 +19,8 @@ Surfaces validated:
 * ``when`` accepts ISO 8601 and natural language ("tomorrow 9pm",
   "in 1 hour"). All resolved to UTC.
 * Identity is pulled from ``tool_context._invocation_context``
-  (``user_id`` / ``app_name``); channel + recipient_id from
-  ``tool_context.state["gateway_channel"]`` / ``["gateway_recipient_id"]``
-  with a CLI fallback when absent.
+  (``user_id`` / ``app_name``); channel + recipient_id are fixed to
+  ``"cli"`` / ``user_id``.
 * ``action='list'`` returns only the calling user's items.
 * ``action='cancel'`` is user-scoped — user A cannot cancel user B's id.
 * ``recurrence`` validation: ``None`` or one of ``daily|weekly|hourly``.
@@ -41,11 +40,10 @@ def _ctx(
     *,
     user_id: str = "u1",
     app_name: str = "lha",
-    state: dict | None = None,
 ):
     return SimpleNamespace(
         _invocation_context=SimpleNamespace(user_id=user_id, app_name=app_name),
-        state=state if state is not None else {},
+        state={},
     )
 
 
@@ -157,27 +155,7 @@ class TestScheduleReminder:
         assert result["success"] is False
         assert "recurrence" in result["error"].lower()
 
-    async def test_channel_and_recipient_from_state(self):
-        from horizon.scheduler.store import get_reminder_store
-        from horizon.scheduler.tools import reminder
-
-        ctx = _ctx(
-            state={
-                "gateway_channel": "telegram",
-                "gateway_recipient_id": "chat-99",
-            }
-        )
-        await reminder(
-            action="schedule",
-            when="2026-12-25T09:00:00Z",
-            message="x",
-            tool_context=ctx,
-        )
-        items = await get_reminder_store().list_for_user("u1")
-        assert items[0].channel == "telegram"
-        assert items[0].recipient_id == "chat-99"
-
-    async def test_channel_falls_back_to_cli(self):
+    async def test_channel_is_cli_and_recipient_is_user(self):
         from horizon.scheduler.store import get_reminder_store
         from horizon.scheduler.tools import reminder
 


### PR DESCRIPTION
## Summary
`reminder(action="schedule")` read two `tool_context.state` keys —
`gateway_channel` / `gateway_recipient_id` — that nothing in the recipe
ever writes, so both reads always took the `"cli"` / `user_id` fallback.
They were a seam for an inbound chat gateway (Telegram/Slack), which the
recipe lists as out of scope.

## Changes
- `_identity` returns `(user_id, app_name)`; the two dead `state.get`
  reads and the 4-tuple are gone.
- `_schedule` sets `channel="cli"`, `recipient_id=user_id` on the row.
- Corrected the module + test docstrings, which claimed the keys were
  "set by the gateway on inbound messages".
- Dropped the unit test that pinned behavior no code path can reach.

`tests/unit`: 2287 passed, 4 skipped.
