### PR TITLE
Fix chat header wordmark overlapping status pills on a narrow centre panel

### DIFF
--- a/core/python/long-horizon-harness/web/components/chat/chat-shell.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/chat-shell.tsx
@@ -913,7 +913,7 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
                 )}
               </SheetContent>
             </Sheet>
-            <Wordmark label="Long Horizon Harness" className="shrink-0 text-base font-semibold tracking-tight" />
+            <Wordmark label="Long Horizon Harness" className="min-w-0 truncate text-base font-semibold tracking-tight" />
             {activeSession && (
               <>
                 <span aria-hidden className="shrink-0 text-muted-foreground/40">


### PR DESCRIPTION
## Summary

- The wordmark was `shrink-0` inside a `min-w-0 flex-1` parent, so narrowing the centre panel made it overflow its own container and paint over the user and status pills instead of truncating.
- Swapped to `min-w-0 truncate` so it degrades to an ellipsis.

## Changes

- `web/components/chat/chat-shell.tsx` — one className on the header Wordmark.

## Verification

Rendered the header markup at 300 / 360 / 420 / 480px. The overlap reproduces at ≤360px before the change and is gone after; at ≥420px the output is identical, so nothing changes at normal widths.
