### PR TITLE
docs(long-horizon-harness): correct nine claims that contradict the code

### DIFF
--- a/core/python/long-horizon-harness/AGENTS.md
+++ b/core/python/long-horizon-harness/AGENTS.md
@@ -234,8 +234,10 @@ All four SQL paths — ADK web-path session service, lifespan Runner session ser
 uv run pytest tests/unit tests/integration              # deterministic — default
 RUN_SMOKE=1 uv run pytest tests/smoke                   # hits FastAPI, no LLM
 RUN_SMOKE=1 RUN_SMOKE_LLM=1 uv run pytest tests/smoke   # adds LLM-hitting smokes
-RUN_SANDBOX_PROBE=1 uv run pytest tests/...             # sandbox-tier probes
-RUN_CUJ_PROBE=1 uv run pytest tests/...                 # critical-user-journey probes
+# Probes are `probe_*.py`, which pytest's default `python_files` does NOT collect
+# from a directory argument — name the file explicitly.
+RUN_SANDBOX_PROBE=1 uv run pytest tests/integration/probes/probe_cuj1_ephemeral.py
+RUN_CUJ_PROBE=1 uv run pytest tests/integration/cuj_probes/probe_cuj10_reminder_fire.py
 agents-cli eval run                                     # ADK evals (LLM behavior)
 agents-cli lint --fix                                   # ruff + ty + codespell
 ```
@@ -265,6 +267,12 @@ The dev stack is **fail-fast and single-instance**: `dev` depends on `dev-prefli
 When `horizon/sandbox/runtime/` changes (Dockerfile, server.py, protocol.py, entrypoint.sh), rebuild via **Cloud Build** — never local `docker build`:
 
 ```bash
+# One-time: nothing in terraform/ creates the `lha-sandbox` repo, and the APIs
+# below are only enabled by Terraform at `make deploy` — too late for this build.
+gcloud services enable artifactregistry.googleapis.com cloudbuild.googleapis.com --project=$PROJECT_ID
+gcloud artifacts repositories create lha-sandbox \
+  --repository-format=docker --location=us-central1 --project=$PROJECT_ID
+
 gcloud builds submit horizon/sandbox/runtime \
   --tag=us-central1-docker.pkg.dev/$PROJECT_ID/lha-sandbox/runtime:vX.Y.Z \
   --project=$PROJECT_ID

--- a/core/python/long-horizon-harness/README.md
+++ b/core/python/long-horizon-harness/README.md
@@ -55,7 +55,7 @@ This sample shows how to build a long-horizon harness on ADK with capabilities l
 | **Sessions** | [Agent Platform Sessions](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/sessions) |
 | **Sandbox** | [Sandboxes](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/sandbox) (BYOC container) — one per user, JWT-routed; reattached between turns (snapshot survival opt-in) |
 | **Frontend** | Vite 8 + TanStack Router/Query + React 18 |
-| **Surface** | Cloud Run + Cloud SQL + Cloud Scheduler — Cloud Run scales to zero between turns (Cloud SQL bills continuously) |
+| **Surface** | Cloud Run + Cloud SQL + Cloud Scheduler — nothing scales to zero: both Cloud Run services hold `min_instance_count = 1` (the every-minute tick can't pay a cold start), and Cloud SQL bills continuously |
 
 On top of those managed primitives, Horizon adds a handful of **interfaces** — the rows in [`AGENTS.md`](AGENTS.md):
 
@@ -144,7 +144,7 @@ Both services `ignore_changes` on their image, so steps 2–3 never fight Terraf
 
 > **IAP access is empty by default.** Set `TF_VAR_iap_users='["user:you@example.com"]'` before `make deploy` (or re-run after) or you'll be locked out of the web UI.
 
-**Billable, always-on resources** (Cloud SQL especially) — tear everything down when you're done. Container images pushed to Artifact Registry (`cloud-run-source-deploy`) are not Terraform-managed and survive `make destroy`; delete them separately if you care about the storage:
+**Billable, always-on resources** (Cloud SQL especially, plus one always-warm instance of each Cloud Run service) — tear everything down when you're done. Container images pushed to Artifact Registry (`cloud-run-source-deploy`) are not Terraform-managed and survive `make destroy`; delete them separately if you care about the storage:
 
 ```bash
 make destroy   # flips the delete guards off, then terraform destroy of all the above

--- a/core/python/long-horizon-harness/docs/configuration.md
+++ b/core/python/long-horizon-harness/docs/configuration.md
@@ -109,11 +109,17 @@ route exposes — and the credentials the `secrets`/`oauth` routes inject — is
 | `LHA_SCHEDULER_AUDIENCE` | — | Expected `aud` on that token. Unset ⇒ endpoints reject. |
 | `LHA_SCHEDULER_AUTH_DISABLED` | _(off)_ | Skips scheduler token verification. Local testing only. |
 
-### Snapshot (Phase C, off by default)
+### Snapshot (Phase C, off in code — **on** after `make deploy`)
+
+> The code default is off, but `terraform/cloud_run.tf` sets
+> `LHA_SNAPSHOT_ENABLED = "1"` on the deployed backend and
+> `terraform/cloud_scheduler.tf` creates the daily job unconditionally. A
+> `make deploy` therefore ships with Phase C **on**. Set the env var to `0` in
+> `cloud_run.tf` if you don't want it.
 
 | Var | Default | Notes |
 |---|---|---|
-| `LHA_SNAPSHOT_ENABLED` | _(off)_ | Master switch for the daily snapshot+prune job and restore-on-session-start. |
+| `LHA_SNAPSHOT_ENABLED` | _(off locally; `1` on Cloud Run via Terraform)_ | Master switch for the daily snapshot+prune job and restore-on-session-start. |
 | `LHA_SNAPSHOT_TTL` | `30d` | Snapshot retention TTL. |
 | `LHA_SNAPSHOT_KEEP` | `2` | Snapshots kept per user. |
 

--- a/core/python/long-horizon-harness/docs/memory.md
+++ b/core/python/long-horizon-harness/docs/memory.md
@@ -57,7 +57,14 @@ service is configured.
 **`PreloadMemoryTool()`**, registered in the root agent's `tools` list
 (`horizon/agent.py`). It queries `memory_service.search_memory()` and injects
 the hits into context. There is no custom `before_model` memory-search
-callback — `PreloadMemoryTool` is the whole prefetch mechanism.
+callback — `PreloadMemoryTool` is the whole *search*-based prefetch.
+
+It is not the only memory-derived injection, though. The structured user
+profile is a second, separate path: `session_start.py` loads it once per
+session into `state["user_profile"]`, and `build_volatile_reminder`
+(`horizon/conversation/reminders.py`) renders it into the prompt on **every**
+turn via `render_user_profile`. So: `PreloadMemoryTool` = per-turn similarity
+search; user profile = once-per-session load, re-rendered each turn.
 
 ## 2. Writing to memory
 

--- a/core/python/long-horizon-harness/docs/quickstart.md
+++ b/core/python/long-horizon-harness/docs/quickstart.md
@@ -12,6 +12,7 @@ Engine, no Cloud SQL. Inference still calls Vertex (there is no local model).
 - **Prerequisites** — uv, google-agents-cli, the gcloud SDK, and Node (web UI only).
 - **GCP access (inference only)** — ADC login + the Vertex AI API.
 - **Run it** — `make dev-local` (backend + web) and the local-first `.env` defaults.
+- **Vertex sandbox** — the four one-time steps `make dev-sandbox` assumes you already did.
 - **Smallest embeddable harness** — three env vars and one import.
 - **Tests** — deterministic `pytest`, no GCP needed.
 - **Connect Google (optional OAuth)** — bring your own OAuth client to wire `gcloud`/`gws` into the sandbox.
@@ -50,8 +51,58 @@ The defaults in `.env.example` already select the local-first combo
 ignores the backend choice in it.
 
 **Trade-off:** no cross-session memory (sessions are in-memory, lost on restart)
-and no isolated sandbox (tools execute on your machine). Switch to the Vertex
-sandbox with `make dev-sandbox` (or `LHA_ENVIRONMENT_BACKEND=sandbox` in `.env`).
+and no isolated sandbox (tools execute on your machine). To get the isolated
+per-user sandbox, see the next section — `make dev-sandbox` alone is not enough.
+
+## 3b. Vertex sandbox instead of your host (optional)
+
+> ⚠️ **`make dev-sandbox` on its own does not give you an isolated sandbox.**
+> `SandboxProvider.build_environment` also needs `LHA_RUNTIME_IMAGE` and
+> `LHA_SANDBOX_CALLER_SA`, both blank in `.env.example`. Off Cloud Run, if
+> either is missing it logs a warning and **silently falls back to
+> `LocalEnvironment` — tools keep running on your machine.** Check the backend
+> log for `falling back to LocalEnvironment` before assuming you're isolated.
+> (Deployed, the same condition raises `SandboxConfigurationError` instead.)
+
+Four one-time steps:
+
+```bash
+# 1. APIs. Terraform enables these at `make deploy`, but you need them earlier
+#    to build the runtime image.
+gcloud services enable artifactregistry.googleapis.com cloudbuild.googleapis.com \
+  aiplatform.googleapis.com --project=$PROJECT_ID
+
+# 2. Artifact Registry repo. Nothing in terraform/ creates this one.
+gcloud artifacts repositories create lha-sandbox \
+  --repository-format=docker --location=us-central1 --project=$PROJECT_ID
+
+# 3. Build + push the sandbox runtime image (Cloud Build, never local docker).
+gcloud builds submit horizon/sandbox/runtime \
+  --tag=us-central1-docker.pkg.dev/$PROJECT_ID/lha-sandbox/runtime:v0.1.0 \
+  --project=$PROJECT_ID
+
+# 4. A caller SA whose JWT the sandbox LB checks, and permission to mint its
+#    tokens. `make deploy` creates one for Cloud Run; locally you make your own.
+gcloud iam service-accounts create lha-sandbox-caller --project=$PROJECT_ID
+gcloud iam service-accounts add-iam-policy-binding \
+  lha-sandbox-caller@$PROJECT_ID.iam.gserviceaccount.com \
+  --member="user:$(gcloud config get-value account)" \
+  --role=roles/iam.serviceAccountTokenCreator --project=$PROJECT_ID
+```
+
+Then set both in `.env` and start:
+
+```bash
+LHA_RUNTIME_IMAGE=us-central1-docker.pkg.dev/<project>/lha-sandbox/runtime:v0.1.0
+LHA_SANDBOX_CALLER_SA=lha-sandbox-caller@<project>.iam.gserviceaccount.com
+```
+
+```bash
+make dev-sandbox   # or LHA_ENVIRONMENT_BACKEND=sandbox in .env + `make dev`
+```
+
+Lifecycle details (reattach, snapshots, version floors):
+[`sandbox-lifecycle.md`](sandbox-lifecycle.md).
 
 ## 4. Smallest embeddable harness
 

--- a/core/python/long-horizon-harness/docs/sandbox-lifecycle.md
+++ b/core/python/long-horizon-harness/docs/sandbox-lifecycle.md
@@ -9,7 +9,7 @@ a workspace did or didn't survive across sessions, restarts, or upgrades.
 - **Persistence model** (blockquote, below the title) — reattach vs snapshot/restore, and version-scoped identity with version-agnostic reattach.
 - **Diagram 1 — Identity hierarchy** — where the sandbox attaches: scope is (process, user), not per-session.
 - **Diagram 2 — Single-process lifecycle** — cache miss/hit, reattach, and what process exit does (and doesn't) do.
-- **Diagram 3 — Snapshot / restore** — the Phase C nightly snapshot + restore-on-session-start path (off by default).
+- **Diagram 3 — Snapshot / restore** — the Phase C nightly snapshot + restore-on-session-start path (off in code; Terraform turns it on when you deploy).
 - **Diagram 4 — What survives what** — the survival matrix across RUNNING vs reaped sandboxes.
 - **Environment variables** — the `LHA_SNAPSHOT_*` / `LHA_SANDBOX_TTL` / `LHA_RUNTIME_MIN_VERSION` knobs.
 - **Troubleshooting** — debug-by-symptom: not reattaching, files lost, force-upgrades.
@@ -27,8 +27,9 @@ Verified against `horizon/sandbox/`, `horizon/conversation/session_start.py`, an
 >    platform-side sandbox stays RUNNING, and the next session for the same user
 >    reattaches to it (`find_latest_user_sandbox`, `horizon/sandbox/lifecycle.py`).
 >    This holds until the sandbox's TTL/idle teardown. See Diagram 2.
-> 2. **Snapshot / restore (Phase C, gated by `LHA_SNAPSHOT_ENABLED`, off by
->    default).** To survive the teardown a daily Cloud Scheduler job snapshots
+> 2. **Snapshot / restore (Phase C, gated by `LHA_SNAPSHOT_ENABLED` — off in
+>    code, but `terraform/cloud_run.tf` sets it to `1`, so a deployed stack has
+>    it on).** To survive the teardown a daily Cloud Scheduler job snapshots
 >    each active user's full `$HOME`, and a session with no RUNNING sandbox
 >    restores from the latest snapshot before provisioning blank. This is a
 >    **real implemented path** — `horizon/scheduler/snapshot_endpoint.py` +
@@ -131,10 +132,13 @@ Two sessions for alice in the same process see the same /workspace.
 > There is no signal-handler snapshot flush and no `~/.lha/snapshots/index.json`.
 > Durable survival across a sandbox teardown is the snapshot/restore job below.
 
-## Diagram 3 — Snapshot / restore (Phase C, off by default)
+## Diagram 3 — Snapshot / restore (Phase C)
 
 Gated by `LHA_SNAPSHOT_ENABLED` (`snapshots_enabled()`). When unset, both halves
-below no-op and the only persistence is reattach-until-TTL (Diagram 2).
+below no-op and the only persistence is reattach-until-TTL (Diagram 2). Unset is
+the *code* default — a deployed stack has it set: `terraform/cloud_run.tf` puts
+`LHA_SNAPSHOT_ENABLED = "1"` on the backend and `terraform/cloud_scheduler.tf`
+creates the daily job unconditionally.
 
 ```
   ── nightly ─────────────────────────────────────────────────────────
@@ -193,7 +197,7 @@ routine (`lhart-`) sandboxes (per-routine, no snapshot/restore).
 
 | Var | Default | Effect |
 |---|---|---|
-| `LHA_SNAPSHOT_ENABLED` | unset (off) | Master switch for Phase C — gates both the daily snapshot job and restore-on-session-start (`snapshots_enabled()`). |
+| `LHA_SNAPSHOT_ENABLED` | unset (off) locally; `1` on Cloud Run (set by `terraform/cloud_run.tf`) | Master switch for Phase C — gates both the daily snapshot job and restore-on-session-start (`snapshots_enabled()`). |
 | `LHA_SNAPSHOT_TTL` | `30d` | TTL stamped on each snapshot. |
 | `LHA_SNAPSHOT_KEEP` | `2` | Snapshots retained per user; older ones pruned each run. |
 | `LHA_SANDBOX_TTL` | `14d` | TTL on the live sandbox (and on a restored one). |
@@ -211,7 +215,7 @@ Debug by symptom. Each row points at the code that owns the behavior.
 |---|---|---|
 | New session gets a fresh blank `/workspace` instead of the previous one | `find_latest_user_sandbox` (version-agnostic, `lha-<user>-` prefix match) | Reattach picks the user's most-recent RUNNING sandbox regardless of image version; if none is RUNNING (TTL/idle teardown, or first run) it provisions blank (or restores a snapshot, if enabled). |
 | Installed CLIs disappear after a backend rollout | `version_below_floor` + `/sandbox-upgrade` (`upgrade_user_sandbox`) migrating only `/workspace` | Reattach is version-agnostic so CLIs in `$HOME`/`~/.local` survive a rollout; an *explicit* upgrade re-provisions and the zip migration (`POST /files/zip`) carries `/workspace` data only (drops binaries/exec bits). |
-| Files gone after a sandbox was reaped | `LHA_SNAPSHOT_ENABLED` (off by default); `snapshot_and_prune_user` / `restore_sandbox_from_snapshot` | Without Phase C there is no durable backing store — reattach only survives until the sandbox's TTL/idle teardown. |
+| Files gone after a sandbox was reaped | `LHA_SNAPSHOT_ENABLED` (off in code, `1` on a Terraform-deployed backend); `snapshot_and_prune_user` / `restore_sandbox_from_snapshot` | Without Phase C there is no durable backing store — reattach only survives until the sandbox's TTL/idle teardown. |
 | Snapshot exists but restore never happens | `snapshots_enabled()`, `find_latest_user_snapshot`; restore skipped on the force-upgrade path and on routine (`lhart-`) sandboxes | The master switch is off, or the path intentionally skips restore (it wants a fresh current-image / per-routine sandbox). |
 | Sandbox force-upgrades on every session | `LHA_RUNTIME_MIN_VERSION` + `version_below_floor` | A sandbox below the floor is migrated to the current image instead of reattached; an unparseable token/floor never forces an upgrade. |
 | A routine sees the user's workspace (or vice versa) | env cache key `("routine", routine_id)` vs `(backend, user_id)`; `find_routine_sandbox` (`lhart-` prefix) | Sandbox scope is (process, user); routine sandboxes use a disjoint `lhart-` prefix and a separate cache key, so neither discovery can resolve the other. |

--- a/core/python/long-horizon-harness/horizon/environment/sandbox.py
+++ b/core/python/long-horizon-harness/horizon/environment/sandbox.py
@@ -52,10 +52,11 @@ class SandboxEnvironment(Environment):
 
     The shim inside the container handles every operation:
     ``POST /exec`` for shell commands, ``GET /files``/``POST /files`` for
-    file I/O. The sandbox itself is long-lived and shared across
-    processes via ``~/.lha/sandboxes/index.json``; ``close()`` just tears
-    down the local HTTP client — the sandbox keeps running so the next
-    process can reattach.
+    file I/O. The sandbox itself is long-lived and shared across processes
+    via Agent Platform's authoritative ``sandboxes.list`` (see
+    ``find_latest_user_sandbox``), not a host-local index file; ``close()``
+    just tears down the local HTTP client — the sandbox keeps running so the
+    next process can reattach.
     """
 
     on_host_fs = False

--- a/core/python/long-horizon-harness/horizon/memory/_throttle.py
+++ b/core/python/long-horizon-harness/horizon/memory/_throttle.py
@@ -31,9 +31,12 @@ applies) — used by evalsets that need every-turn behavior to score the
 underlying logic without throttling noise.
 
 ``flush_fork.spawn_flush_fork`` and ``dream_review.request_dream_review``
-are intentionally NOT routed through ``try_claim``: flush fires at most
-once per session (right before compression) and dream-review is on-demand,
-so per-turn cooldown is not the right shape for either.
+are intentionally NOT routed through ``try_claim``: flush is already
+rate-limited by compaction itself (it fires once per compaction, which
+``compaction_interval=8`` in ``horizon/agent.py`` bounds to roughly one per
+8 invocations — so a long session flushes repeatedly, just never per-turn),
+and dream-review is on-demand. A per-turn cooldown is not the right shape
+for either.
 """
 
 from __future__ import annotations

--- a/core/python/long-horizon-harness/terraform/README.md
+++ b/core/python/long-horizon-harness/terraform/README.md
@@ -43,39 +43,40 @@ shouldn't know who its consumers are.
 ## Sandbox backend
 
 Per-user workspace persistence is provided by `SandboxEnvironment`
-(`horizon/environment/sandbox.py`): each session boots a sandbox container,
-restores from the user's prior snapshot if one exists, and snapshots back at
-session close. Selection is controlled by:
+(`horizon/environment/sandbox.py`). A session **reattaches** to the user's
+most-recent RUNNING sandbox if there is one, else provisions blank (or restores
+a snapshot when Phase C is on). `close()` only tears down the local HTTP client
+— **it does not snapshot**; the platform-side sandbox keeps running for the next
+session. Full lifecycle: [`../docs/sandbox-lifecycle.md`](../docs/sandbox-lifecycle.md).
+Selection is controlled by:
 
 ```bash
 # Required to switch off LocalEnvironment.
 export LHA_ENVIRONMENT_BACKEND=sandbox
 
-# Required when backend=sandbox.
+# Optional: pins the Agent Engine hosting Memory Bank + sandboxes. Unset, it is
+# discovered/created by scripts/provision_agent_engine.py on `terraform apply`.
 export AGENT_ENGINE_RESOURCE_NAME=projects/<p>/locations/<l>/reasoningEngines/<r>
 
+# Required when backend=sandbox. Missing either of the two below, the provider
+# logs a warning and falls back to LocalEnvironment off Cloud Run (and raises
+# SandboxConfigurationError on it).
+#
 # BYOC runtime image the sandbox boots; rebuilt + pushed from
-# horizon/sandbox/runtime/. A new tag forces a new template.
-export LHA_RUNTIME_IMAGE=us-central1-docker.pkg.dev/<p>/<repo>/runtime:<tag>
+# horizon/sandbox/runtime/. A new tag forces a new template. Nothing in this
+# module creates the Artifact Registry repo — see ../AGENTS.md for the one-time
+# `gcloud artifacts repositories create` + Cloud Build steps.
+export LHA_RUNTIME_IMAGE=us-central1-docker.pkg.dev/<p>/lha-sandbox/runtime:<tag>
 
 # SA email whose JWT the sandbox LB checks on every shim request.
 # Caller ADC must hold roles/iam.serviceAccountTokenCreator on this SA.
+# `make deploy` reuses the Cloud Run SA for this; locally you create your own.
 export LHA_SANDBOX_CALLER_SA=lha-sandbox-caller@<p>.iam.gserviceaccount.com
-
-# Optional: how long _close_envs_at_exit waits for snapshot/delete RPCs to
-# finish before abandoning the cleanup thread (default 300s). Bump for very
-# large workspaces; lower for fast shutdown.
-export LHA_CLOSE_JOIN_TIMEOUT_SEC=300
-
-# Optional: set to "1" in the CLI entrypoint so SIGTERM/SIGINT trigger the
-# snapshot flush. Off by default so library/test imports don't hijack signal
-# handlers from the host process.
-export LHA_INSTALL_SIGNAL_HANDLERS=1
 ```
 
-The snapshot index lives on the host at `~/.lha/snapshots/index.json`,
-guarded by a sibling `.lock` file via `fcntl.flock` so parallel sessions for
-the same `user_id` serialize their writes.
+Sandbox discovery is Agent Platform's authoritative `sandboxes.list`, not a
+host-local index file — so any Cloud Run instance resolves the same sandbox and
+a process restart is irrelevant to reattach.
 
 ## Redeploying into a project you previously tore down
 


### PR DESCRIPTION
## Summary

- Nine places where the recipe's docs assert something the code contradicts. Each fix verified against the source, not inferred.
- The important one is #3: the quickstart tells you `make dev-sandbox` gives you an isolated sandbox. Without `LHA_RUNTIME_IMAGE` and `LHA_SANDBOX_CALLER_SA` it silently falls back to `LocalEnvironment` — you think tools are sandboxed, they're running on your host.
- Docs and docstrings only. No behavior change.

## Changes

| Fix | Was | Is |
|---|---|---|
| `README.md` | "Cloud Run scales to zero between turns" | both services pin `min_instance_count = 1` (`cloud_run.tf:37`, `cloud_run_web.tf:43`, `Makefile:215`) |
| `configuration.md`, `sandbox-lifecycle.md` | snapshot "off by default" | off in code, but `cloud_run.tf:175` sets `LHA_SNAPSHOT_ENABLED = "1"` and the scheduler job is unconditional — `make deploy` ships it **on** |
| `quickstart.md` | "switch with `make dev-sandbox`" | new §3b: the four one-time steps, plus a warning about the silent `LocalEnvironment` fallback (`provider.py:549-571`) |
| `_throttle.py` | flush fork "fires at most once per session" | once per *compaction*; `compaction_interval=8` means a long session flushes repeatedly |
| `memory.md` | "`PreloadMemoryTool` is the whole prefetch mechanism" | the user profile is a second path (`session_start.py:449` → `reminders.py:102`) |
| `AGENTS.md` | nothing creates the `lha-sandbox` Artifact Registry repo, and `artifactregistry`/`cloudbuild` are only enabled at `make deploy` — after you need them | one-time `gcloud services enable` + `artifacts repositories create` |
| `AGENTS.md` | `uv run pytest tests/...` for probes | real paths; `probe_*.py` isn't collected from a directory arg (verified: 0 collected) |
| `terraform/README.md` | close-time snapshot; `LHA_CLOSE_JOIN_TIMEOUT_SEC`, `LHA_INSTALL_SIGNAL_HANDLERS`, `~/.lha/snapshots/index.json` | none exist in the code; reattach-based lifecycle, API-based discovery |
| `sandbox.py` docstring | sandboxes shared via `~/.lha/sandboxes/index.json` | nothing reads that file; discovery is Agent Platform's `sandboxes.list` |

## Verification

`ruff format --check` + `ruff check` clean · `pytest tests/unit tests/integration` → 2389 passed · `validate structure` / `validate readme` pass
