### PR TITLE
Add web UI demo GIF to long-horizon-harness README

### DIFF
--- a/core/python/long-horizon-harness/README.md
+++ b/core/python/long-horizon-harness/README.md
@@ -13,6 +13,10 @@ This sample shows how to build a long-horizon harness on ADK with capabilities l
 - **Understand the design** — [`docs/architecture.md`](docs/architecture.md)
 - **Review the security model** — [`docs/security-model.md`](docs/security-model.md), before pointing it at anything real
 
+<div align="center">
+  <img src="https://raw.githubusercontent.com/google/adk-samples/assets/long-horizon-harness/horizon-demo.gif" alt="The Horizon web UI running two tasks: an AI research digest and a BigQuery analysis, each streaming tool calls and ending in a rendered HTML artifact" width="820">
+</div>
+
 **Features:**
 
 *Memory & self-improvement*


### PR DESCRIPTION
## Summary

- Adds a demo GIF to the Long Horizon README showing the web UI running two end-to-end tasks: an AI research digest and a BigQuery analysis, each streaming tool calls and ending in a rendered HTML artifact.
- The GIF lives on a new orphan `assets` branch and is referenced by raw URL, so the 7.7 MB binary never lands in a sparse or shallow clone of the recipe. This follows the existing pattern in `core/python/genmedia-for-commerce`, but keeps the media in this repo rather than a personal one.

## Changes

- `core/python/long-horizon-harness/README.md` — centered embed after the nav bullets, before Features.

## Note

Depends on the `assets` branch, pushed separately. The image will not render until that branch exists.
