### PR TITLE
ci: make every check say why it failed and whose fault it is

### DIFF
--- a/.github/policy.yml
+++ b/.github/policy.yml
@@ -227,9 +227,9 @@ required_files:
     #   SKILL.md  — the conversational installer: runs the interview,
     #               writes the design spec, performs setup.
     #   EVAL.yaml — self-verifying proof of performance (eval rubrics).
-    # The directories a vertical skill must also ship (scripts/, assets/,
-    # references/, tests/unit/) are listed under `required_dirs` below —
-    # this section can only express files.
+    # The one directory a vertical skill must also ship (scripts/) is
+    # listed under `required_dirs` below — this section can only express
+    # files.
     #
     # A Python vertical skill additionally picks up
     # required_files.by_language.python (pyproject.toml, uv.lock,
@@ -287,9 +287,23 @@ required_files:
 # a `scripts` entry under required_files could never be satisfied, since
 # that check requires a file.
 #
-# An empty directory PASSES. assets/ and references/ are legitimately
-# empty for some skills, and git cannot commit an empty directory, so in
-# practice they carry a .gitkeep.
+# An empty directory PASSES, which is why this section is kept as small as
+# possible. A rule that is satisfied by an empty folder enforces nothing:
+# git cannot commit an empty directory, so the author adds a .gitkeep whose
+# only purpose is to satisfy a check that already said it does not care
+# what is inside. That is pure ceremony, and it reliably confuses people —
+# the folder is right there in their editor while CI insists it is missing.
+#
+# So the bar for listing a directory here is: the recipe is BROKEN without
+# it, not merely unconventional. assets/, references/ and tests/unit/ were
+# removed under that bar — plenty of vertical skills legitimately ship no
+# demo data and no deep-dive docs, and tests/unit/ implied a testing
+# discipline it could not enforce (an empty folder passed) while
+# tests/test_runnability.py already covers the real requirement as a FILE.
+#
+# They remain the convention, and the skills scaffold template still
+# creates them — prompting an author to fill a folder is the scaffold's
+# job, not CI's. See docs/recipe-handbook/anatomy.md.
 # --------------------------------------------------------------------------
 required_dirs:
   always: []
@@ -297,17 +311,11 @@ required_dirs:
   by_root:
     core: []
     contrib: []
-    # The shape every vertical skill ships:
-    #   scripts/     — functional code: ADK agents, model implementations,
-    #                  one-shot GCP setup scripts.
-    #   assets/      — demo data, e.g. sample catalogs.
-    #   references/  — deep-dive documentation for human review.
-    #   tests/unit/  — unit tests, for reliability.
+    # scripts/ — functional code: ADK agents, model implementations,
+    #            one-shot GCP setup scripts. A vertical skill with no
+    #            scripts/ has nothing to run, so this one is load-bearing.
     skills:
       - scripts
-      - assets
-      - references
-      - tests/unit
 
   by_language:
     python: []

--- a/.github/scripts/check_env_vars.py
+++ b/.github/scripts/check_env_vars.py
@@ -38,6 +38,7 @@ from ci_message import (
     EXIT_OK,
     Diagnostic,
     Doc,
+    guard,
     infra_fault,
     report,
     report_infra_fault,
@@ -513,14 +514,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    # Belt and braces: a traceback escaping to the runner is reported by the
+    # guard(): a traceback escaping to the runner is reported by the
     # workflow as the contributor's failure, which is exactly the confusion
     # infra_fault exists to prevent.
-    try:
-        sys.exit(main())
-    except Exception as exc:
-        sys.exit(
-            report_infra_fault(
-                infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
-            )
-        )
+    sys.exit(guard(CHECKER, main))

--- a/.github/scripts/check_env_vars.py
+++ b/.github/scripts/check_env_vars.py
@@ -11,13 +11,15 @@ GITHUB_*, etc.).
 
 Usage: python3 check_env_vars.py <recipe-dir>
 
-Output format (one record per line, for the shell caller to parse):
-  PASS::<path>::<message>
-  FAIL::<path>::<message>
+Exit codes:
+  0  every variable read by the recipe's Python source is declared
+  1  contributor-fixable problems found; every one has been reported with
+     a fix, both as a human block and as a ::error annotation
+  2  CI fault — the checker crashed or was invoked wrongly. Never blamed
+     on the contributor's files.
 
-Exits 0 always.  The workflow decides pass/fail from the emitted records so
-that a missing .env.example (caught by a separate required-files check)
-does not produce a redundant error here.
+A missing .env.example is not this script's failure to report (a separate
+required-files check owns it), so that case exits 0 with a note.
 
 MAINTENANCE NOTE — keep in sync with the extract-python-environment-variables
 skill (.agents/skills/extract-python-environment-variables/scripts/
@@ -30,6 +32,24 @@ import ast
 import re
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+from ci_message import (
+    EXIT_OK,
+    Diagnostic,
+    Doc,
+    infra_fault,
+    report,
+    report_infra_fault,
+)
+
+CHECKER = "check_env_vars.py"
+CHECK = "env-vars"
+
+# The value extract_env_vars.py writes for a variable it cannot infer a
+# default for. Suggesting the same token keeps a hand-fixed .env.example
+# indistinguishable from a skill-fixed one.
+PLACEHOLDER = "<TODO: update-this-value>"
 
 # ---------------------------------------------------------------------------
 # Allowlist
@@ -133,7 +153,10 @@ class _EnvVarCollector(ast.NodeVisitor):
     """
 
     def __init__(self) -> None:
-        self.env_vars: set[str] = set()
+        # name -> line of the FIRST read, so a diagnostic can point at a
+        # source location instead of naming a variable and leaving the
+        # contributor to grep for it.
+        self.env_vars: dict[str, int] = {}
         # Aliases introduced by `from os import getenv [as foo]`
         self._getenv_aliases: set[str] = set()
         # Aliases introduced by `from os.environ import get [as foo]`
@@ -215,7 +238,7 @@ class _EnvVarCollector(ast.NodeVisitor):
             if isinstance(slice_node, ast.Constant) and isinstance(
                 slice_node.value, str
             ):
-                self.env_vars.add(slice_node.value)
+                self.env_vars.setdefault(slice_node.value, node.lineno)
         self.generic_visit(node)
 
     # ------------------------------------------------------------------
@@ -229,7 +252,7 @@ class _EnvVarCollector(ast.NodeVisitor):
             and isinstance(node.args[0], ast.Constant)
             and isinstance(node.args[0].value, str)
         ):
-            self.env_vars.add(node.args[0].value)
+            self.env_vars.setdefault(node.args[0].value, node.lineno)
 
 
 # ---------------------------------------------------------------------------
@@ -254,9 +277,60 @@ _EXCLUDED_DIRS: frozenset[str] = frozenset(
 )
 
 
-def _collect_used_vars(recipe_dir: Path) -> set[str]:
-    """AST-parse all non-test, non-venv Python files; return env-var names read."""
-    used: set[str] = set()
+def _unreadable_source(py_file: Path, exc: Exception) -> Diagnostic:
+    """A Python file this check could not read is a hole in the check.
+
+    Skipping it silently is worse than reporting it: the recipe passes with
+    "all env vars declared" while an unknown number of reads inside the
+    unreadable file were never looked at.
+    """
+    if isinstance(exc, SyntaxError):
+        what = f"{py_file}:{exc.lineno or 1} is not valid Python: {exc.msg}."
+        how = (
+            "Fix the syntax error, then re-run. Ruff reports the same "
+            "problem locally:\n"
+            "  uv run ruff check <recipe-dir>"
+        )
+    elif isinstance(exc, UnicodeDecodeError):
+        what = f"{py_file} could not be decoded as UTF-8: {exc}."
+        how = (
+            "Re-save the file as UTF-8 (every Python source file in this "
+            "repo is UTF-8):\n"
+            "  iconv -f <current-encoding> -t utf-8 <file> > <file>.utf8\n"
+            "  mv <file>.utf8 <file>"
+        )
+    else:
+        what = f"{py_file} could not be parsed as Python: {exc}."
+        how = (
+            "Open the file and check it is plain UTF-8 Python source with "
+            "no embedded null bytes, then re-run:\n"
+            "  uv run ruff check <recipe-dir>"
+        )
+    return Diagnostic(
+        check=CHECK,
+        what=what,
+        why=(
+            "This check AST-parses every non-test Python file in the recipe "
+            "to find environment-variable reads. A file it cannot parse is "
+            "invisible to it, so a variable read there could be missing "
+            "from .env.example and still pass CI."
+        ),
+        how=how,
+        doc=Doc.ENV_VARS,
+        file=str(py_file),
+    )
+
+
+def _collect_used_vars(
+    recipe_dir: Path,
+) -> tuple[dict[str, tuple[Path, int]], list[Diagnostic]]:
+    """AST-parse all non-test, non-venv Python files.
+
+    Returns the variables read (name -> the file and line of the first read)
+    and a diagnostic for every file that could not be parsed.
+    """
+    used: dict[str, tuple[Path, int]] = {}
+    unreadable: list[Diagnostic] = []
     for py_file in sorted(recipe_dir.rglob("*.py")):
         # Exclude anything under a directory that appears in the exclusion set.
         if any(part in _EXCLUDED_DIRS for part in py_file.parts):
@@ -264,37 +338,94 @@ def _collect_used_vars(recipe_dir: Path) -> set[str]:
         try:
             source = py_file.read_text(encoding="utf-8")
             tree = ast.parse(source, filename=str(py_file))
-        except (SyntaxError, UnicodeDecodeError):
-            # Unparseable files are skipped silently; a separate lint step
-            # (ruff) catches syntax errors in the same CI run.
+        except (SyntaxError, UnicodeDecodeError, ValueError) as exc:
+            unreadable.append(_unreadable_source(py_file, exc))
             continue
         collector = _EnvVarCollector()
         collector.visit(tree)
-        used |= collector.env_vars
-    return used
+        for name, lineno in collector.env_vars.items():
+            used.setdefault(name, (py_file, lineno))
+    return used, unreadable
 
 
-def _parse_env_example(env_example: Path) -> set[str]:
-    """Return the set of variable names declared in .env.example."""
+def _parse_env_example(
+    env_example: Path,
+) -> tuple[set[str], Diagnostic | None]:
+    """Return the variable names declared in .env.example.
+
+    A file that is not UTF-8 yields no names and a diagnostic: the encoding
+    is the contributor's to fix, and comparing against an empty set would
+    otherwise report every variable in the recipe as undeclared.
+    """
     defined: set[str] = set()
-    for raw in env_example.read_text(encoding="utf-8").splitlines():
+    try:
+        text = env_example.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        return defined, Diagnostic(
+            check=CHECK,
+            what=f"{env_example} is not valid UTF-8: {exc}.",
+            why=(
+                "The declarations in .env.example are read as UTF-8 by this "
+                "check, by python-dotenv at runtime, and by every editor "
+                "that opens the file. A byte that is not valid UTF-8 makes "
+                "the file unreadable to all three."
+            ),
+            how=(
+                "Re-save the file as UTF-8:\n"
+                "  iconv -f <current-encoding> -t utf-8 .env.example "
+                "> .env.example.utf8\n"
+                "  mv .env.example.utf8 .env.example\n"
+                "Values in .env.example are placeholders, so plain ASCII is "
+                "usually the simplest fix."
+            ),
+            doc=Doc.ENV_VARS,
+            file=str(env_example),
+        )
+    for raw in text.splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
         m = re.match(r"^(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=", line)
         if m:
             defined.add(m.group(1))
-    return defined
+    return defined, None
 
 
 # ---------------------------------------------------------------------------
-# Output
+# Diagnostics
 # ---------------------------------------------------------------------------
 
 
-def emit(kind: str, file: Path, msg: str) -> None:
-    """Print one PASS/FAIL record.  Newlines collapsed for line-by-line parsing."""
-    print(f"{kind}::{file}::{msg.replace(chr(10), ' ')}")
+def _undeclared_var(
+    var: str, source: Path, lineno: int, env_example: Path
+) -> Diagnostic:
+    return Diagnostic(
+        check=CHECK,
+        what=(
+            f"{var} is read at {source}:{lineno} but is not declared in "
+            f"{env_example}."
+        ),
+        why=(
+            ".env.example is the only place someone running this recipe can "
+            "discover what they have to configure; a variable that is read "
+            "but not listed there makes the recipe fail with an empty value "
+            "and no explanation. The read was found by AST-parsing the "
+            "recipe's source, so it is a real os.getenv/os.environ access, "
+            "not a string match."
+        ),
+        how=(
+            f"Add this line to {env_example}:\n"
+            f"  {var}={PLACEHOLDER}\n"
+            f"and make sure the recipe loads it (load_dotenv() in the "
+            f"package __init__.py).\n"
+            f"Or ask your AI coding assistant to run the "
+            f"extract-python-environment-variables skill on this recipe — "
+            f"it finds every read and writes the missing declarations, "
+            f"including defaults hidden in os.environ.setdefault() calls."
+        ),
+        doc=Doc.ENV_VARS,
+        file=str(env_example),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -302,55 +433,94 @@ def emit(kind: str, file: Path, msg: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def main() -> int:
-    if len(sys.argv) != 2:
-        print(f"usage: {sys.argv[0]} <recipe-dir>", file=sys.stderr)
-        return 2
-
-    recipe_dir = Path(sys.argv[1])
+def _run(recipe_dir: Path) -> int:
     env_example = recipe_dir / ".env.example"
-
     if not env_example.is_file():
-        # A separate required-files check already reports this; stay silent
-        # here so we don't double-report the same missing file.
-        return 0
+        # A separate required-files check already reports this; staying
+        # quiet here keeps one missing file from producing two errors.
+        print(
+            f"[SKIP] {env_example} does not exist — the required-files "
+            f"check reports that separately."
+        )
+        return EXIT_OK
 
-    defined_vars = _parse_env_example(env_example)
-    used_vars = _collect_used_vars(recipe_dir)
+    defined_vars, encoding_problem = _parse_env_example(env_example)
+    used_vars, diagnostics = _collect_used_vars(recipe_dir)
 
-    missing = sorted(
-        v for v in used_vars if v not in defined_vars and not _is_allowed(v)
+    if encoding_problem is not None:
+        # Without a readable .env.example every variable would look
+        # undeclared, so report the encoding and stop comparing.
+        diagnostics.insert(0, encoding_problem)
+    else:
+        for var, (source, lineno) in sorted(used_vars.items()):
+            if var in defined_vars or _is_allowed(var):
+                continue
+            diagnostics.append(
+                _undeclared_var(var, source, lineno, env_example)
+            )
+
+    n_checked = len(used_vars)
+    n_allowed = sum(1 for v in used_vars if _is_allowed(v))
+    passed_message = (
+        f"{env_example}: no environment-variable reads detected in Python "
+        f"source."
+        if not used_vars
+        else (
+            f"{env_example}: every environment variable read in Python "
+            f"source is declared ({n_checked} detected, {n_allowed} in the "
+            f"OS allowlist, {n_checked - n_allowed} declared)."
+        )
+    )
+    return report(
+        diagnostics,
+        header=f"{recipe_dir}: environment variables",
+        passed_message=passed_message,
+        next_step=(
+            "Declaring a variable does not mean committing a secret: "
+            f"'{PLACEHOLDER}' is a valid value. The file exists to say "
+            "WHICH variables the recipe needs."
+        ),
     )
 
-    if missing:
-        for var in missing:
-            emit(
-                "FAIL",
-                env_example,
-                f"Environment variable '{var}' is read by Python source but"
-                f" not declared in .env.example. Add it (with a TODO"
-                f" placeholder as the value) and load it with load_dotenv().",
-            )
-        return 0
 
-    if not used_vars:
-        emit(
-            "PASS",
-            env_example,
-            "No environment variable reads detected in Python source.",
+def main() -> int:
+    if len(sys.argv) != 2:
+        return report_infra_fault(
+            infra_fault(
+                CHECKER,
+                f"invoked with {len(sys.argv) - 1} argument(s); expected "
+                f"exactly one recipe directory.",
+            )
         )
-    else:
-        n_checked = len(used_vars)
-        n_allowed = sum(1 for v in used_vars if _is_allowed(v))
-        emit(
-            "PASS",
-            env_example,
-            f"All environment variables read in Python source are declared in"
-            f" .env.example ({n_checked} detected,"
-            f" {n_allowed} in OS allowlist, {n_checked - n_allowed} declared).",
+
+    recipe_dir = Path(sys.argv[1])
+    if not recipe_dir.is_dir():
+        return report_infra_fault(
+            infra_fault(
+                CHECKER,
+                f"{recipe_dir} is not a directory. The path came from the "
+                f"workflow's recipe discovery step, not from the "
+                f"contributor.",
+            )
         )
-    return 0
+
+    try:
+        return _run(recipe_dir)
+    except Exception as exc:
+        return report_infra_fault(
+            infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
+        )
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Belt and braces: a traceback escaping to the runner is reported by the
+    # workflow as the contributor's failure, which is exactly the confusion
+    # infra_fault exists to prevent.
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        sys.exit(
+            report_infra_fault(
+                infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
+            )
+        )

--- a/.github/scripts/check_lockfile_hashes.py
+++ b/.github/scripts/check_lockfile_hashes.py
@@ -6,14 +6,29 @@ Usage: python check_lockfile_hashes.py <path-to-uv.lock>
 
 Exit codes:
   0  all distributions have valid hashes
-  1  one or more distributions are missing or have a malformed hash
-  2  usage error (wrong number of arguments)
+  1  contributor-fixable problems found; every one has been reported with
+     a fix, both as a human block and as a ::error annotation
+  2  CI fault — the checker crashed or was invoked wrongly. Never blamed
+     on the contributor's files.
 """
 
 import re
 import sys
+from pathlib import Path
 
 import tomllib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+from ci_message import (
+    Diagnostic,
+    Doc,
+    infra_fault,
+    report,
+    report_infra_fault,
+)
+
+CHECKER = "check_lockfile_hashes.py"
+CHECK = "lockfile-hashes"
 
 # Hashes produced by uv are always sha256; sha384 and sha512 are accepted
 # defensively in case a future uv release adds stronger algorithms.
@@ -28,66 +43,218 @@ _NO_HASH_SOURCE_KEYS = frozenset(
     {"virtual", "path", "editable", "directory", "git"}
 )
 
+_REGENERATE = (
+    "Regenerate the lockfile from the recipe directory rather than editing "
+    "it by hand:\n"
+    "  rm uv.lock\n"
+    "  uv lock\n"
+    "Commit the regenerated uv.lock."
+)
+
+
+def _shape_error(lockfile: str, what: str) -> Diagnostic:
+    """A uv.lock whose structure is not one uv would ever have written.
+
+    Reported to the contributor rather than raised, because every way of
+    getting here — a truncated file, a merge conflict resolved by hand, an
+    entry edited in an editor — is something they did to the file and can
+    undo by regenerating it.
+    """
+    return Diagnostic(
+        check=CHECK,
+        what=what,
+        why=(
+            "uv.lock is a generated file. uv always writes `[[package]]` as "
+            "an array of tables whose `wheels` / `sdist` entries are "
+            "themselves tables. A different shape means this lockfile was "
+            "hand-edited or written by another tool, so its hashes cannot "
+            "be verified."
+        ),
+        how=_REGENERATE,
+        doc=Doc.LOCK_HASH,
+        file=lockfile,
+    )
+
+
+def _missing_hash(lockfile: str, label: str, where: str) -> Diagnostic:
+    return Diagnostic(
+        check=CHECK,
+        what=f"{label} has a distribution with no `hash` field: {where}",
+        why=(
+            "Every registry distribution in uv.lock must carry a hash so "
+            "the artifact CI downloads can be proven identical to the one "
+            "that was locked. uv writes sha256 hashes by default, so a "
+            "missing hash means the lockfile was hand-edited or generated "
+            "with a tool that omits them."
+        ),
+        how=_REGENERATE,
+        doc=Doc.LOCK_HASH,
+        file=lockfile,
+    )
+
+
+def _bad_hash(lockfile: str, label: str, hash_val: str) -> Diagnostic:
+    return Diagnostic(
+        check=CHECK,
+        what=f"{label} has an unrecognised hash: {hash_val!r}",
+        why=(
+            "A hash must be `<algorithm>:<hex digest>` where the algorithm "
+            "is sha256 (sha384 and sha512 are also accepted). Anything else "
+            "cannot be verified at install time, so the entry provides no "
+            "supply-chain guarantee even though a hash is present."
+        ),
+        how=_REGENERATE,
+        doc=Doc.LOCK_HASH,
+        file=lockfile,
+    )
+
+
+def _describe(value: object) -> str:
+    """`list ['a', 'b']` — the type first, because the type is the bug."""
+    text = repr(value)
+    if len(text) > 60:
+        text = text[:57] + "..."
+    return f"{type(value).__name__} {text}"
+
 
 def _check_package(
-    pkg: dict,
-    missing: list[str],
-    bad_hash: list[str],
-) -> None:
+    pkg: object, position: int, lockfile: str
+) -> list[Diagnostic]:
     """Validate hashes for all distributions in one lockfile package entry."""
+    if not isinstance(pkg, dict):
+        return [
+            _shape_error(
+                lockfile,
+                f"`[[package]]` entry #{position} is a {_describe(pkg)}, "
+                f"not a table.",
+            )
+        ]
+
     source = pkg.get("source", {})
+    if not isinstance(source, dict):
+        return [
+            _shape_error(
+                lockfile,
+                f"`[[package]]` entry #{position} has a `source` that is a "
+                f"{_describe(source)}, not a table.",
+            )
+        ]
     if any(key in source for key in _NO_HASH_SOURCE_KEYS):
-        return
+        return []
 
     name = pkg.get("name", "<unknown>")
     version = pkg.get("version", "")
-    dists = pkg.get("wheels", []) + ([pkg["sdist"]] if "sdist" in pkg else [])
+    label = f"{name}=={version}" if version else str(name)
 
+    wheels = pkg.get("wheels", [])
+    if not isinstance(wheels, list):
+        return [
+            _shape_error(
+                lockfile,
+                f"{label} has a `wheels` value that is a "
+                f"{_describe(wheels)}, not an array of tables.",
+            )
+        ]
+    dists = list(wheels) + ([pkg["sdist"]] if "sdist" in pkg else [])
+
+    diagnostics: list[Diagnostic] = []
     for dist in dists:
+        if not isinstance(dist, dict):
+            diagnostics.append(
+                _shape_error(
+                    lockfile,
+                    f"{label} has a distribution entry that is a "
+                    f"{_describe(dist)}, not a table.",
+                )
+            )
+            continue
         url_or_path = dist.get("url", dist.get("path", "?"))
         hash_val = dist.get("hash", "")
         if not hash_val:
-            missing.append(f"  {name}=={version}: {url_or_path}")
-        elif not _HASH_RE.match(hash_val):
-            bad_hash.append(f"  {name}=={version}: malformed hash {hash_val!r}")
+            diagnostics.append(_missing_hash(lockfile, label, url_or_path))
+        elif not isinstance(hash_val, str) or not _HASH_RE.match(hash_val):
+            diagnostics.append(_bad_hash(lockfile, label, hash_val))
+    return diagnostics
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print(
-            "usage: check_lockfile_hashes.py <path-to-uv.lock>",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-
-    lockfile_path = sys.argv[1]
-
+def _run(lockfile: str) -> int:
     try:
-        with open(lockfile_path, "rb") as f:
+        with open(lockfile, "rb") as f:
             data = tomllib.load(f)
     except FileNotFoundError:
-        print(f"[FAIL] {lockfile_path}: file not found", file=sys.stderr)
-        sys.exit(1)
-    except tomllib.TOMLDecodeError as exc:
-        print(
-            f"[FAIL] {lockfile_path} is not valid TOML: {exc}", file=sys.stderr
+        return report_infra_fault(
+            infra_fault(
+                CHECKER,
+                f"{lockfile} does not exist. The path came from the "
+                f"workflow's lockfile discovery step, not from the "
+                f"contributor.",
+            )
         )
-        sys.exit(1)
+    except tomllib.TOMLDecodeError as exc:
+        return _report(
+            [_shape_error(lockfile, f"{lockfile} is not valid TOML: {exc}")],
+            lockfile,
+        )
 
-    missing: list[str] = []
-    bad_hash: list[str] = []
+    packages = data.get("package", [])
+    if not isinstance(packages, list):
+        return _report(
+            [
+                _shape_error(
+                    lockfile,
+                    f"`package` is a {_describe(packages)}, not an array of "
+                    f"tables.",
+                )
+            ],
+            lockfile,
+        )
 
-    for pkg in data.get("package", []):
-        _check_package(pkg, missing, bad_hash)
+    diagnostics: list[Diagnostic] = []
+    for position, pkg in enumerate(packages, start=1):
+        diagnostics.extend(_check_package(pkg, position, lockfile))
+    return _report(diagnostics, lockfile)
 
-    if missing or bad_hash:
-        print(f"[FAIL] {lockfile_path} — hash issues:")
-        for entry in missing:
-            print(entry)
-        for entry in bad_hash:
-            print(entry)
-        sys.exit(1)
+
+def _report(diagnostics: list[Diagnostic], lockfile: str) -> int:
+    return report(
+        diagnostics,
+        header=f"{lockfile} — hash problems",
+        passed_message=(
+            f"{lockfile}: every distribution carries a valid hash."
+        ),
+        next_step=(
+            "Regenerating the lockfile fixes all of the above at once:\n"
+            "  cd <recipe-dir> && rm uv.lock && uv lock"
+        ),
+    )
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return report_infra_fault(
+            infra_fault(
+                CHECKER,
+                f"invoked with {len(sys.argv) - 1} argument(s); expected "
+                f"exactly one path to a uv.lock.",
+            )
+        )
+    try:
+        return _run(sys.argv[1])
+    except Exception as exc:
+        return report_infra_fault(
+            infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
+        )
 
 
 if __name__ == "__main__":
-    main()
+    # Belt and braces: a traceback escaping to the runner is reported by the
+    # workflow as the contributor's failure, which is exactly the confusion
+    # infra_fault exists to prevent.
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        sys.exit(
+            report_infra_fault(
+                infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
+            )
+        )

--- a/.github/scripts/check_lockfile_hashes.py
+++ b/.github/scripts/check_lockfile_hashes.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
 from ci_message import (
     Diagnostic,
     Doc,
+    guard,
     infra_fault,
     report,
     report_infra_fault,
@@ -247,14 +248,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    # Belt and braces: a traceback escaping to the runner is reported by the
+    # guard(): a traceback escaping to the runner is reported by the
     # workflow as the contributor's failure, which is exactly the confusion
     # infra_fault exists to prevent.
-    try:
-        sys.exit(main())
-    except Exception as exc:
-        sys.exit(
-            report_infra_fault(
-                infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
-            )
-        )
+    sys.exit(guard(CHECKER, main))

--- a/.github/scripts/check_recipe_pyproject.py
+++ b/.github/scripts/check_recipe_pyproject.py
@@ -37,13 +37,15 @@ mirror it there (and vice versa).
 
 Usage: python check_recipe_pyproject.py <recipe-dir>
 
-Output format (one record per line, for the shell caller to parse):
-  PASS::<path>::<message>
-  FAIL::<path>::<message>
+Exit codes:
+  0  every rule passed
+  1  contributor-fixable problems found; every one has been reported with
+     a fix, both as a human block and as a ::error annotation
+  2  CI fault — the checker crashed, or its own environment is missing a
+     dependency it needs. Never blamed on the contributor's files.
 
-Exits 0 always. The workflow decides pass/fail from the emitted records so that
-a missing pyproject.toml (which is caught by a separate required-files check)
-does not cause a redundant error here.
+A missing pyproject.toml is not this script's failure to report (a separate
+required-files check owns it), so that case exits 0 with a note.
 """
 
 import sys
@@ -52,6 +54,18 @@ from pathlib import Path
 import tomllib
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+from ci_message import (
+    EXIT_OK,
+    Diagnostic,
+    Doc,
+    infra_fault,
+    report,
+    report_infra_fault,
+)
+
+CHECKER = "check_recipe_pyproject.py"
 
 MIN_PYTHON = (3, 11)
 MIN_PYTHON_STR = f"{MIN_PYTHON[0]}.{MIN_PYTHON[1]}"
@@ -165,53 +179,77 @@ def expected_project_name(
     return recipe_dir.name
 
 
-def emit(kind: str, file: Path, msg: str) -> None:
-    """Print one PASS/FAIL record. Newlines are collapsed so the shell can split
-    stdout line-by-line without worrying about multi-line messages."""
-    msg = msg.replace("\n", " ")
-    print(f"{kind}::{file}::{msg}")
+class CheckerFault(Exception):
+    """A failure in the checker's own environment, not in the recipe.
+
+    Raised instead of reported so it can never be rendered as a Diagnostic
+    against a contributor's file.
+    """
 
 
-def check_name(project: dict, pyproject_path: Path, recipe_dir: Path) -> None:
+def _describe(value: object) -> str:
+    """`list ['a', 'b']` — the type first, because the type is the bug."""
+    text = repr(value)
+    if len(text) > 60:
+        text = text[:57] + "..."
+    return f"{type(value).__name__} {text}"
+
+
+def check_name(
+    project: dict, pyproject_path: Path, recipe_dir: Path
+) -> list[Diagnostic]:
     """B2-name: [project].name must equal expected_project_name(recipe_dir)."""
     expected = expected_project_name(recipe_dir)
-    # Only spell out the derivation when it is not simply the basename, so
-    # the common core/contrib message stays as terse as it was.
+    # Only spell out the namespace derivation when the answer is not simply
+    # the basename, so the common core/contrib message stays terse.
     if expected != recipe_dir.name:
         root = recipe_dir.parts[-3]
-        namespace_term = NAMESPACED_ROOTS[root]
+        term = NAMESPACED_ROOTS[root]
         derivation = (
-            f" (recipes under {root}/ are named "
-            f"'<{namespace_term}>-<solution>', joining the {namespace_term} "
-            f"'{recipe_dir.parts[-2]}' to the folder name "
-            f"'{recipe_dir.name}')"
+            f"Recipes under {root}/ are named '<{term}>-<solution>' — the "
+            f"{term} '{recipe_dir.parts[-2]}' joined to the folder name "
+            f"'{recipe_dir.name}' — because a solution basename is not "
+            f"unique across {term}s."
         )
     else:
-        derivation = ""
+        derivation = (
+            f"A recipe's distribution name must equal its folder name, "
+            f"'{recipe_dir.name}'."
+        )
 
+    how = f'Set the name in [project]:\n  name = "{expected}"'
     name = project.get("name")
     if not name:
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].name is missing; it must be '{expected}'{derivation}.",
-        )
-    elif name != expected:
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].name = '{name}' does not match the required name "
-            f"'{expected}'{derivation}.",
-        )
-    else:
-        emit(
-            "PASS",
-            pyproject_path,
-            f"[project].name matches the required name: '{name}'.",
-        )
+        return [
+            Diagnostic(
+                check="project-name",
+                what=f"[project].name is missing from {pyproject_path}.",
+                why=f"It must be '{expected}'. {derivation}",
+                how=how,
+                doc=Doc.PROJECT_NAME,
+                file=str(pyproject_path),
+            )
+        ]
+    if name != expected:
+        return [
+            Diagnostic(
+                check="project-name",
+                what=(
+                    f"[project].name = '{name}', but this recipe must "
+                    f"declare '{expected}'."
+                ),
+                why=derivation,
+                how=how,
+                doc=Doc.PROJECT_NAME,
+                file=str(pyproject_path),
+            )
+        ]
+    return []
 
 
-def check_requires_python(project: dict, pyproject_path: Path) -> None:
+def check_requires_python(
+    project: dict, pyproject_path: Path
+) -> list[Diagnostic]:
     """B1: [project].requires-python must ACCEPT Python == MIN_PYTHON.
 
     Interpretation B: every recipe must be lockable/runnable under the
@@ -234,27 +272,48 @@ def check_requires_python(project: dict, pyproject_path: Path) -> None:
     implementation) so every legal operator (>=, >, ~=, ==, !=, <, <=, and
     combinations) is handled correctly.
     """
+    floor = f'  requires-python = ">={MIN_PYTHON_STR}"'
     requires_python = project.get("requires-python")
     if not requires_python:
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].requires-python is missing; it must declare a "
-            f"specifier that accepts Python {MIN_PYTHON_STR} and rejects "
-            "anything below (per AGENTS.md).",
-        )
-        return
+        return [
+            Diagnostic(
+                check="requires-python",
+                what=(
+                    f"[project].requires-python is missing from "
+                    f"{pyproject_path}."
+                ),
+                why=(
+                    f"AGENTS.md sets {MIN_PYTHON_STR} as the minimum for "
+                    f"every recipe, and CI pins {MIN_PYTHON_STR} when it "
+                    f"locks and runs this one. Without a specifier, uv is "
+                    f"free to resolve against any interpreter."
+                ),
+                how=f"Add to [project]:\n{floor}",
+                doc=Doc.REQUIRES_PYTHON,
+                file=str(pyproject_path),
+            )
+        ]
 
     try:
-        spec = SpecifierSet(requires_python)
-    except InvalidSpecifier as e:
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].requires-python = '{requires_python}' is not a valid "
-            f"PEP 440 version specifier ({e}).",
-        )
-        return
+        spec = SpecifierSet(str(requires_python))
+    except (InvalidSpecifier, TypeError) as e:
+        return [
+            Diagnostic(
+                check="requires-python",
+                what=(
+                    f"[project].requires-python = '{requires_python}' is not "
+                    f"a valid PEP 440 version specifier ({e})."
+                ),
+                why=(
+                    "uv and pip both parse this field as a PEP 440 "
+                    "specifier set; a value they cannot parse makes the "
+                    "recipe uninstallable."
+                ),
+                how=f"Use a specifier such as:\n{floor}",
+                doc=Doc.REQUIRES_PYTHON,
+                file=str(pyproject_path),
+            )
+        ]
 
     permits_older = [v for v in BELOW_MIN if v in spec]
     excludes_min = Version(MIN_PYTHON_STR) not in spec
@@ -263,208 +322,468 @@ def check_requires_python(project: dict, pyproject_path: Path) -> None:
         # Only surface a real witness version, never a synthetic `.9999`
         # probe (which is the only match for a micro floor like `>=3.10.5`).
         real = [v for v in permits_older if v.micro != _PROBE_MICRO]
-        example = f" (e.g. {real[0]})" if real else ""
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].requires-python = '{requires_python}' permits Python "
-            f"versions below {MIN_PYTHON_STR}{example}; lower bound must be "
-            f">= {MIN_PYTHON_STR} (per AGENTS.md).",
-        )
-        return
+        example = f" (for example {real[0]})" if real else ""
+        return [
+            Diagnostic(
+                check="requires-python",
+                what=(
+                    f"[project].requires-python = '{requires_python}' "
+                    f"accepts Python below {MIN_PYTHON_STR}{example}."
+                ),
+                why=(
+                    f"AGENTS.md sets {MIN_PYTHON_STR} as the minimum for "
+                    f"every recipe in this repo."
+                ),
+                how=(
+                    f"Raise the lower bound to {MIN_PYTHON_STR}, keeping any "
+                    f"upper bound you already have:\n{floor}"
+                ),
+                doc=Doc.REQUIRES_PYTHON,
+                file=str(pyproject_path),
+            )
+        ]
 
     if excludes_min:
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].requires-python = '{requires_python}' excludes Python "
-            f"{MIN_PYTHON_STR}; the specifier must accept {MIN_PYTHON_STR} so "
-            "CI (which pins Python 3.11) can lock and run this recipe. Lower "
-            f"the floor to '>={MIN_PYTHON_STR}' (preserving any upper bound), "
-            "or if the recipe genuinely needs newer features, raise the "
-            "issue with the repo maintainers to update CI's pinned interpreter.",
-        )
-        return
+        return [
+            Diagnostic(
+                check="requires-python",
+                what=(
+                    f"[project].requires-python = '{requires_python}' "
+                    f"excludes Python {MIN_PYTHON_STR}."
+                ),
+                why=(
+                    f"CI pins Python {MIN_PYTHON_STR}. A specifier that "
+                    f"rejects it makes uv fail to resolve an interpreter, "
+                    f"which surfaces later as a misleading 'lockfile is out "
+                    f"of date' error."
+                ),
+                how=(
+                    f"Lower the floor, preserving any upper bound:\n{floor}\n"
+                    f"If the recipe genuinely needs newer language features, "
+                    f"ask the repo maintainers to raise CI's pinned "
+                    f"interpreter instead of raising it here."
+                ),
+                doc=Doc.REQUIRES_PYTHON,
+                file=str(pyproject_path),
+            )
+        ]
 
-    emit(
-        "PASS",
-        pyproject_path,
-        f"[project].requires-python admits Python {MIN_PYTHON_STR} "
-        f"('{requires_python}').",
-    )
+    return []
 
 
 def check_description(
     project: dict, pyproject_path: Path, manifest_path: Path
-) -> None:
+) -> list[Diagnostic]:
     """B2-desc: if [project].description is set, must equal manifest.description.
 
     The field is optional; skipped entirely when absent.
     """
     description = project.get("description")
     if description is None:
-        return
+        return []
+    py_desc = str(description).strip()
 
     if not manifest_path.is_file():
-        emit(
-            "FAIL",
-            pyproject_path,
-            "[project].description is set but manifest.yaml is missing; "
-            "cannot verify consistency.",
-        )
-        return
+        return [
+            Diagnostic(
+                check="description-matches-manifest",
+                what=(
+                    f"[project].description is set in {pyproject_path}, but "
+                    f"there is no {manifest_path} to check it against."
+                ),
+                why=(
+                    "Every recipe ships a manifest.yaml, and its "
+                    "`description` is the single source of truth that "
+                    "[project].description has to match. With no manifest "
+                    "the rule cannot be evaluated, and the recipe is "
+                    "missing a required file besides."
+                ),
+                how=(
+                    f"Create {manifest_path} carrying the same description:\n"
+                    f"  description: {py_desc}\n"
+                    f"The generate-manifest AI skill writes the whole file "
+                    f"from the recipe. If the recipe genuinely has no "
+                    f"manifest, delete [project].description instead — the "
+                    f"field is optional."
+                ),
+                doc=Doc.MANIFEST,
+                file=str(pyproject_path),
+            )
+        ]
 
     # Imported lazily so a recipe with no [project].description does not
     # require pyyaml at all.
     try:
         import yaml
-    except ImportError:
-        emit(
-            "FAIL",
-            manifest_path,
-            "pyyaml is required to verify [project].description against "
-            "manifest.description but is not installed. Ensure the workflow "
-            "invokes this script with pyyaml available (e.g. "
-            "`uv run --with pyyaml`).",
-        )
-        return
+    except ImportError as exc:
+        raise CheckerFault(
+            f"pyyaml is not importable ({exc}), so [project].description "
+            f"cannot be compared with manifest.description. The workflow "
+            f"must invoke this script with pyyaml available: "
+            f"`uv run --no-project --with pyyaml --with packaging`."
+        ) from exc
 
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             manifest = yaml.safe_load(f) or {}
-    except yaml.YAMLError as e:
-        emit("FAIL", manifest_path, f"Failed to parse manifest.yaml: {e}")
-        return
+    except (yaml.YAMLError, UnicodeDecodeError) as e:
+        return [
+            Diagnostic(
+                check="description-matches-manifest",
+                what=f"{manifest_path} could not be read as YAML: {e}",
+                why=(
+                    "manifest.yaml is parsed by this check and by "
+                    "tools/validate_manifest.py; a file neither can read "
+                    "blocks every manifest-derived rule."
+                ),
+                how=(
+                    "Fix the YAML (indentation and unquoted colons are the "
+                    "usual culprits), or regenerate the file with the "
+                    "generate-manifest AI skill."
+                ),
+                doc=Doc.MANIFEST,
+                file=str(manifest_path),
+            )
+        ]
 
-    py_desc = description.strip()
-    mf_desc = (manifest.get("description") or "").strip()
-    if py_desc != mf_desc:
-        emit(
-            "FAIL",
-            pyproject_path,
-            f"[project].description does not match manifest.description. "
-            f"pyproject: {py_desc!r} | manifest: {mf_desc!r}. Update "
-            f"whichever is out of date so both match (or drop "
-            f"[project].description from pyproject.toml, since it is "
-            f"optional).",
+    if not isinstance(manifest, dict):
+        return [
+            Diagnostic(
+                check="description-matches-manifest",
+                what=(
+                    f"{manifest_path} is valid YAML but its top level is a "
+                    f"{_describe(manifest)}, not a mapping of fields."
+                ),
+                why=(
+                    "manifest.yaml must be a mapping with top-level keys "
+                    "(name, description, language, …). A document that "
+                    "starts with `- ` is a list, so it has no `description` "
+                    "field for [project].description to match."
+                ),
+                how=(
+                    "Rewrite manifest.yaml as `key: value` pairs, for "
+                    "example:\n"
+                    f"  description: {py_desc}\n"
+                    "The generate-manifest AI skill writes a correctly "
+                    "shaped file from the recipe."
+                ),
+                doc=Doc.MANIFEST,
+                file=str(manifest_path),
+            )
+        ]
+
+    mf_desc = str(manifest.get("description") or "").strip()
+    if py_desc == mf_desc:
+        return []
+    return [
+        Diagnostic(
+            check="description-matches-manifest",
+            what=(
+                f"[project].description does not match "
+                f"manifest.description.\n"
+                f"  pyproject.toml: {py_desc!r}\n"
+                f"  manifest.yaml:  {mf_desc!r}"
+            ),
+            why=(
+                "The two files describe the same recipe in two places; when "
+                "they disagree, the description shown in the catalogue "
+                "depends on which file the reader happens to open."
+            ),
+            how=(
+                "Update whichever is out of date so both read the same, or "
+                "delete [project].description from pyproject.toml — it is "
+                "optional, and manifest.yaml is the source of truth."
+            ),
+            doc=Doc.PROJECT_DESCRIPTION,
+            file=str(pyproject_path),
         )
-    else:
-        emit(
-            "PASS",
-            pyproject_path,
-            "[project].description matches manifest.description.",
-        )
+    ]
 
 
-def check_default_pypi_index(pyproject: dict, pyproject_path: Path) -> None:
+_INDEX_BLOCK = (
+    '  [[tool.uv.index]]\n  url = "https://pypi.org/simple/"\n  default = true'
+)
+
+# Contributor-facing wording deliberately omits the Google-internal reason.
+# The real one: on a corp workstation the system-wide /etc/uv/uv.toml
+# redirects to the Airlock proxy, which the developer would then have to
+# authenticate to. Per uv's config-file merge rules project-level indexes are
+# concatenated ahead of system-level ones, so declaring public PyPI here as
+# default puts it first in the merged list. External contributors have no
+# Airlock, so naming it in the error only confuses them.
+_INDEX_WHY = (
+    "Every recipe must pin public PyPI as its default index so `uv sync` "
+    "resolves the same way on every machine. Without it, a machine-wide uv "
+    "configuration can silently redirect installs to a different index that "
+    "the next person to run the recipe cannot reach."
+)
+
+
+def check_default_pypi_index(
+    pyproject: dict, pyproject_path: Path
+) -> list[Diagnostic]:
     """default-pypi-index: [[tool.uv.index]] with default=true → public PyPI.
 
-    Required so `uv sync` works on Google corp workstations without the
-    developer having to authenticate to the corp Airlock proxy that the
-    system-wide /etc/uv/uv.toml would otherwise redirect to. Per uv's
-    config-file merge rules, project-level indexes are concatenated ahead
-    of system-level ones — declaring public PyPI here as default puts it
-    first in the merged index list.
-
     Fail modes:
-      - No [[tool.uv.index]] at all: FAIL.
-      - Entries exist but none has default=true: FAIL.
-      - A default entry exists but its url is not public PyPI: FAIL (the
-        recipe author may have a legitimate reason but must justify it;
-        default here is strictness so CI protects the repo standard).
+      - No [[tool.uv.index]] at all.
+      - `index` written in a shape uv does not accept (single-bracket table,
+        or a bare list of URL strings).
+      - Entries exist but none has default=true.
+      - A default entry exists but its url is not public PyPI (the recipe
+        author may have a legitimate reason but must justify it; the default
+        here is strictness so CI protects the repo standard).
     """
-    indexes = pyproject.get("tool", {}).get("uv", {}).get("index") or []
+    tool = pyproject.get("tool")
+    uv = tool.get("uv") if isinstance(tool, dict) else None
+    indexes = uv.get("index") if isinstance(uv, dict) else None
     if not indexes:
-        emit(
-            "FAIL",
-            pyproject_path,
-            "Missing required `[[tool.uv.index]]` block. Every recipe "
-            "must declare public PyPI as its default index so `uv sync` "
-            "works without corp Airlock auth. Add:\n"
-            "  [[tool.uv.index]]\n"
-            '  url = "https://pypi.org/simple/"\n'
-            "  default = true",
-        )
-        return
+        return [
+            Diagnostic(
+                check="default-pypi-index",
+                what=(f"{pyproject_path} has no `[[tool.uv.index]]` block."),
+                why=_INDEX_WHY,
+                how=f"Add to pyproject.toml:\n{_INDEX_BLOCK}",
+                doc=Doc.PYPI_INDEX,
+                file=str(pyproject_path),
+            )
+        ]
 
     # `[tool.uv.index]` (single brackets) parses as a dict; `[[tool.uv.index]]`
-    # (double brackets, array-of-tables) parses as a list of dicts. Only the
-    # latter is what uv accepts. Guard against the single-bracket mistake so
-    # we emit a clean FAIL instead of crashing with AttributeError when we
-    # iterate the dict and try `.get()` on a key-string below.
+    # (double brackets, array of tables) parses as a list of dicts. Only the
+    # latter is what uv accepts.
     if not isinstance(indexes, list):
-        emit(
-            "FAIL",
-            pyproject_path,
-            "`[tool.uv.index]` is declared as a single table but uv "
-            "requires an array of tables. Use double brackets:\n"
-            "  [[tool.uv.index]]   ← not [tool.uv.index]\n"
-            '  url = "https://pypi.org/simple/"\n'
-            "  default = true",
-        )
-        return
+        return [
+            Diagnostic(
+                check="default-pypi-index",
+                what=(
+                    f"`tool.uv.index` is a {_describe(indexes)}, but uv "
+                    f"requires an array of tables."
+                ),
+                why=(
+                    "Single brackets declare one table; uv reads "
+                    "`tool.uv.index` as a list of index definitions. "
+                    f"{_INDEX_WHY}"
+                ),
+                how=(
+                    "Use double brackets — `[[tool.uv.index]]`, not "
+                    f"`[tool.uv.index]`:\n{_INDEX_BLOCK}"
+                ),
+                doc=Doc.PYPI_INDEX,
+                file=str(pyproject_path),
+            )
+        ]
+
+    # An inline `index = ["https://…"]` is a list, so it survives the check
+    # above and then has no `.get()`. Each element must be a table.
+    non_tables = [e for e in indexes if not isinstance(e, dict)]
+    if non_tables:
+        return [
+            Diagnostic(
+                check="default-pypi-index",
+                what=(
+                    f"`tool.uv.index` contains an entry that is a "
+                    f"{_describe(non_tables[0])}, not a table."
+                ),
+                why=(
+                    '`index = ["https://pypi.org/simple/"]` is a list of '
+                    "strings. uv needs an array of TABLES, because an index "
+                    "carries more than a url — `default`, and optionally "
+                    f"`name` and `explicit`. {_INDEX_WHY}"
+                ),
+                how=(
+                    "Replace the list of strings with an array of tables:\n"
+                    f"{_INDEX_BLOCK}"
+                ),
+                doc=Doc.PYPI_INDEX,
+                file=str(pyproject_path),
+            )
+        ]
 
     for entry in indexes:
         if entry.get("default") is True:
             url = entry.get("url")
             if url and str(url).lower() in PYPI_URLS:
-                emit(
-                    "PASS",
-                    pyproject_path,
-                    f"[[tool.uv.index]] with default=true points at "
-                    f"public PyPI ('{url}').",
+                return []
+            return [
+                Diagnostic(
+                    check="default-pypi-index",
+                    what=(
+                        f"The `[[tool.uv.index]]` entry with default=true "
+                        f"has url='{url}', which is not public PyPI."
+                    ),
+                    why=_INDEX_WHY,
+                    how=(
+                        "Point the default entry at public PyPI (both the "
+                        "trailing-slash and non-trailing-slash forms are "
+                        f"accepted):\n{_INDEX_BLOCK}\n"
+                        "A private index may be added as an ADDITIONAL "
+                        "non-default entry."
+                    ),
+                    doc=Doc.PYPI_INDEX,
+                    file=str(pyproject_path),
                 )
-                return
-            emit(
-                "FAIL",
-                pyproject_path,
-                f"[[tool.uv.index]] has default=true but url='{url}' is "
-                f"not public PyPI. Change it to "
-                f"'https://pypi.org/simple/' (both trailing-slash and "
-                f"non-trailing-slash forms are accepted).",
-            )
-            return
+            ]
 
-    emit(
-        "FAIL",
-        pyproject_path,
-        "One or more `[[tool.uv.index]]` entries exist but none is marked "
-        "`default = true`. Mark the public-PyPI entry as default, or add "
-        "one:\n"
-        "  [[tool.uv.index]]\n"
-        '  url = "https://pypi.org/simple/"\n'
-        "  default = true",
-    )
+    return [
+        Diagnostic(
+            check="default-pypi-index",
+            what=(
+                f"{pyproject_path} declares {len(indexes)} "
+                f"`[[tool.uv.index]]` entr"
+                f"{'y' if len(indexes) == 1 else 'ies'}, but none is marked "
+                f"`default = true`."
+            ),
+            why=_INDEX_WHY,
+            how=(
+                "Mark the public-PyPI entry as the default, or add one:\n"
+                f"{_INDEX_BLOCK}"
+            ),
+            doc=Doc.PYPI_INDEX,
+            file=str(pyproject_path),
+        )
+    ]
 
 
-def main() -> int:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <recipe-dir>", file=sys.stderr)
-        return 2
+def _project_table(
+    pyproject: dict, pyproject_path: Path, recipe_dir: Path
+) -> tuple[dict, list[Diagnostic]]:
+    """The `[project]` table, or a shape diagnostic if it is not a table."""
+    project = pyproject.get("project")
+    if project is None:
+        return {}, []
+    if isinstance(project, dict):
+        return project, []
+    return {}, [
+        Diagnostic(
+            check="project-table",
+            what=(
+                f"`project` in {pyproject_path} is a {_describe(project)}, "
+                f"not a table."
+            ),
+            why=(
+                "`[[project]]` (double brackets) declares an array of "
+                "tables. PEP 621 requires a single `[project]` table, and "
+                "every metadata rule reads its fields from there — so as "
+                "written, name, requires-python and description are all "
+                "invisible to uv and to this check."
+            ),
+            how=(
+                "Use single brackets:\n"
+                "  [project]   ← not [[project]]\n"
+                f'  name = "{expected_project_name(recipe_dir)}"\n'
+                f'  requires-python = ">={MIN_PYTHON_STR}"'
+            ),
+            doc=Doc.PROJECT_NAME,
+            file=str(pyproject_path),
+        )
+    ]
 
-    recipe_dir = Path(sys.argv[1])
+
+def _run(recipe_dir: Path) -> int:
     pyproject_path = recipe_dir / "pyproject.toml"
     manifest_path = recipe_dir / "manifest.yaml"
 
     if not pyproject_path.is_file():
-        # A separate required-files check in the workflow reports this; stay
-        # silent here so we don't double up on the same failure.
-        return 0
+        # A separate required-files check in the workflow reports this; not
+        # repeating it here keeps one missing file from producing two errors.
+        print(
+            f"[SKIP] {pyproject_path} does not exist — the required-files "
+            f"check reports that separately."
+        )
+        return EXIT_OK
 
     try:
         with open(pyproject_path, "rb") as f:
             pyproject = tomllib.load(f)
     except tomllib.TOMLDecodeError as e:
-        emit("FAIL", pyproject_path, f"Failed to parse pyproject.toml: {e}")
-        return 0
+        return _report(
+            [
+                Diagnostic(
+                    check="pyproject-parse",
+                    what=f"{pyproject_path} is not valid TOML: {e}",
+                    why=(
+                        "uv, pip and this check all parse pyproject.toml "
+                        "before anything else; while it does not parse, no "
+                        "other rule about the recipe can even be evaluated."
+                    ),
+                    how=(
+                        "Fix the syntax at the position reported above. To "
+                        "see the same error locally:\n"
+                        "  python3 -c 'import tomllib,sys; "
+                        'tomllib.load(open(sys.argv[1],"rb"))\' '
+                        f"{pyproject_path}"
+                    ),
+                    doc=Doc.PROJECT_NAME,
+                    file=str(pyproject_path),
+                )
+            ],
+            recipe_dir,
+        )
 
-    project = pyproject.get("project") or {}
-    check_name(project, pyproject_path, recipe_dir)
-    check_requires_python(project, pyproject_path)
-    check_description(project, pyproject_path, manifest_path)
-    check_default_pypi_index(pyproject, pyproject_path)
-    return 0
+    project, diagnostics = _project_table(pyproject, pyproject_path, recipe_dir)
+    if not diagnostics:
+        diagnostics += check_name(project, pyproject_path, recipe_dir)
+        diagnostics += check_requires_python(project, pyproject_path)
+        diagnostics += check_description(project, pyproject_path, manifest_path)
+    diagnostics += check_default_pypi_index(pyproject, pyproject_path)
+    return _report(diagnostics, recipe_dir)
+
+
+def _report(diagnostics: list[Diagnostic], recipe_dir: Path) -> int:
+    return report(
+        diagnostics,
+        header=f"{recipe_dir}: pyproject.toml metadata",
+        passed_message=(
+            f"{recipe_dir}/pyproject.toml: name, requires-python, "
+            f"description and default index all satisfy the repo rules."
+        ),
+        next_step=(
+            "The align-recipe-pyproject AI skill applies all of these fixes "
+            "in place, preserving comments."
+        ),
+    )
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return report_infra_fault(
+            infra_fault(
+                CHECKER,
+                f"invoked with {len(sys.argv) - 1} argument(s); expected "
+                f"exactly one recipe directory.",
+            )
+        )
+
+    recipe_dir = Path(sys.argv[1])
+    if not recipe_dir.is_dir():
+        return report_infra_fault(
+            infra_fault(
+                CHECKER,
+                f"{recipe_dir} is not a directory. The path came from the "
+                f"workflow's recipe discovery step, not from the "
+                f"contributor.",
+            )
+        )
+
+    try:
+        return _run(recipe_dir)
+    except CheckerFault as exc:
+        return report_infra_fault(infra_fault(CHECKER, str(exc)))
+    except Exception as exc:
+        return report_infra_fault(
+            infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
+        )
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Belt and braces: a traceback escaping to the runner is reported by the
+    # workflow as the contributor's failure, which is exactly the confusion
+    # infra_fault exists to prevent.
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        sys.exit(
+            report_infra_fault(
+                infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
+            )
+        )

--- a/.github/scripts/check_recipe_pyproject.py
+++ b/.github/scripts/check_recipe_pyproject.py
@@ -60,6 +60,7 @@ from ci_message import (
     EXIT_OK,
     Diagnostic,
     Doc,
+    guard,
     infra_fault,
     report,
     report_infra_fault,
@@ -776,14 +777,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    # Belt and braces: a traceback escaping to the runner is reported by the
+    # guard(): a traceback escaping to the runner is reported by the
     # workflow as the contributor's failure, which is exactly the confusion
     # infra_fault exists to prevent.
-    try:
-        sys.exit(main())
-    except Exception as exc:
-        sys.exit(
-            report_infra_fault(
-                infra_fault(CHECKER, f"{type(exc).__name__}: {exc}")
-            )
-        )
+    sys.exit(guard(CHECKER, main))

--- a/.github/scripts/tests/test_check_env_vars.py
+++ b/.github/scripts/tests/test_check_env_vars.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for check_env_vars.py.
+
+The undeclared-variable error is the highest-volume CI failure in this repo,
+so these tests pin what the message has to contain — the reading site, a
+literal line to paste, and the skill that does it for you — as well as the
+exit-code contract the workflow branches on.
+"""
+
+import sys
+from pathlib import Path
+
+import check_env_vars as m
+
+# The numbers the workflow branches on. Spelled out rather than imported so
+# a change to them has to be made deliberately in two places.
+EXIT_OK = 0
+EXIT_VIOLATIONS = 1
+EXIT_CI_FAULT = 2
+
+
+def _recipe(tmp_path: Path, env_example: str | bytes | None, **sources: str):
+    if env_example is not None:
+        target = tmp_path / ".env.example"
+        if isinstance(env_example, bytes):
+            target.write_bytes(env_example)
+        else:
+            target.write_text(env_example, encoding="utf-8")
+    for name, body in sources.items():
+        path = tmp_path / f"{name}.py"
+        path.write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def _run(tmp_path: Path, monkeypatch) -> int:
+    monkeypatch.setattr(sys, "argv", ["check_env_vars.py", str(tmp_path)])
+    return m.main()
+
+
+def test_declared_variable_passes(tmp_path, monkeypatch, capsys):
+    _recipe(
+        tmp_path,
+        "GOOGLE_CLOUD_PROJECT=my-project\n",
+        agent='import os\n\nP = os.getenv("GOOGLE_CLOUD_PROJECT")\n',
+    )
+    assert _run(tmp_path, monkeypatch) == EXIT_OK
+    assert "::error" not in capsys.readouterr().out
+
+
+def test_allowlisted_variable_is_not_reported(tmp_path, monkeypatch):
+    _recipe(
+        tmp_path,
+        "GOOGLE_CLOUD_PROJECT=my-project\n",
+        agent='import os\n\nH = os.environ["HOME"]\n',
+    )
+    assert _run(tmp_path, monkeypatch) == EXIT_OK
+
+
+def test_undeclared_variable_names_the_file_and_line(
+    tmp_path, monkeypatch, capsys
+):
+    _recipe(
+        tmp_path,
+        "GOOGLE_CLOUD_PROJECT=my-project\n",
+        agent=(
+            "import os\n"
+            "\n"
+            'P = os.getenv("GOOGLE_CLOUD_PROJECT")\n'
+            "M = os.getenv(\n"
+            '    "MODEL_NAME",\n'
+            '    "gemini-3.5-flash",\n'
+            ")\n"
+        ),
+    )
+    assert _run(tmp_path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "MODEL_NAME" in out
+    # The read is on line 4 even though the string literal is on line 5.
+    assert f"{tmp_path / 'agent.py'}:4" in out
+    # A literal line to paste, not a description of one.
+    assert f"MODEL_NAME={m.PLACEHOLDER}" in out
+    # The skill the handbook tells contributors to use.
+    assert "extract-python-environment-variables" in out
+    assert f"::error file={tmp_path / '.env.example'}::" in out
+
+
+def test_each_undeclared_variable_gets_its_own_annotation(
+    tmp_path, monkeypatch, capsys
+):
+    _recipe(
+        tmp_path,
+        "# nothing declared\n",
+        agent='import os\n\nA = os.getenv("ONE")\nB = os.getenv("TWO")\n',
+    )
+    assert _run(tmp_path, monkeypatch) == EXIT_VIOLATIONS
+    assert capsys.readouterr().out.count("::error file=") == 2
+
+
+def test_a_file_that_does_not_parse_is_reported_not_skipped(
+    tmp_path, monkeypatch, capsys
+):
+    """A silent skip let a recipe with a syntax error report a false PASS:
+    every env read inside the unparsed file was invisible to the check."""
+    _recipe(tmp_path, "GOOGLE_CLOUD_PROJECT=x\n", broken="def oops(\n")
+    assert _run(tmp_path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "not valid Python" in out
+    assert "[PASS]" not in out
+    assert f"::error file={tmp_path / 'broken.py'}::" in out
+
+
+def test_non_utf8_env_example_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    _recipe(
+        tmp_path,
+        "MY_VAR=caf\u00e9\n".encode("latin-1"),
+        agent='import os\n\nV = os.getenv("MY_VAR")\n',
+    )
+    assert _run(tmp_path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "Traceback" not in out
+    assert "not valid UTF-8" in out
+    # Every variable would look undeclared against an unreadable file, so
+    # the encoding is the only thing reported.
+    assert out.count("::error file=") == 1
+
+
+def test_missing_env_example_is_not_this_checkers_failure(
+    tmp_path, monkeypatch, capsys
+):
+    _recipe(tmp_path, None, agent='import os\n\nV = os.getenv("X")\n')
+    assert _run(tmp_path, monkeypatch) == EXIT_OK
+    assert "::error" not in capsys.readouterr().out
+
+
+def test_a_path_that_is_not_a_directory_is_a_ci_fault(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        sys, "argv", ["check_env_vars.py", str(tmp_path / "nope")]
+    )
+    assert m.main() == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "[ci-fault]" in out
+    assert "::error file=" not in out
+
+
+def test_an_unexpected_crash_is_a_ci_fault_not_the_contributors_fault(
+    tmp_path, monkeypatch, capsys
+):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("checker bug")
+
+    monkeypatch.setattr(m, "_collect_used_vars", boom)
+    _recipe(tmp_path, "A=1\n")
+    assert _run(tmp_path, monkeypatch) == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "RuntimeError: checker bug" in out
+    assert "::error file=" not in out

--- a/.github/scripts/tests/test_check_lockfile_hashes.py
+++ b/.github/scripts/tests/test_check_lockfile_hashes.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for check_lockfile_hashes.py.
+
+A malformed uv.lock used to raise AttributeError here, after which the
+workflow announced a confident and wrong diagnosis about missing sha256
+hashes. These tests pin both halves of the fix: the shape is reported as
+what it is, and a missing hash now carries a rule and a fix instead of a
+bare `name==version: url` line with no annotation at all.
+"""
+
+import sys
+from pathlib import Path
+
+import check_lockfile_hashes as m
+
+# The numbers the workflow branches on. Spelled out rather than imported so
+# a change to them has to be made deliberately in two places.
+EXIT_OK = 0
+EXIT_VIOLATIONS = 1
+EXIT_CI_FAULT = 2
+
+_HASH = "sha256:" + "0" * 64
+
+
+def _lock(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "uv.lock"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _run(path, monkeypatch) -> int:
+    monkeypatch.setattr(sys, "argv", ["check_lockfile_hashes.py", str(path)])
+    return m.main()
+
+
+def test_hashed_lockfile_passes(tmp_path, monkeypatch, capsys):
+    path = _lock(
+        tmp_path,
+        "version = 1\n\n"
+        "[[package]]\n"
+        'name = "foo"\nversion = "1.0"\n\n'
+        "[[package.wheels]]\n"
+        'url = "https://files.pythonhosted.org/foo-1.0.whl"\n'
+        f'hash = "{_HASH}"\n',
+    )
+    assert _run(path, monkeypatch) == EXIT_OK
+    assert "::error" not in capsys.readouterr().out
+
+
+def test_missing_hash_is_annotated_with_a_rule_and_a_fix(
+    tmp_path, monkeypatch, capsys
+):
+    """It used to print `  foo==1.0: <url>` — no verb, no rule, no fix, and
+    no annotation, so the PR Files tab showed nothing at all."""
+    path = _lock(
+        tmp_path,
+        "version = 1\n\n"
+        "[[package]]\n"
+        'name = "foo"\nversion = "1.0"\n\n'
+        "[[package.wheels]]\n"
+        'url = "https://files.pythonhosted.org/foo-1.0.whl"\n',
+    )
+    assert _run(path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "foo==1.0" in out
+    assert "uv lock" in out
+    assert f"::error file={path}::" in out
+
+
+def test_malformed_hash_is_reported(tmp_path, monkeypatch, capsys):
+    path = _lock(
+        tmp_path,
+        "version = 1\n\n"
+        "[[package]]\n"
+        'name = "foo"\nversion = "1.0"\n\n'
+        "[[package.wheels]]\n"
+        'url = "https://files.pythonhosted.org/foo-1.0.whl"\n'
+        'hash = "md5:deadbeef"\n',
+    )
+    assert _run(path, monkeypatch) == EXIT_VIOLATIONS
+    assert "unrecognised hash" in capsys.readouterr().out
+
+
+def test_sourceless_kinds_are_skipped(tmp_path, monkeypatch):
+    path = _lock(
+        tmp_path,
+        "version = 1\n\n"
+        "[[package]]\n"
+        'name = "my-recipe"\nversion = "0.1.0"\n'
+        'source = { virtual = "." }\n',
+    )
+    assert _run(path, monkeypatch) == EXIT_OK
+
+
+def test_a_package_entry_that_is_not_a_table_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    path = _lock(tmp_path, 'version = 1\npackage = ["not-a-table"]\n')
+    assert _run(path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "AttributeError" not in out
+    assert "entry #1" in out
+    assert "not a table" in out
+    assert f"::error file={path}::" in out
+
+
+def test_a_non_table_distribution_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    path = _lock(
+        tmp_path,
+        "version = 1\n\n"
+        "[[package]]\n"
+        'name = "foo"\nversion = "1.0"\nwheels = ["a-wheel"]\n',
+    )
+    assert _run(path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "AttributeError" not in out
+    assert "not a table" in out
+
+
+def test_package_declared_as_a_table_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    path = _lock(tmp_path, 'version = 1\n\n[package]\nname = "foo"\n')
+    assert _run(path, monkeypatch) == EXIT_VIOLATIONS
+    assert "not an array of tables" in capsys.readouterr().out
+
+
+def test_invalid_toml_is_reported_against_the_lockfile(
+    tmp_path, monkeypatch, capsys
+):
+    path = _lock(tmp_path, "[[package\nname = broken\n")
+    assert _run(path, monkeypatch) == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "not valid TOML" in out
+    assert "Traceback" not in out
+
+
+def test_a_missing_lockfile_is_a_ci_fault(tmp_path, monkeypatch, capsys):
+    """The path comes from the workflow's discovery step, not the recipe."""
+    assert _run(tmp_path / "absent.lock", monkeypatch) == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "[ci-fault]" in out
+    assert "::error file=" not in out
+
+
+def test_wrong_argument_count_is_a_ci_fault(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["check_lockfile_hashes.py"])
+    assert m.main() == EXIT_CI_FAULT
+    assert "[ci-fault]" in capsys.readouterr().out
+
+
+def test_an_unexpected_crash_is_a_ci_fault(tmp_path, monkeypatch, capsys):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("checker bug")
+
+    monkeypatch.setattr(m, "_check_package", boom)
+    path = _lock(
+        tmp_path, 'version = 1\n\n[[package]]\nname = "foo"\nversion = "1"\n'
+    )
+    assert _run(path, monkeypatch) == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "RuntimeError: checker bug" in out
+    assert "::error file=" not in out

--- a/.github/scripts/tests/test_check_recipe_pyproject.py
+++ b/.github/scripts/tests/test_check_recipe_pyproject.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the project-name rule in check_recipe_pyproject.py.
+"""Unit tests for check_recipe_pyproject.py.
 
-This script gates real PRs but had no test coverage. These tests pin the
-`skills/<vertical>/<solution>` naming behaviour so a future refactor cannot
+This script gates real PRs. The naming tests pin the
+`skills/<vertical>/<solution>` behaviour so a future refactor cannot
 silently reintroduce the basename-only rule, which would force two verticals
 that ship a same-named solution to declare the same distribution name.
 
@@ -22,12 +22,23 @@ The rule is implemented twice on purpose — the read-only validator here and
 the comment-preserving auto-fixer in
 .agents/skills/align-recipe-pyproject/scripts/align_pyproject.py. The two
 implementations are cross-checked at the bottom of this file.
+
+The rest of the file pins the exit-code contract the workflow reads, and the
+malformed-input cases that used to escape as an AttributeError traceback —
+which the workflow then reported as the contributor's error.
 """
 
+import sys
 from pathlib import Path
 
 import check_recipe_pyproject as m
 import pytest
+
+# The numbers the workflow branches on. Spelled out rather than imported so
+# a change to them has to be made deliberately in two places.
+EXIT_OK = 0
+EXIT_VIOLATIONS = 1
+EXIT_CI_FAULT = 2
 
 # Where actions/checkout puts the repo on a GitHub runner. The workflow hands
 # the script a repo-relative path, but a developer debugging by hand may pass
@@ -35,10 +46,20 @@ import pytest
 CI_CHECKOUT = "/home/runner/work/adk-samples/adk-samples"
 
 
-def _records(capsys) -> list[tuple[str, str]]:
-    """Parse emitted `KIND::path::message` lines into (kind, message)."""
-    out = capsys.readouterr().out.strip().splitlines()
-    return [(ln.split("::", 2)[0], ln.split("::", 2)[2]) for ln in out if ln]
+def _text(diagnostic) -> str:
+    """Everything the contributor reads, as one searchable string."""
+    return diagnostic.render_human()
+
+
+def _run(tmp_path: Path, monkeypatch, pyproject: str, manifest=None) -> int:
+    """Invoke the script the way CI does, on a throwaway recipe."""
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    if manifest is not None:
+        (tmp_path / "manifest.yaml").write_text(manifest, encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", ["check_recipe_pyproject.py", str(tmp_path)]
+    )
+    return m.main()
 
 
 # ---------------------------------------------------------------------------
@@ -124,63 +145,296 @@ def test_two_verticals_sharing_a_solution_name_do_not_collide():
 # ---------------------------------------------------------------------------
 
 
-def test_skill_with_vertical_prefixed_name_passes(capsys):
-    m.check_name(
-        {"name": "retail-product-search"},
-        Path("skills/retail/product-search/pyproject.toml"),
-        Path("skills/retail/product-search"),
+def test_skill_with_vertical_prefixed_name_passes():
+    assert (
+        m.check_name(
+            {"name": "retail-product-search"},
+            Path("skills/retail/product-search/pyproject.toml"),
+            Path("skills/retail/product-search"),
+        )
+        == []
     )
-    ((kind, msg),) = _records(capsys)
-    assert kind == "PASS"
-    assert "retail-product-search" in msg
 
 
-def test_skill_with_bare_basename_fails_and_explains_why(capsys):
-    m.check_name(
+def test_skill_with_bare_basename_fails_and_explains_why():
+    (diag,) = m.check_name(
         {"name": "product-search"},
         Path("skills/retail/product-search/pyproject.toml"),
         Path("skills/retail/product-search"),
     )
-    ((kind, msg),) = _records(capsys)
-    assert kind == "FAIL"
-    assert "retail-product-search" in msg
+    text = _text(diag)
+    assert "retail-product-search" in text
     # The contributor should not have to go read the script to understand it.
-    assert "<vertical>-<solution>" in msg
+    assert "<vertical>-<solution>" in text
+    # And should not have to work out where to type it.
+    assert 'name = "retail-product-search"' in diag.how
 
 
-def test_core_recipe_message_omits_the_vertical_explanation(capsys):
+def test_core_recipe_message_omits_the_vertical_explanation():
     """core/ and contrib/ messages stay as terse as they were pre-change."""
-    m.check_name(
+    (diag,) = m.check_name(
         {"name": "wrong"},
         Path("core/python/deep-search/pyproject.toml"),
         Path("core/python/deep-search"),
     )
-    ((kind, msg),) = _records(capsys)
-    assert kind == "FAIL"
-    assert "deep-search" in msg
-    assert "vertical" not in msg
+    text = _text(diag)
+    assert "deep-search" in text
+    assert "vertical" not in text
 
 
-def test_core_recipe_with_matching_basename_passes(capsys):
-    m.check_name(
-        {"name": "deep-search"},
-        Path("core/python/deep-search/pyproject.toml"),
-        Path("core/python/deep-search"),
+def test_core_recipe_with_matching_basename_passes():
+    assert (
+        m.check_name(
+            {"name": "deep-search"},
+            Path("core/python/deep-search/pyproject.toml"),
+            Path("core/python/deep-search"),
+        )
+        == []
     )
-    ((kind, _),) = _records(capsys)
-    assert kind == "PASS"
 
 
-def test_missing_name_reports_the_expected_value(capsys):
-    m.check_name(
+def test_missing_name_reports_the_expected_value():
+    (diag,) = m.check_name(
         {},
         Path("skills/retail/product-search/pyproject.toml"),
         Path("skills/retail/product-search"),
     )
-    ((kind, msg),) = _records(capsys)
-    assert kind == "FAIL"
-    assert "is missing" in msg
-    assert "retail-product-search" in msg
+    assert "is missing" in diag.what
+    assert "retail-product-search" in _text(diag)
+
+
+# ---------------------------------------------------------------------------
+# Exit-code contract
+#
+# The workflow no longer parses records out of stdout; it branches on the
+# exit code alone. 0/1/2 have to mean exactly one thing each.
+# ---------------------------------------------------------------------------
+
+_GOOD_INDEX = """
+[[tool.uv.index]]
+url = "https://pypi.org/simple/"
+default = true
+"""
+
+
+def _good_pyproject(name: str) -> str:
+    return (
+        f'[project]\nname = "{name}"\nversion = "0.1.0"\n'
+        f'requires-python = ">=3.11"\n{_GOOD_INDEX}'
+    )
+
+
+def test_conforming_recipe_exits_zero(tmp_path, monkeypatch, capsys):
+    code = _run(tmp_path, monkeypatch, _good_pyproject(tmp_path.name))
+    assert code == EXIT_OK
+    out = capsys.readouterr().out
+    assert out.startswith("[PASS]")
+    assert "::error" not in out
+
+
+def test_violation_exits_one_and_annotates_the_file(
+    tmp_path, monkeypatch, capsys
+):
+    code = _run(tmp_path, monkeypatch, _good_pyproject("wrong-name"))
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert f"::error file={tmp_path}/pyproject.toml::" in out
+
+
+def test_every_violation_gets_its_own_annotation(tmp_path, monkeypatch, capsys):
+    """No "first error (+N more)" collapse: the Files tab shows them all."""
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        '[project]\nname = "wrong-name"\nrequires-python = ">=3.9"\n',
+    )
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    # name, requires-python, missing index.
+    assert out.count("::error file=") == 3
+
+
+def test_missing_pyproject_is_not_this_checkers_failure(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        sys, "argv", ["check_recipe_pyproject.py", str(tmp_path)]
+    )
+    assert m.main() == EXIT_OK
+    assert "::error" not in capsys.readouterr().out
+
+
+def test_a_path_that_is_not_a_directory_is_a_ci_fault(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        sys, "argv", ["check_recipe_pyproject.py", str(tmp_path / "nope")]
+    )
+    assert m.main() == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "[ci-fault]" in out
+    # A CI fault must never put a marker on a contributor's file.
+    assert "::error file=" not in out
+
+
+def test_an_unexpected_crash_is_a_ci_fault_not_the_contributors_fault(
+    tmp_path, monkeypatch, capsys
+):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("checker bug")
+
+    monkeypatch.setattr(m, "check_name", boom)
+    code = _run(tmp_path, monkeypatch, _good_pyproject(tmp_path.name))
+    assert code == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "RuntimeError: checker bug" in out
+    assert "::error file=" not in out
+
+
+# ---------------------------------------------------------------------------
+# Malformed input that used to raise AttributeError
+#
+# Each of these produced a traceback, which the workflow then reported as
+# "checker crashed" against the contributor's pyproject.toml.
+# ---------------------------------------------------------------------------
+
+
+def test_project_as_array_of_tables_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        f'[[project]]\nname = "{tmp_path.name}"\n{_GOOD_INDEX}',
+    )
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "AttributeError" not in out
+    assert "not a table" in out
+    assert "[project]   ← not [[project]]" in out
+
+
+def test_index_as_a_list_of_strings_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\n'
+        f'requires-python = ">=3.11"\n\n[tool.uv]\n'
+        f'index = ["https://pypi.org/simple/"]\n',
+    )
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "AttributeError" not in out
+    assert "not a table" in out
+    assert "[[tool.uv.index]]" in out
+
+
+def test_index_as_a_single_table_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\n'
+        f'requires-python = ">=3.11"\n\n[tool.uv.index]\n'
+        f'url = "https://pypi.org/simple/"\ndefault = true\n',
+    )
+    assert code == EXIT_VIOLATIONS
+    assert "array of tables" in capsys.readouterr().out
+
+
+def test_the_index_fix_survives_as_multiple_lines_in_the_annotation(
+    tmp_path, monkeypatch, capsys
+):
+    """The reason the annotation is built here and not in shell: the old
+    demux collapsed newlines, rendering the TOML fix as one invalid line."""
+    _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\nrequires-python = ">=3.11"\n',
+    )
+    annotation = next(
+        ln
+        for ln in capsys.readouterr().out.splitlines()
+        if ln.startswith("::error file=")
+    )
+    assert "%0A" in annotation
+    assert 'url = "https://pypi.org/simple/"' in annotation
+
+
+def test_the_index_message_carries_no_google_internal_jargon(
+    tmp_path, monkeypatch, capsys
+):
+    _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\nrequires-python = ">=3.11"\n',
+    )
+    assert "Airlock" not in capsys.readouterr().out
+
+
+def test_list_shaped_manifest_is_reported_not_crashed(
+    tmp_path, monkeypatch, capsys
+):
+    pytest.importorskip("yaml")
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\n'
+        f'requires-python = ">=3.11"\ndescription = "d"\n{_GOOD_INDEX}',
+        manifest="- a\n- b\n",
+    )
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "AttributeError" not in out
+    assert "not a mapping" in out
+
+
+def test_missing_manifest_says_what_to_do_about_it(
+    tmp_path, monkeypatch, capsys
+):
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\n'
+        f'requires-python = ">=3.11"\ndescription = "A recipe."\n'
+        f"{_GOOD_INDEX}",
+    )
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    # A symptom ("cannot verify consistency") is not an action.
+    assert "description: A recipe." in out
+
+
+def test_missing_pyyaml_is_a_ci_fault_not_a_contributor_error(
+    tmp_path, monkeypatch, capsys
+):
+    """The contributor cannot install a dependency into our runner."""
+    # A None entry in sys.modules makes `import yaml` raise ImportError.
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    code = _run(
+        tmp_path,
+        monkeypatch,
+        f'[project]\nname = "{tmp_path.name}"\n'
+        f'requires-python = ">=3.11"\ndescription = "d"\n{_GOOD_INDEX}',
+        manifest="description: d\n",
+    )
+    assert code == EXIT_CI_FAULT
+    out = capsys.readouterr().out
+    assert "[ci-fault]" in out
+    assert "::error file=" not in out
+
+
+def test_invalid_toml_is_reported_against_the_file(
+    tmp_path, monkeypatch, capsys
+):
+    code = _run(tmp_path, monkeypatch, "[project\nname = broken\n")
+    assert code == EXIT_VIOLATIONS
+    out = capsys.readouterr().out
+    assert "not valid TOML" in out
+    assert "Traceback" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -41,11 +41,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check links
+        id: lychee
         # Lychee: covers relative filesystem links, anchor links, and
         # external HTTP(S) URLs. --no-progress keeps CI logs clean.
         # --exclude on '^https?://github.com/google/adk-samples/(issues|pulls)'
         # avoids rate-limiting on unauthenticated GitHub API calls when
         # docs link to the repo's own issues page.
+        #
+        # `fail: false` + an explicit failure step below. Letting the action
+        # fail on its own produced a red X and nothing else: a genuinely
+        # dead link and a transient upstream 503 were indistinguishable,
+        # and neither told the contributor which file to open. --format
+        # markdown writes a readable report we can put in the job summary
+        # and echo.
         uses: lycheeverse/lychee-action@v2
         env:
           # Authenticate GitHub link checks with the workflow token so
@@ -59,4 +67,48 @@ jobs:
             --no-progress
             --exclude '^https?://github\.com/google/adk-samples/(issues|pulls)'
             'docs/**/*.md'
-          fail: true
+          output: lychee-report.md
+          format: markdown
+          fail: false
+
+      - name: Report broken links
+        env:
+          EXIT_CODE: ${{ steps.lychee.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EXIT_CODE" = "0" ]; then
+            echo "[PASS] Every link under docs/ resolves."
+            exit 0
+          fi
+
+          echo "::group::lychee report"
+          cat lychee-report.md 2>/dev/null || echo "(no report file was produced)"
+          echo "::endgroup::"
+
+          # Surface the report on the run summary page too, so a reviewer
+          # does not have to open the raw log to see which link broke.
+          if [ -f lychee-report.md ]; then
+            cat lychee-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo ""
+          echo "========================================"
+          echo "  ACTION REQUIRED: broken link(s) in docs/"
+          echo "========================================"
+          echo ""
+          echo "The report above lists each failing link with the file it"
+          echo "appears in and the status it returned."
+          echo ""
+          echo "  - 404 / ENOTFOUND on a relative path: the target file was"
+          echo "    renamed, moved or deleted. Fix the path."
+          echo "  - 404 on an anchor (#some-heading): the heading was renamed."
+          echo "    Anchors are lowercase, spaces become hyphens, punctuation"
+          echo "    is dropped."
+          echo "  - 429 / 503 / timeout on an external URL: usually transient."
+          echo "    Re-run the job before changing anything. If the host is"
+          echo "    permanently rate-limiting us, add it to --exclude in"
+          echo "    .github/workflows/docs-links.yml."
+          echo ""
+          echo "::error::Broken link(s) found in docs/ — see the lychee report in this job's log and summary."
+          exit 1

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v4
 
       - name: Check links
         id: lychee
@@ -54,7 +54,7 @@ jobs:
         # and neither told the contributor which file to open. --format
         # markdown writes a readable report we can put in the job summary
         # and echo.
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # ratchet:lycheeverse/lychee-action@v2.9.0
         env:
           # Authenticate GitHub link checks with the workflow token so
           # docs that link to any github.com URL (users, other repos,

--- a/.github/workflows/go-format.yml
+++ b/.github/workflows/go-format.yml
@@ -358,11 +358,33 @@ jobs:
             exit 1
           fi
 
+          # Both exits below used to be bare, so a formatting failure and a
+          # reviewdog failure each produced a red X with nothing to read.
           if [ "$FMT_STATUS" -ne 0 ]; then
+            echo ""
+            echo "========================================"
+            echo "  ACTION REQUIRED: Go files need formatting"
+            echo "========================================"
+            echo ""
+            echo "The diff above shows what gofmt/gci would change. Apply it"
+            echo "locally and commit the result:"
+            echo ""
+            echo "  gofmt -w <changed .go files>"
+            echo ""
+            echo "Import grouping is enforced by gci using each module's own"
+            echo "go.mod for the localmodule section, so run it from inside"
+            echo "the module directory."
             exit 1
           fi
 
-          exit "$RD_STATUS"
+          if [ "$RD_STATUS" -ne 0 ]; then
+            echo ""
+            echo "::error::reviewdog reported at least one formatting finding on the changed Go files — see the annotations and the diff above."
+            echo "[FAIL] reviewdog exited $RD_STATUS."
+            exit "$RD_STATUS"
+          fi
+
+          echo "[PASS] All changed Go files are correctly formatted."
 
   go-lint:
     name: Go Lint Suggestions
@@ -545,15 +567,29 @@ jobs:
           #    --issues-exit-code 0 a non-zero there can only be a crash
           #    (unresolvable dep, broken go.mod), which stays fatal.
           RD_STATUS=0
+          FINDINGS=0
           for mod in "${MODULES[@]}"; do
             echo "Linting module '$mod'"
+
+            # Emit BOTH formats: text to the log for a human, checkstyle to
+            # a file for reviewdog. Previously checkstyle went to stdout and
+            # was redirected wholesale into lint.xml, so the findings existed
+            # only inside a file that the EXIT trap deleted unprinted — on a
+            # fork PR, where reviewdog cannot post review comments (read-only
+            # GITHUB_TOKEN, 403), the contributor got a red X and no way to
+            # learn which rule fired in which file.
             ( cd "$mod" && golangci-lint run \
                 --issues-exit-code 0 \
                 --show-stats=false \
-                --output.text.path "" \
-                --output.checkstyle.path stdout \
-                ./... ) > "$WORK/lint.xml"
+                --output.text.path stdout \
+                --output.checkstyle.path "$WORK/lint.xml" \
+                ./... )
 
+            if [ -s "$WORK/lint.xml" ] && grep -q "<error" "$WORK/lint.xml"; then
+              FINDINGS=1
+            fi
+
+            # Best-effort inline annotations; the log above is authoritative.
             reviewdog -f=checkstyle \
                       -name="golangci-lint" \
                       -reporter=github-pr-review \
@@ -561,4 +597,22 @@ jobs:
                       -fail-level=any < "$WORK/lint.xml" || RD_STATUS=1
           done
 
-          exit "$RD_STATUS"
+          if [ "$FINDINGS" -eq 0 ] && [ "$RD_STATUS" -eq 0 ]; then
+            echo "[PASS] golangci-lint reported no findings on the changed Go files."
+            exit 0
+          fi
+
+          echo ""
+          echo "========================================"
+          echo "  ACTION REQUIRED: Go lint findings"
+          echo "========================================"
+          echo ""
+          echo "Each finding above is printed as file:line:col: message"
+          echo "followed by the linter that produced it. Reproduce locally:"
+          echo ""
+          echo "  cd <module-dir> && golangci-lint run ./..."
+          echo ""
+          echo "Some linters can fix their own findings:"
+          echo ""
+          echo "  cd <module-dir> && golangci-lint run --fix ./..."
+          exit 1

--- a/.github/workflows/python-dependency-policy.yml
+++ b/.github/workflows/python-dependency-policy.yml
@@ -317,6 +317,7 @@ jobs:
           set -euo pipefail
 
           FAILED=0
+          CI_FAULT=0
 
           while IFS= read -r lockfile; do
             # --no-project: skip project discovery so uv does NOT walk up, find
@@ -325,13 +326,55 @@ jobs:
             # project environment is needed. Using `uv run` (vs bare python3)
             # still gives us uv's managed Python rather than whatever happens to
             # be on the runner's PATH.
-            uv run --no-project python3 .github/scripts/check_lockfile_hashes.py "$lockfile" || FAILED=1
+            #
+            # Exit status carries whose fault it is: 1 = missing hashes the
+            # contributor must regenerate, 2 = the checker itself could not
+            # parse the lockfile. Previously ANY failure printed the
+            # "re-generate with uv lock" advice below, so a crash produced a
+            # confident diagnosis that happened to be wrong.
+            set +e
+            uv run --no-project python3 .github/scripts/check_lockfile_hashes.py "$lockfile"
+            hash_exit=$?
+            set -e
+            case "$hash_exit" in
+              0) ;;
+              1) FAILED=1 ;;
+              2) CI_FAULT=1 ;;
+              *)
+                echo "::error::check_lockfile_hashes.py exited with an undefined status ($hash_exit). This is a CI tooling bug, not a problem with your recipe."
+                CI_FAULT=1
+                ;;
+            esac
           done < "$LOCKFILES_FILE"
+
+          if [ "$CI_FAULT" -eq 1 ]; then
+            echo ""
+            echo "========================================"
+            echo "  CI TOOLING FAILURE — not your changes"
+            echo "========================================"
+            echo ""
+            echo "The hash checker could not read a lockfile, so we do not"
+            echo "know whether the hashes are present. Re-run the job; if it"
+            echo "fails again, open an issue with the detail above."
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
+            exit 1
+          fi
 
           if [ "$FAILED" -eq 1 ]; then
             echo ""
-            echo "All distributions must have sha256 hashes for supply chain integrity."
-            echo "Re-generate the lockfile with 'uv lock'."
+            echo "========================================"
+            echo "  ACTION REQUIRED: lockfile missing hashes"
+            echo "========================================"
+            echo ""
+            echo "Every distribution needs a sha256 hash for supply-chain"
+            echo "integrity. uv writes them by default, so an entry without"
+            echo "one usually means the lockfile was hand-edited or produced"
+            echo "by a different tool. Regenerate it:"
+            echo ""
+            echo "  uv lock --project <recipe-dir>"
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md#missing-package-hash-in-uvlock"
             exit 1
           fi
 
@@ -349,6 +392,7 @@ jobs:
           set -euo pipefail
 
           FAILED=0
+          CI_FAULT=0
           FAILED_DIRS=""
 
           while IFS= read -r lockfile; do
@@ -361,13 +405,49 @@ jobs:
             # staleness (transient registry error, malformed pyproject.toml,
             # unresolvable dep) the real error is visible rather than being
             # silently mis-reported as "stale lockfile".
-            if ! uv lock --check --project "$lockdir"; then
-              echo "::error file=$lockfile::$lockfile is out of date — run: uv lock --project $lockdir"
+            #
+            # Visible was not enough on its own, though. The old message
+            # asserted "is out of date — run: uv lock" for ANY non-zero
+            # exit, so a network blip told the contributor to run a command
+            # that could not possibly fix it, against a file that was
+            # already correct. Distinguish the two by inspecting what uv
+            # actually said.
+            set +e
+            lock_output=$(uv lock --check --project "$lockdir" 2>&1)
+            lock_exit=$?
+            set -e
+            printf '%s\n' "$lock_output"
+
+            [ "$lock_exit" -eq 0 ] && continue
+
+            if printf '%s' "$lock_output" | grep -qiE "not up-to-date|out of date|would be (updated|added|removed)|needs to be updated|lockfile is outdated"; then
+              echo "::error file=$lockfile::$lockfile is out of date with $lockdir/pyproject.toml. Fix: run 'uv lock --project $lockdir' and commit the updated lockfile. Docs: docs/recipe-handbook/troubleshooting.md#uvlock-out-of-sync"
               echo "[FAIL] $lockfile is out of date with $lockdir/pyproject.toml"
               FAILED_DIRS="${FAILED_DIRS}  uv lock --project ${lockdir}"$'\n'
               FAILED=1
+            else
+              echo "::error::uv could not check $lockfile (exit $lock_exit) and the cause is NOT a stale lockfile — see the uv output above. This is usually a transient registry or network failure. Re-run the job; if it persists it needs a repo maintainer, not a change to your PR. Docs: docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
+              echo "[CI FAULT] 'uv lock --check' failed on $lockdir for a reason other than staleness (exit $lock_exit)."
+              CI_FAULT=1
             fi
           done < "$LOCKFILES_FILE"
+
+          if [ "$CI_FAULT" -eq 1 ]; then
+            echo ""
+            echo "========================================"
+            echo "  CI TOOLING FAILURE — not your changes"
+            echo "========================================"
+            echo ""
+            echo "uv could not complete a lockfile check for a reason other"
+            echo "than staleness. Do not run 'uv lock' to work around this —"
+            echo "it will produce an unrelated diff."
+            echo ""
+            echo "Re-run the job. If it fails again, open an issue with the"
+            echo "uv output above and a link to this run."
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
+            exit 1
+          fi
 
           if [ "$FAILED" -eq 1 ]; then
             echo ""
@@ -380,6 +460,8 @@ jobs:
             echo "$FAILED_DIRS"
             echo "If you recently edited a pyproject.toml, make sure to run 'uv lock' in the"
             echo "same directory before pushing."
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md#uvlock-out-of-sync"
             echo ""
             exit 1
           fi

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -82,14 +82,55 @@ jobs:
           # 3. Format ONLY the modified python files (rules come from pyproject.toml)
           uvx ruff format --force-exclude "${CHANGED_FILES[@]}"
 
-          # 4. Post formatting suggestion comments strictly targeting modified files.
-          #    --no-color is defensive: CI git doesn't colorize by default, but a
-          #    self-hosted runner or global git config could break the diff parser.
-          git diff --no-color "${CHANGED_FILES[@]}" | reviewdog -f=diff \
-                                                                -name="ruff-formatter" \
-                                                                -reporter=github-pr-review \
-                                                                -filter-mode=added \
-                                                                -fail-on-error=true
+          # 4. Print the findings BEFORE handing them to reviewdog.
+          #
+          #    reviewdog cannot post review comments on a PR from a fork: the
+          #    GITHUB_TOKEN is read-only there, the API answers "403 Resource
+          #    not accessible by integration", and reviewdog degrades to
+          #    annotations. Piping the diff straight into it therefore left
+          #    external contributors with a red X and NOTHING else — the
+          #    findings existed only inside a pipe that produced no output.
+          #    The job log is the one surface that always works, so write to
+          #    it first and treat reviewdog as the enhancement it is.
+          #    --no-color is defensive: CI git doesn't colorize by default,
+          #    but a self-hosted runner or global git config could break the
+          #    diff parser.
+          FORMAT_DIFF=$(git diff --no-color "${CHANGED_FILES[@]}")
+
+          if [ -z "$FORMAT_DIFF" ]; then
+            echo "[PASS] All modified Python files are already formatted."
+            exit 0
+          fi
+
+          mapfile -t UNFORMATTED < <(git diff --name-only "${CHANGED_FILES[@]}")
+
+          echo "::group::Reformatting diff (what ruff would change)"
+          echo "$FORMAT_DIFF"
+          echo "::endgroup::"
+          echo ""
+          echo "[FAIL] ${#UNFORMATTED[@]} file(s) are not formatted:"
+          printf '  - %s\n' "${UNFORMATTED[@]}"
+          echo ""
+          echo "Fix locally by running:"
+          echo ""
+          echo "  uv run ruff format ${UNFORMATTED[*]}"
+          echo ""
+          echo "Then commit the result. Docs: docs/recipe-handbook/troubleshooting.md#ruff-format-or-check-failed"
+
+          for f in "${UNFORMATTED[@]}"; do
+            echo "::error file=$f::This file is not formatted. Run 'uv run ruff format $f' and commit the result. See docs/recipe-handbook/troubleshooting.md#ruff-format-or-check-failed"
+          done
+
+          # Inline suggestions are best-effort: on a fork PR this 403s, which
+          # is fine because everything above is already in the log. Never let
+          # its exit status decide the job's.
+          echo "$FORMAT_DIFF" | reviewdog -f=diff \
+                                          -name="ruff-formatter" \
+                                          -reporter=github-pr-review \
+                                          -filter-mode=added \
+                                          -fail-on-error=false || true
+
+          exit 1
 
   ruff-lint:
     name: Ruff Lint Suggestions
@@ -140,22 +181,54 @@ jobs:
           uvx ruff check --force-exclude --fix "${CHANGED_FILES[@]}" || true
 
           # 4. Post auto-fix suggestion comments strictly targeting modified files.
+          #    Best-effort only — see step 6 for why the log is authoritative.
           git diff --no-color "${CHANGED_FILES[@]}" | reviewdog -f=diff \
                                                                 -name="ruff-linter-suggestions" \
                                                                 -reporter=github-pr-review \
                                                                 -filter-mode=added \
-                                                                -fail-on-error=false
+                                                                -fail-on-error=false || true
 
           # 5. Restore files so we can check non-fixable violations on the
           #    original user commits (not the auto-fixed versions).
           git checkout -- .
 
-          # 6. Run strict diagnostic linter in RDJSON format on only the modified
-          #    python files. --exit-zero tells ruff to exit 0 on lint VIOLATIONS
-          #    (so reviewdog gets the full JSON and can annotate them).
-          #    set -o pipefail still catches a ruff CRASH (bad file, missing dep)
-          #    — that path exits non-zero and would otherwise be swallowed by
-          #    reviewdog's success exit.
+          # 6. Print the violations to the log FIRST, in human form.
+          #
+          #    The rdjson pipe below is machine-readable and produces no
+          #    console output, and reviewdog 403s on a fork PR (read-only
+          #    GITHUB_TOKEN). Together that meant an external contributor saw
+          #    a red X with no rule, no file and no line — the violation was
+          #    real but invisible. `--output-format=concise` costs one extra
+          #    ruff invocation and makes the log self-sufficient.
+          LINT_OUTPUT=$(uvx ruff check \
+            --force-exclude \
+            --output-format=concise \
+            --exit-zero "${CHANGED_FILES[@]}")
+
+          if [ -n "$LINT_OUTPUT" ]; then
+            echo "::group::Ruff lint violations"
+            echo "$LINT_OUTPUT"
+            echo "::endgroup::"
+            echo ""
+            echo "[FAIL] Ruff reported the violations listed above."
+            echo ""
+            echo "Most are auto-fixable:"
+            echo ""
+            echo "  uv run ruff check --fix ${CHANGED_FILES[*]}"
+            echo ""
+            echo "Anything left after that needs a manual edit; ruff names the"
+            echo "rule ID on each line and https://docs.astral.sh/ruff/rules/"
+            echo "explains it."
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md#ruff-format-or-check-failed"
+          else
+            echo "[PASS] No Ruff lint violations in the modified Python files."
+          fi
+
+          # 7. Hand the same findings to reviewdog for inline annotations.
+          #    --exit-zero keeps ruff quiet about violations so reviewdog gets
+          #    the full JSON; `set -o pipefail` still catches a ruff CRASH
+          #    (bad file, missing dep), which must not be mistaken for "clean".
           uvx ruff check \
             --force-exclude \
             --output-format=rdjson \
@@ -163,4 +236,11 @@ jobs:
                                                           -name="ruff-linter" \
                                                           -reporter=github-pr-review \
                                                           -filter-mode=added \
-                                                          -fail-on-error=true
+                                                          -fail-on-error=false || true
+
+          # The log above is authoritative, so decide the job here rather than
+          # letting reviewdog's exit status (which depends on token scope) do
+          # it. A fork PR and a branch PR now fail identically.
+          if [ -n "$LINT_OUTPUT" ]; then
+            exit 1
+          fi

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -12,9 +12,11 @@ on:
       - "skills/**/*.py"
       - "**/pyproject.toml"
 
+# Read-only by default. `pull-requests: write` is granted per job below
+# rather than here, because a workflow-level grant is handed to every job in
+# the file — including any future job that has no business posting comments.
 permissions:
   contents: read
-  pull-requests: write # Essential for posting reviewdog suggestion comments
 
 # Cancel superseded runs on the same PR to save runner minutes and avoid
 # stale suggestion comments from an older commit lingering on the PR.
@@ -33,23 +35,26 @@ jobs:
   ruff-format:
     name: Ruff Format Suggestions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # Essential for posting reviewdog suggestion comments
     # Ruff on the PR-diff is fast; 10 min is a generous ceiling that still
     # protects against a stuck reviewdog HTTP call to the GitHub API.
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch complete history to locate the merge-base cleanly
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # ratchet:astral-sh/setup-uv@v6.3.0
         with:
           python-version: "3.11"
           enable-cache: false
 
       - name: Install Reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # ratchet:reviewdog/action-setup@v1
         with:
           # Pinned rather than `latest` so a reviewdog release cannot turn every
           # open PR red without warning. Bump deliberately.
@@ -135,22 +140,25 @@ jobs:
   ruff-lint:
     name: Ruff Lint Suggestions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # Essential for posting reviewdog suggestion comments
     # Same rationale as ruff-format above.
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch complete history to locate the merge-base cleanly
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # ratchet:astral-sh/setup-uv@v6.3.0
         with:
           python-version: "3.11"
           enable-cache: false
 
       - name: Install Reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # ratchet:reviewdog/action-setup@v1
         with:
           # Pinned rather than `latest` — see ruff-format job for rationale.
           reviewdog_version: v0.21.0

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -206,8 +206,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          FIX="Fix: ask your AI coding assistant to run the generate-python-runnability-test skill on ${RECIPE}, or copy the template from docs/recipe-handbook/languages/python.md#copy-paste-starters. Docs: docs/recipe-handbook/troubleshooting.md#runnability-test-missing"
+
           if [ ! -d "tests" ]; then
-            echo "::error::Missing tests/ directory in ${RECIPE}"
+            echo "::error file=${RECIPE}::${RECIPE} has no tests/ directory. Why: every Python recipe must prove it at least imports. ${FIX}"
+            echo "[FAIL] ${RECIPE}/tests/ does not exist."
+            echo "       ${FIX}"
             exit 1
           fi
 
@@ -216,7 +220,17 @@ jobs:
           # `head` closes stdin early and `find` dies from SIGPIPE.
           RUNNABILITY=$(find tests -name "test_runnability.py" -print -quit)
           if [ -z "$RUNNABILITY" ]; then
-            echo "::error::No test_runnability.py found under ${RECIPE}/tests/"
+            echo "::error file=${RECIPE}/tests::${RECIPE}/tests/ has no test_runnability.py. Why: every Python recipe must prove it at least imports. ${FIX}"
+            echo "[FAIL] No test_runnability.py under ${RECIPE}/tests/."
+            echo ""
+            echo "       The file must import the recipe's agent module and"
+            echo "       assert root_agent is not None. If that import has"
+            echo "       side effects needing credentials (google.auth.default,"
+            echo "       vertexai.init) the generator mocks them for you — CI"
+            echo "       has no application default credentials, so an"
+            echo "       unmocked import will fail here."
+            echo ""
+            echo "       ${FIX}"
             exit 1
           fi
 
@@ -264,8 +278,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # This job is a branch-protection gate: it reports the aggregate of
+          # a matrix, so it can never name the specific recipe that failed.
+          # Say that outright and point at the matrix legs, rather than
+          # leaving a bare "did not succeed" that reads like a CI glitch.
           if [ "$DETECT_RESULT" != "success" ]; then
-            echo "::error::detect-recipes did not succeed (result: $DETECT_RESULT)."
+            echo "::error::Could not work out which Python recipes this PR affects (detect-recipes: $DETECT_RESULT), so no tests ran. This is a CI tooling failure, not a problem with your changes — re-run the job. Docs: docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
             exit 1
           fi
 
@@ -277,7 +295,11 @@ jobs:
               echo "No Python recipes to test — gate passes."
               ;;
             *)
-              echo "::error::run-tests did not succeed (result: $RUN_RESULT)."
+              echo "::error::One or more Python recipe test jobs did not pass (run-tests: $RUN_RESULT). This gate reports the aggregate — open the 'pytest — <recipe>' job for the recipe that failed to see the actual pytest output. Docs: docs/recipe-handbook/troubleshooting.md"
+              echo ""
+              echo "This job is a gate, not a test run. The failure is in one"
+              echo "of the matrix legs above, each named 'pytest — <recipe>'."
+              echo "Open the red one for the pytest output."
               exit 1
               ;;
           esac

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -190,12 +190,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v4
 
       - name: Install uv
         # Leave enable-cache at the default (true) — wheel caching between
         # runs is worthwhile here (contrast with detect-recipes above).
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # ratchet:astral-sh/setup-uv@v6.3.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/python-validate-recipe.yml
+++ b/.github/workflows/python-validate-recipe.yml
@@ -157,19 +157,36 @@ jobs:
           fi
 
           FAILED=0
+          CI_FAULTS=0
 
           # Each recipe is validated in a subshell so a transient failure
           # inside one recipe (e.g. a `find` error) aborts only that
-          # recipe's checks, not the whole loop. The subshell exits 1
-          # when any check fails; `|| FAILED=1` records the aggregate.
+          # recipe's checks, not the whole loop.
+          #
+          # The subshell's exit status carries WHOSE fault it was, because
+          # a subshell cannot write back to the parent's variables:
+          #   0 — recipe passed
+          #   1 — the recipe has problems the contributor must fix
+          #   2 — one of OUR checkers crashed or the CI environment broke
+          # Keeping 2 distinct is the point: a contributor should never be
+          # sent hunting through their own PR for a bug in our tooling.
           while IFS= read -r recipe; do
             [ -z "$recipe" ] && continue
             echo ""
             echo "========================================"
             echo "Validating: $recipe"
             echo "========================================"
+            # `set +e` here only so the parent can READ the subshell's exit
+            # status; without it `set -e` would abort this script the moment
+            # a recipe fails, before the case below can classify it. The
+            # subshell re-enables `set -e` for itself on its first line, so
+            # an unexpected failure mid-recipe still aborts that recipe's
+            # remaining checks exactly as before.
+            set +e
             (
+              set -e
               RECIPE_FAILED=0
+              CI_FAULT=0
 
               # ------------------------------------------------------------
               # Check: .env.example — notice keys
@@ -205,38 +222,25 @@ jobs:
               # (HOME, PATH, GITHUB_*, INTEGRATION_TEST, …).
               # ------------------------------------------------------------
               if [ -f "$recipe/.env.example" ]; then
+                # Output is NOT captured: the checker prints its own human
+                # blocks and its own ::error annotations. Capturing would
+                # swallow the annotations, and re-echoing them through a
+                # shell demux is what used to flatten every multi-line fix
+                # instruction into one unusable line.
                 set +e
-                env_vars_result=$(uv run --no-project \
-                  python3 .github/scripts/check_env_vars.py "$recipe")
+                uv run --no-project \
+                  python3 .github/scripts/check_env_vars.py "$recipe"
                 env_vars_exit=$?
                 set -e
-
-                if [ "$env_vars_exit" -ne 0 ]; then
-                  echo "::error file=$recipe/.env.example::env-var checker crashed (exit=$env_vars_exit). See job output."
-                  echo "[FAIL] env-var checker crashed (exit=$env_vars_exit)."
-                  RECIPE_FAILED=1
-                fi
-
-                while IFS= read -r line; do
-                  [ -z "$line" ] && continue
-                  kind="${line%%::*}"
-                  rest="${line#*::}"
-                  file="${rest%%::*}"
-                  msg="${rest#*::}"
-                  case "$kind" in
-                    PASS)
-                      echo "[PASS] $msg"
-                      ;;
-                    FAIL)
-                      echo "::error file=$file::$msg"
-                      echo "[FAIL] $msg"
-                      RECIPE_FAILED=1
-                      ;;
-                    *)
-                      echo "$line"
-                      ;;
-                  esac
-                done <<< "$env_vars_result"
+                case "$env_vars_exit" in
+                  0) ;;
+                  1) RECIPE_FAILED=1 ;;
+                  2) CI_FAULT=1 ;;
+                  *)
+                    echo "::error::check_env_vars.py exited with an undefined status ($env_vars_exit). This is a CI tooling bug, not a problem with your recipe."
+                    CI_FAULT=1
+                    ;;
+                esac
               fi
 
               # ------------------------------------------------------------
@@ -298,40 +302,21 @@ jobs:
                 # env via `uv run --with`. `packaging` is used for PEP
                 # 440 version specifier parsing (see
                 # check_requires_python in the checker).
+                # Uncaptured for the same reason as check_env_vars.py above.
                 set +e
-                pyproject_result=$(uv run --no-project --with pyyaml --with packaging \
-                  python .github/scripts/check_recipe_pyproject.py "$recipe")
+                uv run --no-project --with pyyaml --with packaging \
+                  python .github/scripts/check_recipe_pyproject.py "$recipe"
                 py_exit=$?
                 set -e
-
-                if [ "$py_exit" -ne 0 ]; then
-                  echo "::error file=$pyproject::pyproject.toml metadata checker crashed (uv/python exit=$py_exit). See job output."
-                  echo "[FAIL] pyproject.toml metadata checker crashed (uv/python exit=$py_exit)."
-                  RECIPE_FAILED=1
-                fi
-
-                while IFS= read -r line; do
-                  [ -z "$line" ] && continue
-                  kind="${line%%::*}"
-                  rest="${line#*::}"
-                  file="${rest%%::*}"
-                  msg="${rest#*::}"
-                  case "$kind" in
-                    PASS)
-                      echo "[PASS] $msg"
-                      ;;
-                    FAIL)
-                      echo "::error file=$file::$msg"
-                      echo "[FAIL] $msg"
-                      RECIPE_FAILED=1
-                      ;;
-                    *)
-                      # Unrecognized line — surface it so it isn't
-                      # silently lost.
-                      echo "$line"
-                      ;;
-                  esac
-                done <<< "$pyproject_result"
+                case "$py_exit" in
+                  0) ;;
+                  1) RECIPE_FAILED=1 ;;
+                  2) CI_FAULT=1 ;;
+                  *)
+                    echo "::error::check_recipe_pyproject.py exited with an undefined status ($py_exit). This is a CI tooling bug, not a problem with your recipe."
+                    CI_FAULT=1
+                    ;;
+                esac
               fi
 
               # ------------------------------------------------------------
@@ -351,20 +336,55 @@ jobs:
                 done <<< "$matches"
               done < <(find "$recipe" -type f -name "*.py" ! -path "*/tests/*")
 
+              # A CI fault outranks a recipe failure: if our own checker
+              # could not run, we do not actually know whether the recipe
+              # is valid, and saying "your recipe is broken" would be a
+              # guess.
+              if [ "$CI_FAULT" -eq 1 ]; then
+                exit 2
+              fi
               if [ "$RECIPE_FAILED" -eq 1 ]; then
                 exit 1
               fi
               echo ""
               echo "[PASS] All Python-specific checks passed for: $recipe"
-            ) || FAILED=1
+            )
+            recipe_status=$?
+            set -e
+            case "$recipe_status" in
+              0) ;;
+              2) CI_FAULTS=1 ;;
+              *) FAILED=1 ;;
+            esac
           done <<< "$RECIPES"
+
+          if [ "$CI_FAULTS" -eq 1 ]; then
+            echo ""
+            echo "========================================"
+            echo "  CI TOOLING FAILURE — not your changes"
+            echo "========================================"
+            echo ""
+            echo "One of this repo's own checker scripts could not run, so"
+            echo "validation is inconclusive. Do not change your recipe to"
+            echo "work around this."
+            echo ""
+            echo "  1. Re-run this job — transient failures clear on retry."
+            echo "  2. If it fails again, open an issue with the [ci-fault]"
+            echo "     detail above and a link to this run."
+            echo ""
+            echo "See docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
+            exit 1
+          fi
 
           if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "========================================"
-            echo "  One or more Python recipes failed validation."
-            echo "  See errors above for details."
+            echo "  ACTION REQUIRED: recipe validation failed"
             echo "========================================"
+            echo ""
+            echo "Each problem above lists why the rule applies and how to"
+            echo "fix it. Every fix is documented in"
+            echo "docs/recipe-handbook/troubleshooting.md"
             exit 1
           fi
 

--- a/.github/workflows/validate-recipe-structure.yml
+++ b/.github/workflows/validate-recipe-structure.yml
@@ -147,11 +147,51 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Exit status carries whose fault it is: 1 = rules the contributor
+          # must fix, 2 = one of our validators crashed. `|| FAILED=1` used
+          # to flatten the two, so a tooling bug printed the "here is how to
+          # fix your recipe" banner over a traceback.
+          run_validator() {
+            set +e
+            uv run validate "$@"
+            local status=$?
+            set -e
+            case "$status" in
+              0) ;;
+              1) FAILED=1 ;;
+              2) CI_FAULT=1 ;;
+              *)
+                echo "::error::'uv run validate $*' exited with an undefined status ($status). This is a CI tooling bug, not a problem with your recipe."
+                CI_FAULT=1
+                ;;
+            esac
+          }
+
+          ci_fault_banner() {
+            echo ""
+            echo "========================================"
+            echo "  CI TOOLING FAILURE — not your changes"
+            echo "========================================"
+            echo ""
+            echo "A validator crashed, so we do not know whether your recipe"
+            echo "is valid. Re-run the job; if it fails again, open an issue"
+            echo "with the detail above."
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
+          }
+
+          FAILED=0
+          CI_FAULT=0
+
           if [ "$VALIDATE_ALL" = "true" ]; then
             # Both validators walk core/, contrib/, and skills/ in one pass.
-            FAILED=0
-            uv run validate structure || FAILED=1
-            uv run validate readme    || FAILED=1
+            run_validator structure
+            run_validator readme
+
+            if [ "$CI_FAULT" -eq 1 ]; then
+              ci_fault_banner
+              exit 1
+            fi
 
             # This branch used to `exit $FAILED` with no message while the
             # per-recipe branch below printed a banner. It is the branch
@@ -185,12 +225,19 @@ jobs:
           # Per-recipe invocation: keeps annotations scoped to the recipe
           # under review and lets one broken recipe not short-circuit
           # validation of the others in the same PR.
-          FAILED=0
+          #
+          # A here-string feeds the loop rather than a pipe, so the body runs
+          # in this shell and the FAILED / CI_FAULT assignments survive it.
           while IFS= read -r recipe; do
             [ -z "$recipe" ] && continue
-            uv run validate structure "$recipe" || FAILED=1
-            uv run validate readme    "$recipe" || FAILED=1
+            run_validator structure "$recipe"
+            run_validator readme    "$recipe"
           done <<< "$CHANGED_RECIPES"
+
+          if [ "$CI_FAULT" -eq 1 ]; then
+            ci_fault_banner
+            exit 1
+          fi
 
           if [ "$FAILED" -eq 1 ]; then
             echo ""
@@ -290,7 +337,33 @@ jobs:
         run: uv sync
 
       - name: Check every recipe sits at its required path
-        run: uv run python tools/validate_placement.py
+        run: |
+          set -euo pipefail
+
+          # Distinguish "a recipe is misplaced" (1) from "the placement
+          # validator crashed" (2); a bare invocation would surface the
+          # second as the first.
+          set +e
+          uv run python tools/validate_placement.py
+          status=$?
+          set -e
+          case "$status" in
+            0) ;;
+            1) exit 1 ;;
+            2|*)
+              echo ""
+              echo "========================================"
+              echo "  CI TOOLING FAILURE — not your changes"
+              echo "========================================"
+              echo ""
+              echo "The placement validator could not complete, so we do not"
+              echo "know whether every recipe is correctly placed. Re-run the"
+              echo "job; if it fails again, open an issue with the detail above."
+              echo ""
+              echo "Docs: docs/recipe-handbook/troubleshooting.md#ci-infrastructure-failure"
+              exit 1
+              ;;
+          esac
 
   # The `check-dependabot-config` job used to live here. It failed a
   # contributor's PR when .github/dependabot.yml no longer matched the recipe

--- a/.github/workflows/validate-recipe-structure.yml
+++ b/.github/workflows/validate-recipe-structure.yml
@@ -152,7 +152,29 @@ jobs:
             FAILED=0
             uv run validate structure || FAILED=1
             uv run validate readme    || FAILED=1
-            exit $FAILED
+
+            # This branch used to `exit $FAILED` with no message while the
+            # per-recipe branch below printed a banner. It is the branch
+            # taken whenever a PR touches pyproject.toml, policy.yml, the
+            # schema or a validation tool, so the silent variant was hit
+            # often — a red X with nothing to read.
+            if [ "$FAILED" -eq 1 ]; then
+              echo ""
+              echo "========================================"
+              echo "  ACTION REQUIRED: recipe validation failed"
+              echo "========================================"
+              echo ""
+              echo "Every recipe was re-validated because this PR changed the"
+              echo "schema, the policy, or a validation tool. Failures may"
+              echo "therefore be in recipes you did not touch — that is"
+              echo "expected, and they still have to be fixed or the rule"
+              echo "change reverted."
+              echo ""
+              echo "Each problem above says why the rule applies and how to"
+              echo "fix it. Docs: docs/recipe-handbook/troubleshooting.md"
+              exit 1
+            fi
+            exit 0
           fi
 
           if [ -z "$CHANGED_RECIPES" ]; then
@@ -173,9 +195,13 @@ jobs:
           if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "========================================"
-            echo "  One or more recipes failed structural validation."
-            echo "  See errors above for details."
+            echo "  ACTION REQUIRED: recipe validation failed"
             echo "========================================"
+            echo ""
+            echo "Each problem above says which rule applies, why it applies"
+            echo "to this recipe, and how to fix it."
+            echo ""
+            echo "Docs: docs/recipe-handbook/troubleshooting.md"
             exit 1
           fi
 

--- a/docs/recipe-handbook/troubleshooting.md
+++ b/docs/recipe-handbook/troubleshooting.md
@@ -23,6 +23,9 @@ CI log, or [jump to Something else](#something-else).
 - [ownership.team or poc is a placeholder](#ownershipteam-or-poc-is-a-placeholder)
 - [Directory name too long or invalid](#directory-name-too-long-or-invalid)
 - [Recipe exceeds size or file limit](#recipe-exceeds-size-or-file-limit)
+- [Required file or directory missing](#required-file-or-directory-missing)
+- [Recipe is in the wrong folder](#recipe-is-in-the-wrong-folder)
+- [Changes inside a retired folder](#changes-inside-a-retired-folder)
 
 **README.md**
 - [README.md is missing or empty](#readmemd-is-missing-or-empty)
@@ -38,6 +41,7 @@ CI log, or [jump to Something else](#something-else).
 - [Project description doesn't match manifest](#project-description-doesnt-match-manifest)
 - [requires-python below 3.11](#requires-python-below-311)
 - [pyproject.toml has no sibling uv.lock](#pyprojecttoml-has-no-sibling-uvlock)
+- [Missing [[tool.uv.index]] block](#missing-tooluvindex-block)
 
 **Environment variables**
 - [Env var missing from .env.example](#env-var-missing-from-envexample)
@@ -54,6 +58,7 @@ CI log, or [jump to Something else](#something-else).
 - [Ruff format or check failed](#ruff-format-or-check-failed)
 
 **Other**
+- [CI infrastructure failure](#ci-infrastructure-failure)
 - [Non-blocking notices](#non-blocking-notices)
 - [Something else](#something-else)
 
@@ -156,6 +161,98 @@ To fix: move data files larger than 1 MB to a linked storage bucket
 and reference them in `README.md`. Delete generated files that
 shouldn't be committed (`.venv/`, IDE configs, build output — check
 the workflow output for the actual counted paths).
+
+## Required file or directory missing
+
+**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+
+CI output contains: `Required file '<name>' is missing` or
+`Required directory '<name>/' is missing`
+
+The set of required entries is the **union** of three rules in
+[`.github/policy.yml`](../../.github/policy.yml). The CI message names
+which one applied to your recipe:
+
+| Rule | Applies to | Entries |
+| --- | --- | --- |
+| `always` | every recipe | `README.md` |
+| `by_root.core` | anything under `core/` | `AGENTS.md` |
+| `by_root.skills` | anything under `skills/` | `SKILL.md`, `EVAL.yaml`, `scripts/` |
+| `by_language.python` | `manifest.language: python` | `pyproject.toml`, `uv.lock`, `.env.example`, `tests/test_runnability.py` |
+
+`manifest.yaml` is required for every recipe and reported separately.
+
+Note that language requirements come from **`manifest.language`**, not
+from the folder path. A vertical skill at `skills/retail/product-search`
+picks up the Python list because its manifest says so — the middle folder
+is a vertical, not a language.
+
+Most of these have a generator:
+
+| Missing | Fix |
+| --- | --- |
+| `manifest.yaml` | `generate-manifest` (AI skill) |
+| `.env.example` | `extract-python-environment-variables` (AI skill) |
+| `tests/test_runnability.py` | `generate-python-runnability-test` (AI skill) |
+| `uv.lock` | `uv lock` in the recipe directory |
+| `pyproject.toml` | `align-recipe-pyproject` (AI skill) |
+| everything at once | `scaffold-python-recipe` (AI skill) |
+
+**Directory looks present but CI says it's missing?** Git cannot commit an
+empty directory. Add a placeholder file and commit that:
+
+```bash
+touch scripts/.gitkeep && git add scripts/.gitkeep
+```
+
+## Recipe is in the wrong folder
+
+**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+
+CI output contains: `sits directly under` or `is nested too deeply`
+
+Every recipe under `skills/` must live at
+`skills/<vertical>/<solution>/`. The vertical (`retail/`, `hr/`,
+`finance/`) is mandatory — it surfaces ownership and lets a team see its
+whole surface at a glance. A solution dropped directly under `skills/`
+has no owning vertical and is rejected.
+
+```
+skills/retail/product-search/manifest.yaml    valid
+skills/product-search/manifest.yaml           too shallow — no vertical
+skills/retail/product-search/x/manifest.yaml  too deep
+```
+
+Move the directory to the path shown in the error, then re-run
+`uv run validate placement`.
+
+Remember that `[project].name` in `pyproject.toml` is
+`<vertical>-<solution>` for a vertical skill (`retail-product-search`),
+not the folder basename — see
+[Project name doesn't match the required name](#project-name-doesnt-match-the-required-name).
+
+## Changes inside a retired folder
+
+**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+
+CI output contains: `is in a retired folder and no longer accepts changes`
+
+Recipes used to live at `<language>/agents/<recipe>` in the repo root (for
+example `python/agents/academic-research`). Those roots are closed. The
+retired roots are listed under `frozen_paths` in
+[`.github/policy.yml`](../../.github/policy.yml).
+
+Move the whole recipe to `contrib/<language>/<recipe>` and make the change
+there. The error names the destination it expects.
+
+Deletions and renames are exempt, so migrating a recipe *out* of a retired
+folder is never blocked by this check — only adding to or editing one in
+place is.
+
+After moving, the recipe has to meet the current contribution
+requirements, which the retired copy predates: see
+[the checklist](../recipe-checklist.md) and
+[Required file or directory missing](#required-file-or-directory-missing).
 
 ## pyproject.toml has a local ruff configuration
 
@@ -286,6 +383,33 @@ cd contrib/python/my-recipe
 uv lock
 ```
 
+## Missing [[tool.uv.index]] block
+
+**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
+
+CI output contains: `Missing required [[tool.uv.index]] block` or
+`has default=true but url=`
+
+Every recipe must declare public PyPI as its default index. Add this to
+the recipe's `pyproject.toml`:
+
+```toml
+[[tool.uv.index]]
+url = "https://pypi.org/simple/"
+default = true
+```
+
+Note the **double** brackets: `[[tool.uv.index]]` is an array of tables.
+A single-bracket `[tool.uv.index]` is a different TOML construct and uv
+will not accept it.
+
+Why it is required: on a Google corp workstation a system-wide
+`/etc/uv/uv.toml` redirects package resolution to an authenticated proxy.
+uv concatenates project-level indexes ahead of system-level ones, so
+declaring PyPI here puts it first and `uv sync` works without that auth.
+
+`align-recipe-pyproject` (AI skill) adds the block for you.
+
 ## Lockfile references a non-PyPI URL
 
 **Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml)
@@ -353,9 +477,34 @@ the rule ID.
 
 ---
 
-**The following will not block your PR.** Fix them when convenient.
+## CI infrastructure failure
 
-### Non-blocking notices
+CI output contains: `[ci-fault]` or `CI tooling failure in`
+
+**This is not caused by your changes.** One of the repo's own checker
+scripts crashed, or the CI environment failed (network, a missing
+dependency, an unhandled file encoding).
+
+You will see this instead of a normal error when the failure is ours
+rather than yours. It is annotated against the workflow, not against
+your files, precisely so you do not go hunting for a bug in your PR.
+
+What to do:
+
+1. Re-run the failed job. Genuinely transient failures (network, registry
+   timeouts) clear on a retry.
+2. If it fails again, it needs a repo maintainer. Open an issue with the
+   workflow name, the `Detail:` line from the output, and a link to the
+   run. Do not change your recipe to work around it.
+
+If the crash was triggered by something unusual in your recipe — an
+unusual file encoding, a hand-edited `uv.lock` — say so in the issue.
+The checker should report that as a clear error rather than crash, so
+it is a bug in the checker either way.
+
+## Non-blocking notices
+
+**The following will not block your PR.** Fix them when convenient.
 
 - **Hardcoded model name** — replace with `os.getenv("MODEL_NAME")`.
   Run `extract-python-environment-variables`.

--- a/tools/check_frozen_paths.py
+++ b/tools/check_frozen_paths.py
@@ -33,6 +33,7 @@ import sys
 from pathlib import Path
 
 import yaml
+from ci_message import Diagnostic, Doc, report
 
 REPO_ROOT = Path(__file__).parent.parent
 POLICY_PATH = REPO_ROOT / ".github" / "policy.yml"
@@ -40,10 +41,10 @@ POLICY_PATH = REPO_ROOT / ".github" / "policy.yml"
 # Where recipes live now. Only used to build the "move it here" hint.
 ACTIVE_CONTRIB_ROOT = "contrib"
 
-# How many offending recipes to spell out before truncating the summary.
-# Every one still gets its own ::error annotation; this only bounds the
-# human-readable block at the end.
-MAX_LISTED = 20
+# A MAX_LISTED cap used to truncate the human-readable summary at 20
+# entries. `report` in ci_message prints every diagnostic in full, so the
+# cap is gone: a contributor with 21 affected recipes needs all 21, not
+# 20 and a count.
 
 
 def load_frozen_paths(policy_path: Path = POLICY_PATH) -> list[str]:
@@ -120,36 +121,50 @@ def find_violations(
     return violations
 
 
-def _report(violations: dict[str, str]) -> None:
-    """Print GitHub annotations plus a human-readable summary."""
-    for recipe_dir, example in violations.items():
-        destination = suggested_destination(recipe_dir)
-        print(
-            f"::error file={example}::"
-            f"'{recipe_dir}' is in a retired folder and no longer accepts "
-            f"changes. Move this recipe to '{destination}'. "
-            f"See docs/recipe-checklist.md."
-        )
+def _report(violations: dict[str, str]) -> int:
+    """Report every violation through the shared diagnostic helper.
 
-    count = len(violations)
+    Nothing is truncated: `report` prints one annotation per diagnostic.
+    """
+    diagnostics = [
+        Diagnostic(
+            check="frozen-path",
+            what=(
+                f"'{recipe_dir}' is in a retired folder, which no longer "
+                f"accepts changes."
+            ),
+            why=(
+                "Recipes used to live at <language>/agents/<recipe>. Those "
+                "roots are closed — they are listed under frozen_paths in "
+                ".github/policy.yml — and every active recipe now lives "
+                "under contrib/. A change to the retired copy is invisible "
+                "to anyone actually using the recipe."
+            ),
+            how=(
+                f"Move the recipe, then make your change at the new path:\n"
+                f"  git mv {recipe_dir} {suggested_destination(recipe_dir)}\n"
+                f"The move itself is not blocked: this check ignores "
+                f"deletions and renames precisely so a migration can "
+                f"proceed. The moved recipe then has to meet the current "
+                f"contribution requirements, which the retired copy "
+                f"predates — see docs/recipe-checklist.md."
+            ),
+            doc=Doc.RETIRED_FOLDER,
+            file=example,
+        )
+        for recipe_dir, example in violations.items()
+    ]
+    count = len(diagnostics)
     noun = "recipe" if count == 1 else "recipes"
-    print("")
-    print("=" * 60)
-    print(f"  ACTION REQUIRED: {count} {noun} in a retired folder")
-    print("=" * 60)
-    print("")
-    print("These folders are closed. Recipes now live under contrib/.")
-    print("")
-    for recipe_dir in list(violations)[:MAX_LISTED]:
-        print(f"  {recipe_dir}  ->  {suggested_destination(recipe_dir)}")
-    if count > MAX_LISTED:
-        print(f"  ... and {count - MAX_LISTED} more")
-    print("")
-    print("To fix: move the recipe to the path shown above, then make sure")
-    print("it meets the contribution requirements:")
-    print("")
-    print("  docs/recipe-checklist.md")
-    print("")
+    return report(
+        diagnostics,
+        header=f"{count} {noun} in a retired folder",
+        passed_message="No changes inside retired recipe folders.",
+        next_step=(
+            "Move each recipe to the destination shown above, then re-run.\n"
+            "Requirements for the moved recipe: docs/recipe-checklist.md"
+        ),
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -165,8 +180,7 @@ def main(argv: list[str] | None = None) -> int:
         print("[PASS] No changes inside retired recipe folders.")
         return 0
 
-    _report(violations)
-    return 1
+    return _report(violations)
 
 
 if __name__ == "__main__":

--- a/tools/check_frozen_paths.py
+++ b/tools/check_frozen_paths.py
@@ -33,7 +33,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from ci_message import Diagnostic, Doc, report
+from ci_message import Diagnostic, Doc, guard, report
 
 REPO_ROOT = Path(__file__).parent.parent
 POLICY_PATH = REPO_ROOT / ".github" / "policy.yml"
@@ -184,4 +184,4 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(guard("check_frozen_paths.py", main))

--- a/tools/ci_message.py
+++ b/tools/ci_message.py
@@ -57,6 +57,7 @@ with no repo dependencies available) as well as from `tools/*`:
 from __future__ import annotations
 
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 
@@ -323,3 +324,25 @@ def report_infra_fault(fault: InfraFault) -> int:
     print("")
     print(fault.render_annotation())
     return EXIT_CI_FAULT
+
+
+def guard(checker: str, run: Callable[[], int]) -> int:
+    """Run a checker's entrypoint so a crash becomes a CI fault, not a verdict.
+
+    Every entrypoint in this repo must be wrapped. Without it an unhandled
+    exception exits non-zero, and the calling workflow cannot tell that
+    apart from :data:`EXIT_VIOLATIONS` — so it prints "ACTION REQUIRED, here
+    is how to fix your recipe" underneath a traceback the contributor did
+    not cause and cannot act on. That is the exact confusion
+    :class:`InfraFault` exists to prevent, and it has to be enforced out
+    here because a crash by definition escaped the checker's own handling.
+
+    ``SystemExit`` and ``KeyboardInterrupt`` derive from BaseException, so
+    ``argparse --help`` and Ctrl-C pass through untouched.
+    """
+    try:
+        return run()
+    except Exception as exc:
+        return report_infra_fault(
+            infra_fault(checker, f"{type(exc).__name__}: {exc}")
+        )

--- a/tools/ci_message.py
+++ b/tools/ci_message.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+One shared way to tell a contributor what went wrong.
+
+Every user-facing CI failure in this repo is a :class:`Diagnostic`. The
+class exists to make one specific failure mode impossible: a message that
+says WHAT is wrong and stops there, leaving the contributor to reverse
+engineer the rule from `.github/policy.yml`.
+
+A Diagnostic must answer four questions, and the constructor rejects it if
+any answer is missing:
+
+    what   The problem, naming the exact file / field / value.
+    why    Which rule fired, and why it applies to THIS recipe. Provenance,
+           not restatement: "required because manifest.language is 'python'"
+           rather than "this file is required".
+    how    The concrete fix. A command to run, or the exact text to add.
+           May be multi-line; formatting survives to both renderers.
+    doc    Anchor into docs/recipe-handbook/troubleshooting.md, so there is
+           always somewhere to go for more than one line of context.
+
+The acid test each message must pass: *could a contributor who has never
+opened policy.yml fix this in one attempt, without asking anyone?*
+
+Two renderers, one Diagnostic:
+
+    render_human()       Multi-line block for the job log, where there is
+                         room to breathe.
+    render_annotation()  A single ``::error`` line for the PR Files tab.
+                         Newlines are percent-encoded as ``%0A``, which is
+                         GitHub's own escape — multi-line `how` blocks stay
+                         multi-line in the annotation instead of being
+                         flattened into one unusable line.
+
+CONTRIBUTOR FAULT vs CI FAULT
+-----------------------------
+:class:`Diagnostic` is for things the contributor can fix. When one of our
+own checkers crashes — bad TOML we failed to guard, a missing CI dep, a
+network blip — use :func:`infra_fault` instead. It annotates the *checker*,
+never the contributor's file, and says plainly that the failure is not
+theirs. Putting a red marker on someone's `.env.example` because our TOML
+parser raised AttributeError is how you teach people to ignore CI.
+
+Import from anywhere
+--------------------
+Stdlib only, and no imports from other repo modules, so this is safe to
+import from `.github/scripts/*` (which run under `uv run --no-project`
+with no repo dependencies available) as well as from `tools/*`:
+
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+    from ci_message import Diagnostic, Doc
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from enum import Enum
+
+# ---------------------------------------------------------------------------
+# Documentation anchors
+#
+# Every value is a real heading in docs/recipe-handbook/troubleshooting.md.
+# tools/tests/test_ci_message.py asserts that — if you add a member here
+# without adding the heading, that test fails rather than shipping a link
+# that 404s onto the contributor's screen.
+# ---------------------------------------------------------------------------
+
+_TROUBLESHOOTING = "docs/recipe-handbook/troubleshooting.md"
+
+
+class Doc(str, Enum):
+    """Anchors into the troubleshooting handbook."""
+
+    MANIFEST = "manifestyaml-missing-or-invalid"
+    OWNERSHIP_PLACEHOLDER = "ownershipteam-or-poc-is-a-placeholder"
+    FOLDER_NAME = "directory-name-too-long-or-invalid"
+    SIZE_LIMIT = "recipe-exceeds-size-or-file-limit"
+    REQUIRED_FILES = "required-file-or-directory-missing"
+    PLACEMENT = "recipe-is-in-the-wrong-folder"
+    RETIRED_FOLDER = "changes-inside-a-retired-folder"
+
+    README_MISSING = "readmemd-is-missing-or-empty"
+    README_TODO = "readmemd-contains-todo-placeholders"
+    README_SHORT = "readmemd-is-too-short"
+    README_SETUP = "readmemd-is-missing-a-setup-section"
+    README_RUN = "readmemd-is-missing-a-run-section-or-code-block"
+
+    RUFF_CONFIG = "pyprojecttoml-has-a-local-ruff-configuration"
+    RUFF_STANDALONE = "standalone-ruff-config-file"
+    PROJECT_NAME = "project-name-doesnt-match-the-required-name"
+    PROJECT_DESCRIPTION = "project-description-doesnt-match-manifest"
+    REQUIRES_PYTHON = "requires-python-below-311"
+    NO_SIBLING_LOCK = "pyprojecttoml-has-no-sibling-uvlock"
+    PYPI_INDEX = "missing-tooluvindex-block"
+
+    ENV_VARS = "env-var-missing-from-envexample"
+
+    LOCK_STALE = "uvlock-out-of-sync"
+    LOCK_NON_PYPI = "lockfile-references-a-non-pypi-url"
+    LOCK_VCS = "vcs-dependency-in-uvlock"
+    LOCK_PATH = "local-path-dependency-in-uvlock"
+    LOCK_HASH = "missing-package-hash-in-uvlock"
+
+    RUNNABILITY = "runnability-test-missing"
+    RUFF_FAILED = "ruff-format-or-check-failed"
+
+    CI_FAULT = "ci-infrastructure-failure"
+
+    @property
+    def url(self) -> str:
+        """Repo-relative path plus anchor, e.g. ``docs/…md#env-var-…``."""
+        return f"{_TROUBLESHOOTING}#{self.value}"
+
+
+class Severity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    NOTICE = "notice"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic
+# ---------------------------------------------------------------------------
+
+
+def _clean(value: str, field: str) -> str:
+    """Reject the empty-ish values that make a message useless."""
+    if not isinstance(value, str):
+        raise TypeError(f"Diagnostic.{field} must be a string, got {value!r}")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(
+            f"Diagnostic.{field} is empty. Every diagnostic must answer "
+            f"what/why/how — a message that only says WHAT sends the "
+            f"contributor to policy.yml to work out the rest."
+        )
+    return stripped
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One contributor-facing problem, with the fix attached.
+
+    Construct it and hand it to a reporter; do not build ``::error``
+    strings by hand. The point of the type is that the four questions are
+    answered at the callsite, where the answers are actually known.
+    """
+
+    check: str
+    what: str
+    why: str
+    how: str
+    doc: Doc
+    file: str | None = None
+    severity: Severity = Severity.ERROR
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "check", _clean(self.check, "check"))
+        object.__setattr__(self, "what", _clean(self.what, "what"))
+        object.__setattr__(self, "why", _clean(self.why, "why"))
+        object.__setattr__(self, "how", _clean(self.how, "how"))
+        if not isinstance(self.doc, Doc):
+            raise TypeError(
+                f"Diagnostic.doc must be a Doc member, got {self.doc!r}. "
+                f"Add an anchor to Doc (and a heading to {_TROUBLESHOOTING}) "
+                f"rather than passing a bare string."
+            )
+
+    # -- rendering ---------------------------------------------------------
+
+    def render_human(self, indent: str = "  ") -> str:
+        """Multi-line block for the job log."""
+        lines = [f"{indent}[{self.check}] {self.what}"]
+        lines.append(f"{indent}  Why:  {self.why}")
+        how_lines = self.how.splitlines()
+        lines.append(f"{indent}  Fix:  {how_lines[0]}")
+        lines.extend(f"{indent}        {ln}" for ln in how_lines[1:])
+        lines.append(f"{indent}  Docs: {self.doc.url}")
+        return "\n".join(lines)
+
+    def render_annotation(self) -> str:
+        """One ``::error`` line, with newlines preserved via ``%0A``.
+
+        GitHub decodes ``%0A`` back into a line break when it renders the
+        annotation, so a multi-line `how` block survives the trip. Encoding
+        the other two reserved characters (``%25``, ``%0D``) matters because
+        a literal ``%`` in a message would otherwise corrupt the escape.
+        """
+        body = (
+            f"{self.what}\n"
+            f"Why:  {self.why}\n"
+            f"Fix:  {self.how}\n"
+            f"Docs: {self.doc.url}"
+        )
+        encoded = (
+            body.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        )
+        location = f" file={self.file}" if self.file else ""
+        return f"::{self.severity.value}{location}::{encoded}"
+
+
+# ---------------------------------------------------------------------------
+# CI faults — our bug, not theirs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InfraFault:
+    """A failure in the checker itself, or in the CI environment.
+
+    Deliberately NOT a Diagnostic: it carries no `file`, because pointing
+    at a contributor's file for our crash is the specific behaviour this
+    type exists to prevent.
+    """
+
+    checker: str
+    detail: str
+    contributor_action: str = (
+        "Nothing — re-run the job. If it fails again, this needs a repo "
+        "maintainer, not a change to your PR."
+    )
+
+    def render_human(self, indent: str = "  ") -> str:
+        return "\n".join(
+            [
+                f"{indent}[ci-fault] {self.checker} failed to run.",
+                f"{indent}  This is a problem with the repo's CI tooling, "
+                f"NOT with your changes.",
+                f"{indent}  Detail: {self.detail}",
+                f"{indent}  You:    {self.contributor_action}",
+                f"{indent}  Docs:   {Doc.CI_FAULT.url}",
+            ]
+        )
+
+    def render_annotation(self) -> str:
+        """Annotate the checker, never the contributor's file."""
+        body = (
+            f"CI tooling failure in {self.checker} — this is NOT caused by "
+            f"your changes.\n"
+            f"Detail: {self.detail}\n"
+            f"You: {self.contributor_action}"
+        )
+        encoded = (
+            body.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        )
+        return f"::error::{encoded}"
+
+
+def infra_fault(checker: str, detail: str) -> InfraFault:
+    return InfraFault(checker=checker, detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+# Exit codes. Kept distinct so a workflow can tell "your recipe is wrong"
+# from "our checker broke" and word its own output accordingly.
+EXIT_OK = 0
+EXIT_VIOLATIONS = 1
+EXIT_CI_FAULT = 2
+
+
+def _rule() -> str:
+    width = min(shutil.get_terminal_size((72, 20)).columns, 72)
+    return "=" * width
+
+
+def report(
+    diagnostics: list[Diagnostic],
+    *,
+    header: str,
+    passed_message: str,
+    next_step: str,
+) -> int:
+    """Print every diagnostic (human block + annotation) and return an exit
+    code.
+
+    One annotation per diagnostic — never a "first error (+N more)"
+    collapse. A contributor reading the Files tab should see every problem
+    anchored to the file it belongs to, not a teaser for the job log.
+    """
+    if not diagnostics:
+        print(f"[PASS] {passed_message}")
+        return EXIT_OK
+
+    print(f"\n[FAIL] {header}\n")
+    by_file: dict[str, list[Diagnostic]] = {}
+    for diag in diagnostics:
+        by_file.setdefault(diag.file or "(repository)", []).append(diag)
+
+    for path, group in by_file.items():
+        print(f"  {path}")
+        for diag in group:
+            print(diag.render_human(indent="    "))
+            print("")
+
+    for diag in diagnostics:
+        print(diag.render_annotation())
+
+    count = len(diagnostics)
+    noun = "problem" if count == 1 else "problems"
+    print("")
+    print(_rule())
+    print(f"  ACTION REQUIRED: {count} {noun} to fix")
+    print(_rule())
+    print("")
+    print(next_step)
+    print("")
+    print(f"Every fix above is documented in {_TROUBLESHOOTING}")
+    print("")
+    return EXIT_VIOLATIONS
+
+
+def report_infra_fault(fault: InfraFault) -> int:
+    """Print a CI fault and return :data:`EXIT_CI_FAULT`."""
+    print(f"\n[CI FAULT] {fault.checker} could not complete.\n")
+    print(fault.render_human(indent="  "))
+    print("")
+    print(fault.render_annotation())
+    return EXIT_CI_FAULT

--- a/tools/tests/test_ci_message.py
+++ b/tools/tests/test_ci_message.py
@@ -297,3 +297,113 @@ def test_troubleshooting_contents_list_covers_every_anchor_used_by_code():
         f"Anchors referenced from code but absent from the Contents list: "
         f"{missing}"
     )
+
+
+def test_every_checker_entrypoint_is_crash_guarded():
+    """An unguarded entrypoint turns our bug into the contributor's verdict.
+
+    A crash exits non-zero, and the calling workflow cannot tell that apart
+    from EXIT_VIOLATIONS — so it prints "ACTION REQUIRED, here is how to fix
+    your recipe" underneath a traceback nobody can act on. Every checker
+    therefore has to route its `sys.exit` through `guard()` (or handle the
+    fault itself via `report_infra_fault`).
+
+    Scoped to modules that actually import ci_message: those are the
+    contributor-facing checkers. A helper or maintenance script that never
+    reports to a contributor has nothing to guard.
+    """
+    offenders: list[str] = []
+
+    for directory in ("tools", ".github/scripts"):
+        for path in sorted((REPO_ROOT / directory).glob("*.py")):
+            if path.name == "ci_message.py":
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "ci_message" not in text:
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                stripped = line.strip()
+                if not stripped.startswith("sys.exit("):
+                    continue
+                if "guard(" in stripped or "report_infra_fault(" in stripped:
+                    continue
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {stripped}")
+
+    assert not offenders, (
+        "These exit without a crash guard, so an unhandled exception is "
+        "reported to the contributor as a problem with their recipe. Wrap "
+        "the call in ci_message.guard():\n  " + "\n  ".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# guard()
+# ---------------------------------------------------------------------------
+
+
+def test_guard_returns_the_exit_code_of_a_clean_run():
+    """The guard must be transparent when nothing goes wrong."""
+    assert m.guard("checker.py", lambda: m.EXIT_OK) == m.EXIT_OK
+    assert m.guard("checker.py", lambda: m.EXIT_VIOLATIONS) == m.EXIT_VIOLATIONS
+
+
+def test_guard_turns_a_crash_into_exit_ci_fault():
+    def boom() -> int:
+        raise RuntimeError("kaboom")
+
+    assert m.guard("checker.py", boom) == m.EXIT_CI_FAULT
+
+
+def test_guard_crash_output_names_the_checker_not_a_file(capsys):
+    """A CI fault must never carry `file=`.
+
+    `::error file=x` is what paints a red marker on a contributor's source
+    in the Files tab. Doing that for our own crash is the single behaviour
+    InfraFault exists to prevent.
+    """
+
+    def boom() -> int:
+        raise ValueError("bad internals")
+
+    m.guard("check_env_vars.py", boom)
+    out = capsys.readouterr().out
+    assert "::error file=" not in out
+    assert "check_env_vars.py" in out
+    assert "ValueError: bad internals" in out
+    assert "NOT caused by your changes" in out
+    assert m.Doc.CI_FAULT.url in out
+
+
+def test_guard_lets_systemexit_through():
+    """`argparse --help` raises SystemExit; swallowing it would turn a
+    help request into a spurious CI fault."""
+
+    def helped() -> int:
+        raise SystemExit(0)
+
+    with pytest.raises(SystemExit):
+        m.guard("checker.py", helped)
+
+
+def test_guard_lets_keyboardinterrupt_through():
+    """Ctrl-C locally must stay a Ctrl-C, not become 'CI tooling failure'."""
+
+    def interrupted() -> int:
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        m.guard("checker.py", interrupted)
+
+
+def test_guard_reports_an_exception_with_an_empty_message():
+    """`raise RuntimeError()` has no str(); the detail must still render.
+
+    A bare type name is thin, but an empty `Detail:` line would read as if
+    the checker had nothing to say about its own failure.
+    """
+
+    def boom() -> int:
+        raise RuntimeError
+
+    assert m.guard("checker.py", boom) == m.EXIT_CI_FAULT

--- a/tools/tests/test_ci_message.py
+++ b/tools/tests/test_ci_message.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Tests for the shared diagnostic helper.
+
+Two jobs here. The first is ordinary unit testing of Diagnostic and
+InfraFault. The second is the one that actually keeps message quality from
+rotting: `test_every_doc_anchor_exists_in_troubleshooting` walks the `Doc`
+enum and fails if any anchor is missing from the handbook, so a link can
+never 404 onto a contributor's screen; and the standard tests below assert
+that a Diagnostic cannot be constructed without an answer to what/why/how.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import ci_message as m
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TROUBLESHOOTING = REPO_ROOT / "docs" / "recipe-handbook" / "troubleshooting.md"
+
+
+def _github_anchor(heading: str) -> str:
+    """Slugify a Markdown heading the way GitHub does.
+
+    Lowercase, strip anything that is not alphanumeric/space/hyphen, then
+    spaces to hyphens. Good enough for the headings this repo actually
+    uses; the test that consumes it compares against a set, so a wrong
+    slug shows up as a failure rather than a silent pass.
+    """
+    text = heading.strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    return re.sub(r"\s+", "-", text).strip("-")
+
+
+def _anchors_in_troubleshooting() -> set[str]:
+    anchors: set[str] = set()
+    for line in TROUBLESHOOTING.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#"):
+            anchors.add(_github_anchor(line.lstrip("#")))
+    return anchors
+
+
+def _valid_diagnostic(**overrides) -> m.Diagnostic:
+    kwargs = {
+        "check": "required-files",
+        "what": "Required file '.env.example' is missing.",
+        "why": "Required because manifest.language is 'python'.",
+        "how": "Run the extract-python-environment-variables skill.",
+        "doc": m.Doc.REQUIRED_FILES,
+        "file": "skills/retail/product-search/.env.example",
+    }
+    kwargs.update(overrides)
+    return m.Diagnostic(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The contract: a message that only says WHAT cannot be built
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["check", "what", "why", "how"])
+@pytest.mark.parametrize("empty", ["", "   ", "\n\t "])
+def test_blank_required_field_is_rejected(field, empty):
+    with pytest.raises(ValueError, match=field):
+        _valid_diagnostic(**{field: empty})
+
+
+def test_doc_must_be_an_enum_member_not_a_bare_string():
+    """A bare string would let a caller invent an anchor that does not
+    exist; the enum is what the anchor-existence test can enumerate."""
+    with pytest.raises(TypeError, match="Doc member"):
+        _valid_diagnostic(doc="some-anchor-i-made-up")
+
+
+def test_fields_are_stripped():
+    diag = _valid_diagnostic(what="  padded  ")
+    assert diag.what == "padded"
+
+
+def test_diagnostic_is_frozen():
+    diag = _valid_diagnostic()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        diag.what = "mutated"
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def test_human_render_contains_all_four_answers():
+    out = _valid_diagnostic().render_human()
+    assert "[required-files]" in out
+    assert "Why:" in out
+    assert "Fix:" in out
+    assert "Docs:" in out
+    assert "troubleshooting.md#required-file-or-directory-missing" in out
+
+
+def test_human_render_indents_continuation_lines_of_a_multiline_fix():
+    out = _valid_diagnostic(how="line one\nline two").render_human()
+    lines = out.splitlines()
+    fix_idx = next(i for i, ln in enumerate(lines) if "Fix:" in ln)
+    # The continuation must be indented to align under the first line, not
+    # left-aligned where it would read as a separate finding.
+    assert lines[fix_idx + 1].startswith("          ")
+    assert "line two" in lines[fix_idx + 1]
+
+
+def test_annotation_is_exactly_one_line():
+    """GitHub reads one annotation per line; a raw newline would truncate
+    the message at the first break and silently drop the fix."""
+    out = _valid_diagnostic(how="first\nsecond\nthird").render_annotation()
+    assert "\n" not in out
+    assert out.startswith("::error file=")
+
+
+def test_annotation_encodes_newlines_as_percent_0a():
+    out = _valid_diagnostic(how="first\nsecond").render_annotation()
+    assert "%0A" in out
+    assert "first%0Asecond" in out
+
+
+def test_annotation_escapes_a_literal_percent_before_encoding_newlines():
+    """A literal % in a message would otherwise corrupt the %0A escape."""
+    out = _valid_diagnostic(what="100% broken").render_annotation()
+    assert "100%25 broken" in out
+
+
+def test_annotation_without_a_file_has_no_file_key():
+    out = _valid_diagnostic(file=None).render_annotation()
+    assert out.startswith("::error::")
+
+
+def test_severity_is_reflected_in_the_annotation():
+    out = _valid_diagnostic(severity=m.Severity.WARNING).render_annotation()
+    assert out.startswith("::warning file=")
+
+
+# ---------------------------------------------------------------------------
+# CI faults never point at the contributor's file
+# ---------------------------------------------------------------------------
+
+
+def test_infra_fault_annotation_carries_no_file_location():
+    """The whole point of the type: our crash must not put a red marker on
+    someone else's file."""
+    out = m.infra_fault(
+        "check_env_vars.py", "AttributeError"
+    ).render_annotation()
+    assert out.startswith("::error::")
+    assert "file=" not in out
+
+
+def test_infra_fault_says_it_is_not_the_contributors_fault():
+    out = m.infra_fault("check_env_vars.py", "boom").render_annotation()
+    assert "NOT caused by your changes" in out
+
+
+def test_report_infra_fault_returns_the_dedicated_exit_code(capsys):
+    code = m.report_infra_fault(m.infra_fault("x.py", "boom"))
+    assert code == m.EXIT_CI_FAULT
+    assert code != m.EXIT_VIOLATIONS
+    assert "[ci-fault]" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# report()
+# ---------------------------------------------------------------------------
+
+
+def test_report_emits_one_annotation_per_diagnostic(capsys):
+    """No "first error (+N more)" collapse: a contributor reading the Files
+    tab should see every problem, not a teaser for the job log."""
+    diags = [
+        _valid_diagnostic(what=f"Problem {i}.", file=f"a/f{i}.toml")
+        for i in range(4)
+    ]
+    code = m.report(
+        diags, header="h", passed_message="p", next_step="do the thing"
+    )
+    out = capsys.readouterr().out
+    assert code == m.EXIT_VIOLATIONS
+    assert out.count("::error file=") == 4
+    assert "more)" not in out
+
+
+def test_report_groups_human_output_by_file(capsys):
+    m.report(
+        [
+            _valid_diagnostic(file="a/one.toml", what="First."),
+            _valid_diagnostic(file="a/one.toml", what="Second."),
+            _valid_diagnostic(file="b/two.toml", what="Third."),
+        ],
+        header="h",
+        passed_message="p",
+        next_step="n",
+    )
+    out = capsys.readouterr().out
+    assert out.count("a/one.toml") >= 1
+    assert out.count("b/two.toml") >= 1
+
+
+def test_report_with_no_diagnostics_passes_quietly(capsys):
+    code = m.report([], header="h", passed_message="all good", next_step="n")
+    assert code == m.EXIT_OK
+    out = capsys.readouterr().out
+    assert "[PASS] all good" in out
+    assert "::error" not in out
+
+
+def test_report_always_points_at_the_troubleshooting_handbook(capsys):
+    m.report(
+        [_valid_diagnostic()], header="h", passed_message="p", next_step="n"
+    )
+    assert "troubleshooting.md" in capsys.readouterr().out
+
+
+def test_exit_codes_are_distinct():
+    codes = {m.EXIT_OK, m.EXIT_VIOLATIONS, m.EXIT_CI_FAULT}
+    assert len(codes) == 3
+
+
+# ---------------------------------------------------------------------------
+# The anti-rot test
+# ---------------------------------------------------------------------------
+
+
+def test_every_doc_anchor_exists_in_troubleshooting():
+    """Every Doc member must resolve to a real heading.
+
+    This is the test that keeps the handbook honest: adding a Doc member
+    without writing the section fails here rather than shipping a link
+    that 404s for a contributor who is already stuck.
+    """
+    present = _anchors_in_troubleshooting()
+    missing = sorted(d.value for d in m.Doc if d.value not in present)
+    assert not missing, (
+        f"Doc members with no matching heading in {TROUBLESHOOTING.name}: "
+        f"{missing}. Add a '## <heading>' section for each, or remove the "
+        f"enum member."
+    )
+
+
+def test_no_contributor_checker_hand_builds_an_annotation():
+    """Hand-rolled `::error` strings are how message quality drifted in the
+    first place: each one is a separate author deciding for themselves
+    whether to include a why, a fix or a doc link. Routing everything
+    through Diagnostic makes those three mandatory. This test is the
+    regression guard.
+
+    close_orphan_dependabot_prs.py is exempt: it is a maintenance bot whose
+    output is read by maintainers, not by a contributor fixing a PR.
+    """
+    exempt = {"ci_message.py", "close_orphan_dependabot_prs.py"}
+    pattern = re.compile(r'["\']::(error|warning|notice)')
+    offenders: list[str] = []
+
+    for directory in ("tools", ".github/scripts"):
+        for path in sorted((REPO_ROOT / directory).glob("*.py")):
+            if path.name in exempt:
+                continue
+            for lineno, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if pattern.search(line):
+                    rel = path.relative_to(REPO_ROOT)
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "These build a GitHub annotation by hand instead of going through "
+        "ci_message.Diagnostic, which means nothing forces them to explain "
+        "WHY the rule applies or HOW to fix it:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_doc_url_is_repo_relative_and_anchored():
+    url = m.Doc.ENV_VARS.url
+    assert url.startswith("docs/recipe-handbook/troubleshooting.md#")
+    assert not url.startswith("/")
+
+
+def test_troubleshooting_contents_list_covers_every_anchor_used_by_code():
+    """The Contents block at the top is how people navigate the page; an
+    anchor reachable only by scrolling is half-documented."""
+    text = TROUBLESHOOTING.read_text(encoding="utf-8")
+    contents = text.split("---", 1)[0]
+    missing = [d.value for d in m.Doc if f"(#{d.value})" not in contents]
+    assert not missing, (
+        f"Anchors referenced from code but absent from the Contents list: "
+        f"{missing}"
+    )

--- a/tools/tests/test_validate.py
+++ b/tools/tests/test_validate.py
@@ -146,3 +146,85 @@ def test_run_all_returns_zero_if_all_pass(monkeypatch):
         {"a": ("A", a), "b": ("B", b)},
     )
     assert m.run_all(None) == 0
+
+
+def test_run_all_ci_fault_outranks_a_violation(monkeypatch):
+    """A crashed validator must not be reported as an invalid recipe.
+
+    run_all used to `return 0 if all_passed else 1`, which flattened
+    EXIT_CI_FAULT into EXIT_VIOLATIONS. The workflow then printed "ACTION
+    REQUIRED: here is how to fix your recipe" for a bug in our own code.
+    """
+    violation = _Recorder(return_code=1)
+    crashed = _Recorder(return_code=2)
+    monkeypatch.setattr(
+        m,
+        "SUBCOMMANDS",
+        {
+            "violation": ("Violating tool", violation),
+            "faulted": ("Faulting tool", crashed),
+        },
+    )
+    assert m.run_all(None) == 2
+
+
+def test_run_all_reports_a_ci_fault_distinctly(monkeypatch, capsys):
+    """The summary line has to name the CI fault, not label it [FAIL]."""
+    monkeypatch.setattr(
+        m,
+        "SUBCOMMANDS",
+        {"faulted": ("Faulting tool", _Recorder(return_code=2))},
+    )
+    m.run_all(None)
+    out = capsys.readouterr().out
+    assert "[CI FAULT] Faulting tool" in out
+    assert "[FAIL] Faulting tool" not in out
+
+
+def test_run_all_still_returns_one_for_a_pure_violation(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "SUBCOMMANDS",
+        {"violation": ("Violating tool", _Recorder(return_code=1))},
+    )
+    assert m.run_all(None) == 1
+
+
+# ---------------------------------------------------------------------------
+# Crash containment at the console-script boundary
+#
+# `validate = "validate:main"` in pyproject.toml means main() — not the
+# __main__ block — is what CI actually calls. A guard on __main__ alone
+# would never fire for `uv run validate structure`.
+# ---------------------------------------------------------------------------
+
+
+def _exploding(scope=None):
+    raise RuntimeError("simulated validator crash")
+
+
+def test_main_converts_a_validator_crash_into_a_ci_fault(monkeypatch):
+    subs = {"manifest": ("Manifest validation", _exploding)}
+    monkeypatch.setattr(m, "SUBCOMMANDS", subs)
+    monkeypatch.setattr(m, "VALID_SUBCOMMANDS", [*subs, "all"])
+    assert _run(monkeypatch, ["manifest"]) == 2
+
+
+def test_main_crash_never_blames_a_contributor_file(monkeypatch, capsys):
+    subs = {"manifest": ("Manifest validation", _exploding)}
+    monkeypatch.setattr(m, "SUBCOMMANDS", subs)
+    monkeypatch.setattr(m, "VALID_SUBCOMMANDS", [*subs, "all"])
+    _run(monkeypatch, ["manifest"])
+    out = capsys.readouterr().out
+    # `::error file=...` is what puts a red marker on someone's source.
+    assert "::error file=" not in out
+    assert "NOT caused by your changes" in out
+    assert "simulated validator crash" in out
+
+
+def test_main_passes_a_clean_run_through_unchanged(monkeypatch):
+    """The guard must not mask ordinary exit codes."""
+    subs = {"manifest": ("Manifest validation", _Recorder(return_code=0))}
+    monkeypatch.setattr(m, "SUBCOMMANDS", subs)
+    monkeypatch.setattr(m, "VALID_SUBCOMMANDS", [*subs, "all"])
+    assert _run(monkeypatch, ["manifest"]) == 0

--- a/tools/tests/test_validate_manifest.py
+++ b/tools/tests/test_validate_manifest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 import validate_manifest as m
+from ci_message import Diagnostic, Doc
 
 VALID_MANIFEST = textwrap.dedent(
     """\
@@ -29,6 +30,19 @@ def _write(path: Path, content: str = "") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _blob(diagnostics: list[Diagnostic]) -> str:
+    """Every field of every diagnostic, flattened for substring checks.
+
+    The tests assert on the CONTRACT — the offending name, the rule that
+    fired, an actionable fix, a doc link — not on one exact sentence, so
+    wording can be improved without a test edit.
+    """
+    return "\n".join(
+        f"{d.check}|{d.what}|{d.why}|{d.how}|{d.doc.url}|{d.file}"
+        for d in diagnostics
+    )
 
 
 def _make_recipe(
@@ -93,15 +107,43 @@ def test_validate_manifest_valid(tmp_path):
 def test_validate_manifest_empty_file(tmp_path):
     schema = m.load_schema()
     manifest = _write(tmp_path / "manifest.yaml", "")
-    errors = m.validate_manifest(manifest, schema)
-    assert errors == ["manifest.yaml is empty"]
+    (diag,) = m.validate_manifest(manifest, schema)
+    assert diag.check == "manifest-empty"
+    # The fix has to name the fields the author is expected to write; a
+    # bare "manifest.yaml is empty" left them to go and find the schema.
+    for field in ("type", "status", "language", "description", "ownership"):
+        assert field in diag.how
+    assert diag.doc is Doc.MANIFEST
+
+
+def test_validate_manifest_comments_only_is_named_as_such(tmp_path):
+    """The confusing half of the empty case: the author can see text."""
+    manifest = _write(
+        tmp_path / "manifest.yaml", "# type: standalone\n# TODO fill in\n"
+    )
+    (diag,) = m.validate_manifest(manifest, m.load_schema())
+    assert "only comments" in diag.what
 
 
 def test_validate_manifest_bad_yaml(tmp_path):
     schema = m.load_schema()
     manifest = _write(tmp_path / "manifest.yaml", "type: [unclosed\n")
-    errors = m.validate_manifest(manifest, schema)
-    assert any("YAML parse error" in e for e in errors)
+    (diag,) = m.validate_manifest(manifest, schema)
+    assert diag.check == "manifest-yaml"
+    assert "YAML parse error" in diag.how
+    assert "line" in diag.how
+
+
+def test_yaml_parse_error_keeps_line_and_column_in_the_annotation(tmp_path):
+    """The parser's report is multi-line. An annotation is one line, so
+    the detail used to be truncated away at the first newline — leaving
+    "YAML parse error: while parsing a flow node" and nothing else."""
+    manifest = _write(tmp_path / "manifest.yaml", "type: [unclosed\n")
+    (diag,) = m.validate_manifest(manifest, m.load_schema())
+    annotation = diag.render_annotation()
+    assert "\n" not in annotation
+    assert "%0A" in annotation
+    assert "line 1" in annotation
 
 
 def test_validate_manifest_missing_required_field(tmp_path):
@@ -116,9 +158,53 @@ def test_validate_manifest_missing_required_field(tmp_path):
         """
     )
     manifest = _write(tmp_path / "manifest.yaml", content)
-    errors = m.validate_manifest(manifest, schema)
-    assert errors
-    assert any("ownership" in e for e in errors)
+    diagnostics = m.validate_manifest(manifest, schema)
+    blob = _blob(diagnostics)
+    assert "'ownership'" in blob
+    assert "generate-manifest" in blob
+    assert Doc.MANIFEST.url in blob
+
+
+def test_unknown_field_lists_the_allowed_ones_and_suggests(tmp_path):
+    """A closed schema turns a typo into a hard failure, so the message
+    has to carry the correction — not just the rejection."""
+    manifest = _write(tmp_path / "manifest.yaml", VALID_MANIFEST + "tag: []\n")
+    diagnostics = m.validate_manifest(manifest, m.load_schema())
+    blob = _blob(diagnostics)
+    assert "'tag'" in blob
+    assert "Did you mean 'tags'?" in blob
+    # The allowed set is in the schema we already loaded; withholding it
+    # buys the contributor a second CI round trip.
+    assert "ownership" in blob and "description" in blob
+
+
+def test_top_level_json_path_is_named_in_english(tmp_path):
+    manifest = _write(tmp_path / "manifest.yaml", VALID_MANIFEST + "tag: []\n")
+    diagnostics = m.validate_manifest(manifest, m.load_schema())
+    blob = _blob(diagnostics)
+    assert "top level" in blob
+    assert "[$]" not in blob
+
+
+def test_too_short_prints_the_threshold_and_the_actual_length(tmp_path):
+    content = VALID_MANIFEST.replace(
+        "description: A valid recipe description that is comfortably long.",
+        "description: short",
+    )
+    manifest = _write(tmp_path / "manifest.yaml", content)
+    blob = _blob(m.validate_manifest(manifest, m.load_schema()))
+    assert "5 characters" in blob
+    assert "at least 10" in blob
+    assert "minLength: 10" in blob
+
+
+def test_enum_violation_lists_the_allowed_values(tmp_path):
+    content = VALID_MANIFEST.replace(
+        "type: standalone", "type: not_a_valid_type"
+    )
+    manifest = _write(tmp_path / "manifest.yaml", content)
+    blob = _blob(m.validate_manifest(manifest, m.load_schema()))
+    assert "standalone" in blob and "module" in blob
 
 
 def test_validate_manifest_placeholder_team_and_poc(tmp_path):
@@ -135,9 +221,15 @@ def test_validate_manifest_placeholder_team_and_poc(tmp_path):
         """
     )
     manifest = _write(tmp_path / "manifest.yaml", content)
-    errors = m.validate_manifest(manifest, schema)
-    assert any("ownership.team" in e for e in errors)
-    assert any("ownership.poc" in e for e in errors)
+    diagnostics = m.validate_manifest(manifest, schema)
+    blob = _blob(diagnostics)
+    assert "ownership.team" in blob
+    assert "ownership.poc" in blob
+    assert all(
+        d.doc is Doc.OWNERSHIP_PLACEHOLDER
+        for d in diagnostics
+        if d.check == "ownership-placeholder"
+    )
 
 
 def test_validate_manifest_placeholder_description(tmp_path):
@@ -156,8 +248,8 @@ def test_validate_manifest_placeholder_description(tmp_path):
         """
     )
     manifest = _write(tmp_path / "manifest.yaml", content)
-    errors = m.validate_manifest(manifest, schema)
-    assert any("description" in e for e in errors)
+    blob = _blob(m.validate_manifest(manifest, schema))
+    assert "description" in blob
 
 
 def test_validate_manifest_with_valid_license(tmp_path):
@@ -171,8 +263,9 @@ def test_validate_manifest_with_empty_license(tmp_path):
     schema = m.load_schema()
     content = VALID_MANIFEST + 'license: ""\n'
     manifest = _write(tmp_path / "manifest.yaml", content)
-    errors = m.validate_manifest(manifest, schema)
-    assert any("license" in e for e in errors)
+    blob = _blob(m.validate_manifest(manifest, schema))
+    assert "license" in blob
+    assert "minLength: 1" in blob
 
 
 # ---------------------------------------------------------------------------
@@ -223,9 +316,17 @@ def test_collect_single_namespaced_recipe(fake_repo):
     assert _rel(dirs, fake_repo) == {"core/python/recipe-b"}
 
 
-def test_collect_nonexistent_scope_exits(fake_repo):
-    with pytest.raises(SystemExit):
-        m.collect_recipe_dirs("core/does-not-exist")
+def test_collect_nonexistent_scope_returns_nothing(fake_repo):
+    """A collector must not kill the process from inside a helper: only
+    the caller knows enough to say WHY nothing matched."""
+    assert m.collect_recipe_dirs("core/does-not-exist") == []
+
+
+def test_nonexistent_scope_is_explained_not_silently_passed(fake_repo, capsys):
+    assert m.main("core/does-not-exist") == 1
+    out = capsys.readouterr().out
+    assert "does not exist" in out
+    assert "troubleshooting.md" in out
 
 
 # ---------------------------------------------------------------------------
@@ -314,13 +415,24 @@ def test_is_namespace_path(parts, expected):
     assert m.is_namespace_path(parts) is expected
 
 
-def test_collect_invalid_recipe_dir_exits(tmp_path, monkeypatch):
-    # A dir with only README.md is not a valid recipe dir.
+def test_collect_invalid_recipe_dir_says_what_a_recipe_is(
+    tmp_path, monkeypatch, capsys
+):
+    """A dir with only README.md is not a recipe dir. The old message was
+    "[ERROR] Not a valid recipe directory: /abs/path" — it named neither
+    the rule nor the fix, and it was an absolute path."""
     readme_only = tmp_path / "core" / "readme-only"
     _write(readme_only / "README.md", "# just docs")
     monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
-    with pytest.raises(SystemExit):
-        m.collect_recipe_dirs("core/readme-only")
+
+    assert m.collect_recipe_dirs("core/readme-only") == []
+    assert m.main("core/readme-only") == 1
+
+    out = capsys.readouterr().out
+    assert "'core/readme-only' is not a recipe directory" in out
+    assert str(tmp_path) not in out
+    assert "manifest.yaml" in out
+    assert "generate-manifest" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tests/test_validate_placement.py
+++ b/tools/tests/test_validate_placement.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 import validate_placement as m
+from ci_message import Doc
 
 MANIFEST = "manifest.yaml"
 
@@ -42,31 +43,53 @@ def test_correctly_placed_returns_none(rel_parts):
 
 def test_flat_skill_is_rejected():
     """The case that matters: a solution dropped straight under skills/."""
-    message = m.describe_violation(["skills", "foo", MANIFEST])
-    assert message is not None
-    assert "no vertical" in message
-    assert "skills/<vertical>/foo" in message
+    diag = m.describe_violation(["skills", "foo", MANIFEST])
+    assert diag is not None
+    assert "no vertical" in diag.what
+    assert "skills/<vertical>/foo" in diag.how
+    # The fix is the command, not a description of the destination.
+    assert "git mv skills/foo" in diag.how
+    assert diag.doc is Doc.PLACEMENT
+    assert diag.file == f"skills/foo/{MANIFEST}"
 
 
 def test_flat_skill_message_names_the_offending_dir():
-    message = m.describe_violation(["skills", "store-ops", MANIFEST])
-    assert "'skills/store-ops'" in message
-    assert "skills/retail/store-ops" in message
+    diag = m.describe_violation(["skills", "store-ops", MANIFEST])
+    assert "'skills/store-ops'" in diag.what
+    assert "skills/retail/store-ops" in diag.how
 
 
 def test_manifest_at_root_of_skills_is_rejected():
-    message = m.describe_violation(["skills", MANIFEST])
-    assert message is not None
-    assert "no vertical" in message
+    diag = m.describe_violation(["skills", MANIFEST])
+    assert diag is not None
+    assert "no vertical" in diag.what
 
 
 def test_too_deep_is_rejected():
-    message = m.describe_violation(
+    diag = m.describe_violation(
         ["skills", "retail", "store-ops", "subproject", MANIFEST]
     )
-    assert message is not None
-    assert "too deeply" in message
-    assert "skills/retail/store-ops/subproject" in message
+    assert diag is not None
+    assert "too deeply" in diag.what
+    assert "skills/retail/store-ops/subproject" in diag.what
+    # The suggested destination must be a path that does not already
+    # exist — moving onto its own ancestor is not a fix.
+    assert (
+        "git mv skills/retail/store-ops/subproject skills/retail/subproject"
+        in diag.how
+    )
+
+
+def test_every_violation_explains_why_the_vertical_exists():
+    """ "Move it" without the reason invites the next contributor to make
+    the same choice again."""
+    for parts in (
+        ["skills", "foo", MANIFEST],
+        ["skills", "retail", "store-ops", "deep", MANIFEST],
+    ):
+        diag = m.describe_violation(parts)
+        assert "ownership" in diag.why
+        assert "mandatory" in diag.why
 
 
 # ---------------------------------------------------------------------------
@@ -100,13 +123,15 @@ def test_check_root_accepts_valid_tree(tmp_path, capsys):
     assert "::error" not in capsys.readouterr().out
 
 
-def test_check_root_flags_flat_skill(tmp_path, capsys):
+def test_check_root_flags_flat_skill(tmp_path):
     _make_manifest(tmp_path, "skills/retail/store-ops")
     _make_manifest(tmp_path, "skills/oops")
-    errors = m.check_root("skills", repo_root=tmp_path)
-    assert len(errors) == 1
-    out = capsys.readouterr().out
-    assert f"::error file=skills/oops/{MANIFEST}::" in out
+    (diag,) = m.check_root("skills", repo_root=tmp_path)
+    # check_root collects; main() renders. Emitting the annotation from
+    # inside the scan is what made "one annotation per problem" hard to
+    # guarantee in the first place.
+    assert diag.file == f"skills/oops/{MANIFEST}"
+    assert f"::error file=skills/oops/{MANIFEST}::" in diag.render_annotation()
 
 
 def test_check_root_flags_every_offender(tmp_path):
@@ -118,9 +143,8 @@ def test_check_root_flags_every_offender(tmp_path):
 
 def test_check_root_flags_too_deep(tmp_path):
     _make_manifest(tmp_path, "skills/retail/store-ops/inner")
-    errors = m.check_root("skills", repo_root=tmp_path)
-    assert len(errors) == 1
-    assert "too deeply" in errors[0]
+    (diag,) = m.check_root("skills", repo_root=tmp_path)
+    assert "too deeply" in diag.what
 
 
 def test_check_root_on_empty_root(tmp_path):
@@ -150,7 +174,31 @@ def test_main_reports_failure(monkeypatch, tmp_path, capsys):
     assert m.main() == 1
     out = capsys.readouterr().out
     assert "ACTION REQUIRED" in out
-    assert "1 misplaced recipe" in out
+    assert "1 problem to fix" in out
+    assert f"::error file=skills/oops/{MANIFEST}::" in out
+
+
+def test_main_annotates_every_offender(monkeypatch, tmp_path, capsys):
+    _make_manifest(tmp_path, "skills/a")
+    _make_manifest(tmp_path, "skills/b")
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    assert m.main() == 1
+    out = capsys.readouterr().out
+    assert "(+" not in out
+    assert f"::error file=skills/a/{MANIFEST}::" in out
+    assert f"::error file=skills/b/{MANIFEST}::" in out
+
+
+def test_main_footer_leads_with_the_authoring_docs(
+    monkeypatch, tmp_path, capsys
+):
+    _make_manifest(tmp_path, "skills/oops")
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    assert m.main() == 1
+    out = capsys.readouterr().out
+    assert "docs/recipe-handbook/README.md" in out
+    assert "docs/recipe-checklist.md" in out
+    assert "docs/recipe-handbook/troubleshooting.md" in out
 
 
 def test_main_narrows_to_the_given_scope(monkeypatch, tmp_path):

--- a/tools/tests/test_validate_readme.py
+++ b/tools/tests/test_validate_readme.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import validate_manifest as m
 import validate_readme as r
+from ci_message import Diagnostic, Doc
 
 # A minimal README that passes all checks (must be >= 100 words).
 VALID_README = textwrap.dedent(
@@ -53,6 +54,14 @@ def _write(path: Path, content: str = "") -> Path:
     return path
 
 
+def _blob(diagnostics: list[Diagnostic]) -> str:
+    """Every field of every diagnostic, flattened for substring checks."""
+    return "\n".join(
+        f"{d.check}|{d.what}|{d.why}|{d.how}|{d.doc.url}|{d.file}"
+        for d in diagnostics
+    )
+
+
 def _make_recipe(
     root: Path,
     rel: str,
@@ -90,22 +99,43 @@ def test_validate_readme_valid(tmp_path):
 
 def test_validate_readme_empty(tmp_path):
     readme = _write(tmp_path / "README.md", "")
-    errors = r.validate_readme(readme)
-    assert errors == ["README.md is empty"]
+    (diag,) = r.validate_readme(readme)
+    assert diag.check == "readme-empty"
+    assert diag.doc is Doc.README_MISSING
+    assert str(r.MIN_WORD_COUNT) in diag.how
 
 
 def test_validate_readme_todo_placeholder(tmp_path):
     content = VALID_README + "\nTODO: describe the agent here\n"
     readme = _write(tmp_path / "README.md", content)
-    errors = r.validate_readme(readme)
-    assert any("TODO" in e for e in errors)
+    (diag,) = r.validate_readme(readme)
+    assert diag.check == "readme-todo"
+    # Quote the offending line back — searching for it is the author's job
+    # only if we decline to do it for them.
+    assert "TODO: describe the agent here" in diag.how
 
 
 def test_validate_readme_too_short(tmp_path):
     content = "# My Recipe\n\n## Setup\n\nRun it.\n\n## Run\n\n```bash\nuv run adk web\n```\n"
     readme = _write(tmp_path / "README.md", content)
-    errors = r.validate_readme(readme)
-    assert any("too short" in e for e in errors)
+    (diag,) = r.validate_readme(readme)
+    # Both numbers, so the author knows how much further they have to go.
+    assert "words" in diag.what and str(r.MIN_WORD_COUNT) in diag.what
+    assert diag.doc is Doc.README_SHORT
+
+
+def test_a_latin1_readme_is_reported_not_a_traceback(tmp_path):
+    """UnicodeDecodeError is a ValueError, not an OSError, so the original
+    `except OSError` never caught it: one badly-encoded README aborted the
+    whole run and took every other recipe's results with it."""
+    readme = tmp_path / "README.md"
+    readme.write_bytes("# Café Agent\n".encode("latin-1"))
+
+    (diag,) = r.validate_readme(readme)
+
+    assert diag.check == "readme-encoding"
+    assert "UTF-8" in diag.what
+    assert "iconv" in diag.how
 
 
 # ---------------------------------------------------------------------------
@@ -121,8 +151,11 @@ def test_validate_readme_missing_setup(tmp_path):
     # path at all.
     content = VALID_README.replace("## Setup", "## Overview of Dependencies")
     readme = _write(tmp_path / "README.md", content)
-    errors = r.validate_readme(readme)
-    assert any("setup" in e for e in errors)
+    (diag,) = r.validate_readme(readme)
+    assert diag.check == "readme-setup"
+    # The accepted headings are listed, so the author does not have to
+    # guess which synonym the checker knows about.
+    assert "Prerequisites" in diag.how and "Installation" in diag.how
 
 
 def test_validate_readme_setup_synonym_prerequisites(tmp_path):
@@ -158,8 +191,10 @@ def test_validate_readme_setup_synonym_configuration(tmp_path):
 def test_validate_readme_missing_run(tmp_path):
     content = VALID_README.replace("## Run", "## Overview of Execution Details")
     readme = _write(tmp_path / "README.md", content)
-    errors = r.validate_readme(readme)
-    assert any("[run]" in e and "missing a run section" in e for e in errors)
+    (diag,) = r.validate_readme(readme)
+    assert diag.check == "readme-run"
+    assert "no run section" in diag.what
+    assert "Quickstart" in diag.how
 
 
 def test_validate_readme_run_synonym_usage(tmp_path):
@@ -204,7 +239,8 @@ def test_validate_readme_no_code_block(tmp_path):
     content = _re.sub(r"```.*?```", "", VALID_README, flags=_re.DOTALL)
     readme = _write(tmp_path / "README.md", content)
     errors = r.validate_readme(readme)
-    assert any("code block" in e for e in errors)
+    assert any("code block" in e.what for e in errors)
+    assert "```bash" in _blob(errors)
 
 
 # ---------------------------------------------------------------------------
@@ -264,3 +300,34 @@ def test_main_invalid_readme_emits_github_annotation(
 
     out = capsys.readouterr().out
     assert "::error file=core/bad/README.md::" in out
+
+
+def test_main_annotates_every_problem_not_just_the_first(
+    tmp_path, monkeypatch, capsys
+):
+    """A README this bad trips four rules. All four must reach the Files
+    tab; the old output showed one and "(+3 more)"."""
+    _make_recipe(tmp_path, "core/bad", readme="too short\n")
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(r, "REPO_ROOT", tmp_path)
+
+    assert r.main("core/bad") == 1
+
+    out = capsys.readouterr().out
+    assert "(+" not in out
+    assert out.count("::error file=core/bad/README.md::") == 4
+
+
+def test_main_footer_leads_with_the_authoring_docs(
+    tmp_path, monkeypatch, capsys
+):
+    _make_recipe(tmp_path, "core/bad", readme="too short\n")
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(r, "REPO_ROOT", tmp_path)
+
+    assert r.main("core/bad") == 1
+
+    out = capsys.readouterr().out
+    assert "docs/recipe-handbook/README.md" in out
+    assert "docs/recipe-checklist.md" in out
+    assert "docs/recipe-handbook/troubleshooting.md" in out

--- a/tools/tests/test_validate_structure.py
+++ b/tools/tests/test_validate_structure.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 import validate_manifest as vm
 import validate_structure as m
+from ci_message import Diagnostic, Doc
 
 # Shared minimal-valid manifest — mirrors test_validate_manifest.VALID_MANIFEST.
 VALID_MANIFEST = textwrap.dedent(
@@ -32,6 +33,23 @@ def _write(path: Path, content: str = "") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _blob(diagnostics: list[Diagnostic]) -> str:
+    """Every field of every diagnostic, flattened for substring checks.
+
+    The tests assert on the CONTRACT — the offending name, the rule that
+    fired (provenance), an actionable fix, a doc link — rather than on one
+    exact sentence, so wording can be improved without a test edit.
+    """
+    return "\n".join(
+        f"{d.check}|{d.what}|{d.why}|{d.how}|{d.doc.url}|{d.file}"
+        for d in diagnostics
+    )
+
+
+def _names(entries: list[tuple[str, str]]) -> list[str]:
+    return [name for name, _ in entries]
 
 
 def _make_python_recipe(
@@ -96,30 +114,40 @@ def _base_policy() -> dict:
 
 
 def test_required_files_for_core_python():
-    files = m.required_files_for(_base_policy(), "core", "python")
-    assert files == [
-        "README.md",
-        "AGENTS.md",
-        "pyproject.toml",
-        "uv.lock",
+    # Each entry carries the rule that contributed it — that provenance is
+    # the whole answer to "why does MY recipe need this file", and it
+    # cannot be recovered from the name alone once the lists are merged.
+    assert m.required_files_for(_base_policy(), "core", "python") == [
+        ("README.md", "always"),
+        ("AGENTS.md", "by_root.core"),
+        ("pyproject.toml", "by_language.python"),
+        ("uv.lock", "by_language.python"),
     ]
 
 
 def test_required_files_for_contrib_python():
-    files = m.required_files_for(_base_policy(), "contrib", "python")
     # No AGENTS.md — contrib has no by_root files.
-    assert files == ["README.md", "pyproject.toml", "uv.lock"]
+    assert m.required_files_for(_base_policy(), "contrib", "python") == [
+        ("README.md", "always"),
+        ("pyproject.toml", "by_language.python"),
+        ("uv.lock", "by_language.python"),
+    ]
 
 
 def test_required_files_for_skills_no_language():
-    files = m.required_files_for(_base_policy(), "skills", None)
-    assert files == ["README.md", "SKILL.md", "EVAL.yaml"]
+    assert m.required_files_for(_base_policy(), "skills", None) == [
+        ("README.md", "always"),
+        ("SKILL.md", "by_root.skills"),
+        ("EVAL.yaml", "by_root.skills"),
+    ]
 
 
 def test_required_files_for_unknown_root_and_language():
-    files = m.required_files_for(_base_policy(), "core", "brainfuck")
     # Unknown language falls back to only always + by_root[core].
-    assert files == ["README.md", "AGENTS.md"]
+    assert m.required_files_for(_base_policy(), "core", "brainfuck") == [
+        ("README.md", "always"),
+        ("AGENTS.md", "by_root.core"),
+    ]
 
 
 def test_required_files_for_missing_config():
@@ -130,6 +158,7 @@ def test_required_files_for_missing_config():
 def test_required_files_for_deduplicates():
     # The dedup path is exercised even if the intended policy layout
     # avoids overlaps — someone editing policy.yml could reintroduce one.
+    # The FIRST source wins, so the reported rule stays stable.
     policy = {
         "required_files": {
             "always": ["README.md"],
@@ -137,8 +166,11 @@ def test_required_files_for_deduplicates():
             "by_language": {"python": ["AGENTS.md", "pyproject.toml"]},
         }
     }
-    files = m.required_files_for(policy, "core", "python")
-    assert files == ["README.md", "AGENTS.md", "pyproject.toml"]
+    assert m.required_files_for(policy, "core", "python") == [
+        ("README.md", "always"),
+        ("AGENTS.md", "by_root.core"),
+        ("pyproject.toml", "by_language.python"),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -219,28 +251,32 @@ def test_check_folder_name_rejects_underscore(tmp_path):
     d = tmp_path / "my_recipe"
     d.mkdir()
     errs = m.check_folder_name(d, max_length=30)
-    assert errs and "invalid" in errs[0].lower()
+    assert errs and "invalid" in errs[0].what.lower()
+    # The fix is a runnable rename, not a restatement of the rule.
+    assert "git mv" in errs[0].how and "my-recipe" in errs[0].how
 
 
 def test_check_folder_name_rejects_uppercase(tmp_path):
     d = tmp_path / "MyRecipe"
     d.mkdir()
     errs = m.check_folder_name(d, max_length=30)
-    assert errs and "invalid" in errs[0].lower()
+    assert errs and "invalid" in errs[0].what.lower()
 
 
 def test_check_folder_name_rejects_leading_digit(tmp_path):
     d = tmp_path / "1recipe"
     d.mkdir()
     errs = m.check_folder_name(d, max_length=30)
-    assert errs and "invalid" in errs[0].lower()
+    assert errs and "invalid" in errs[0].what.lower()
 
 
 def test_check_folder_name_too_long(tmp_path):
     d = tmp_path / ("x" * 31)
     d.mkdir()
     errs = m.check_folder_name(d, max_length=30)
-    assert errs and "31 characters" in errs[0]
+    assert errs and "31 characters" in errs[0].what
+    assert "max_folder_name_length" in errs[0].why
+    assert errs[0].doc is Doc.FOLDER_NAME
 
 
 def test_check_folder_name_both_violations_reported(tmp_path):
@@ -257,6 +293,23 @@ def test_check_folder_name_both_violations_reported(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_committed_policy_pairs_every_entry_with_a_rule():
+    """Provenance is only useful if it is always there — an entry with a
+    blank source would report "Required for every recipe" for a rule that
+    is nothing of the kind."""
+    policy = m.load_policy()
+    for root in ("core", "contrib", "skills"):
+        entries = m.required_files_for(policy, root, "python")
+        entries += m.required_dirs_for(policy, root, "python")
+        for name, source in entries:
+            assert name and source
+            assert source in (
+                "always",
+                f"by_root.{root}",
+                "by_language.python",
+            ), (name, source)
+
+
 def test_check_required_files_all_present(tmp_path):
     recipe = _make_python_recipe(tmp_path, "core/foo", include_agents=True)
     policy = _base_policy()
@@ -267,7 +320,44 @@ def test_check_required_files_missing_agents_in_core(tmp_path):
     recipe = _make_python_recipe(tmp_path, "core/foo", include_agents=False)
     policy = _base_policy()
     errs = m.check_required_files(recipe, "core", "python", policy)
-    assert any("AGENTS.md" in e for e in errs)
+    assert any("AGENTS.md" in e.what for e in errs)
+
+
+def test_missing_file_says_which_rule_required_it(tmp_path):
+    """ "Required file X is missing" without the rule sends the author to
+    policy.yml to work out whether it even applies to their recipe."""
+    recipe = _make_python_recipe(tmp_path, "core/foo", include_agents=False)
+    (recipe / ".env.example").unlink()
+    policy = _full_policy()
+    by_name = {
+        d.what.split("'")[1]: d
+        for d in m.check_required_files(recipe, "core", "python", policy)
+    }
+
+    assert "by_root.core" in by_name["AGENTS.md"].why
+    assert "under core/" in by_name["AGENTS.md"].why
+
+    env = by_name[".env.example"]
+    assert "manifest.language is 'python'" in env.why
+    assert "by_language.python" in env.why
+    # …and a generator, so the fix is a command, not a research project.
+    assert "extract-python-environment-variables" in env.how
+
+
+def test_missing_uv_lock_gives_the_exact_command(isolated_repo):
+    recipe = _make_python_recipe(isolated_repo, "core/foo", include_agents=True)
+    (recipe / "uv.lock").unlink()
+    errs = m.check_required_files(recipe, "core", "python", _full_policy())
+    (lock,) = [d for d in errs if "uv.lock" in d.what]
+    assert lock.how == "cd core/foo && uv lock"
+
+
+def test_a_required_file_with_no_generator_points_at_the_checklist(tmp_path):
+    recipe = _make_python_recipe(tmp_path, "core/foo", include_agents=True)
+    policy = _full_policy()
+    policy["required_files"]["always"] = ["ARCHITECTURE.md"]
+    (diag,) = m.check_required_files(recipe, "core", None, policy)
+    assert "docs/recipe-checklist.md" in diag.how
 
 
 def test_check_required_files_contrib_does_not_require_agents(tmp_path):
@@ -287,7 +377,7 @@ def test_check_required_files_nested_path(tmp_path):
         "tests/test_runnability.py"
     )
     errs = m.check_required_files(recipe, "core", "python", policy)
-    assert any("tests/test_runnability.py" in e for e in errs)
+    assert any("tests/test_runnability.py" in e.what for e in errs)
 
 
 def test_check_required_files_directory_does_not_satisfy(tmp_path):
@@ -299,7 +389,7 @@ def test_check_required_files_directory_does_not_satisfy(tmp_path):
     _write(recipe / "README.md", "# x\n")
     policy = _base_policy()
     errs = m.check_required_files(recipe, "core", None, policy)
-    assert any("AGENTS.md" in e for e in errs)
+    assert any("AGENTS.md" in e.what and "directory" in e.what for e in errs)
 
 
 # ---------------------------------------------------------------------------
@@ -339,9 +429,15 @@ def test_check_size_and_count_exceeds_file_count(tmp_path):
     manifest = recipe / "manifest.yaml"
     # Add enough files to exceed max_files=10 (recipe already has ~6).
     for i in range(20):
-        _write(recipe / f"extra_{i}.py", "# noop\n")
-    errs = m.check_size_and_count(recipe, "core", _size_policy(), manifest)
-    assert any("exceeding the limit" in e for e in errs)
+        _write(recipe / "generated" / f"extra_{i}.py", "# noop\n")
+    (diag,) = m.check_size_and_count(recipe, "core", _size_policy(), manifest)
+    assert "the limit is 10" in diag.what
+    # Which directory is responsible — a total alone leaves the author to
+    # go and find that out with `find | wc -l`.
+    assert "generated" in diag.how
+    assert "20 files" in diag.how
+    assert "core/default tier" in diag.why
+    assert "large: true" in diag.how
 
 
 def test_check_size_and_count_exceeds_size(tmp_path):
@@ -349,8 +445,44 @@ def test_check_size_and_count_exceeds_size(tmp_path):
     manifest = recipe / "manifest.yaml"
     # Write a single 2 MiB blob; limit is 1 MiB.
     _write(recipe / "blob.bin", "x" * (2 * 1024 * 1024))
-    errs = m.check_size_and_count(recipe, "core", _size_policy(), manifest)
-    assert any("exceeds" in e and "MB" in e for e in errs)
+    (diag,) = m.check_size_and_count(recipe, "core", _size_policy(), manifest)
+    assert "2.0 MB" in diag.what and "limit is 1 MB" in diag.what
+    # The walk already knew the offending path and its size.
+    assert "blob.bin" in diag.how
+    assert "recipe_size_limits.core.default.max_size_mb = 1" in diag.why
+    assert "large: true" in diag.how
+    assert diag.doc is Doc.SIZE_LIMIT
+
+
+def test_size_message_names_the_five_largest_and_no_more(tmp_path):
+    recipe = _make_python_recipe(tmp_path, "core/foo", include_agents=True)
+    manifest = recipe / "manifest.yaml"
+    for i in range(8):
+        _write(recipe / f"blob_{i}.bin", "x" * (300 * 1024))
+    (diag,) = m.check_size_and_count(
+        recipe, "core", _size_policy(max_files=100), manifest
+    )
+    listed = [f"blob_{i}.bin" for i in range(8) if f"blob_{i}.bin" in diag.how]
+    assert len(listed) == 5
+
+
+def test_large_tier_message_says_there_is_no_higher_tier(tmp_path):
+    recipe = _make_python_recipe(
+        tmp_path,
+        "core/foo",
+        manifest=VALID_MANIFEST + "large: true\n",
+        include_agents=True,
+    )
+    manifest = recipe / "manifest.yaml"
+    policy = _size_policy()
+    policy["recipe_size_limits"]["core"]["large"] = {
+        "max_files": 1000,
+        "max_size_mb": 1,
+    }
+    _write(recipe / "blob.bin", "x" * (2 * 1024 * 1024))
+    (diag,) = m.check_size_and_count(recipe, "core", policy, manifest)
+    assert "core/large tier" in diag.why
+    assert "no higher one" in diag.how
 
 
 def test_check_size_and_count_excludes_uv_lock(tmp_path):
@@ -422,12 +554,12 @@ def test_check_size_and_count_missing_large_tier_fails(tmp_path):
             "core": {"default": {"max_files": 50, "max_size_mb": 5}}
         }
     }
-    errs = m.check_size_and_count(recipe, "core", policy, manifest)
-    assert errs
-    assert any(
-        "manifest.large=true" in e and "does not define a 'large' tier" in e
-        for e in errs
-    )
+    (diag,) = m.check_size_and_count(recipe, "core", policy, manifest)
+    assert "manifest.large is true" in diag.what
+    assert "no 'large' size tier" in diag.what
+    # Both ways out, named: drop the opt-in, or have policy.yml grow one.
+    assert "Remove `large: true`" in diag.how
+    assert "core.large" in diag.how
 
 
 def test_check_size_and_count_missing_both_tiers_is_a_noop(tmp_path):
@@ -488,13 +620,13 @@ def test_validate_recipe_missing_manifest_reports_and_skips_schema(
     schema = vm.load_schema()
     errs = m.validate_recipe(recipe, _full_policy(), schema)
     # Missing manifest is reported…
-    assert any("manifest" in e and "missing" in e for e in errs)
+    assert any(e.check == "manifest-missing" for e in errs)
     # …and required files that depend on the manifest's language are
     # NOT reported (we don't know the language, so we skip that source).
     # But `always` + `by_root[core]` files still apply.
     # AGENTS.md is present, README is present, so no other errors expected
     # beyond the manifest itself.
-    assert not any(".env.example" in e for e in errs)
+    assert ".env.example" not in _blob(errs)
 
 
 def test_validate_recipe_invalid_manifest_still_runs_other_checks(
@@ -520,8 +652,8 @@ def test_validate_recipe_invalid_manifest_still_runs_other_checks(
     (recipe / ".env.example").unlink()
     schema = vm.load_schema()
     errs = m.validate_recipe(recipe, _full_policy(), schema)
-    assert any("manifest" in e for e in errs)
-    assert any(".env.example" in e for e in errs)
+    assert any(e.check.startswith("manifest") for e in errs)
+    assert ".env.example" in _blob(errs)
 
 
 def test_validate_recipe_bad_folder_name(isolated_repo):
@@ -530,7 +662,7 @@ def test_validate_recipe_bad_folder_name(isolated_repo):
     )
     schema = vm.load_schema()
     errs = m.validate_recipe(recipe, _full_policy(), schema)
-    assert any("folder-name" in e for e in errs)
+    assert any(e.check == "folder-name" for e in errs)
 
 
 def test_validate_recipe_missing_agents_in_core(isolated_repo):
@@ -539,7 +671,7 @@ def test_validate_recipe_missing_agents_in_core(isolated_repo):
     )
     schema = vm.load_schema()
     errs = m.validate_recipe(recipe, _full_policy(), schema)
-    assert any("AGENTS.md" in e for e in errs)
+    assert "AGENTS.md" in _blob(errs)
 
 
 def test_validate_recipe_outside_known_roots(isolated_repo):
@@ -549,7 +681,23 @@ def test_validate_recipe_outside_known_roots(isolated_repo):
     )
     schema = vm.load_schema()
     errs = m.validate_recipe(recipe, _full_policy(), schema)
-    assert errs and "must live under" in errs[0]
+    assert len(errs) == 1
+    assert errs[0].check == "placement"
+    assert "core/" in errs[0].how and "skills/" in errs[0].how
+
+
+def test_every_diagnostic_carries_a_working_doc_anchor(isolated_repo):
+    """Every path out of validate_recipe must hand back somewhere to go
+    for more than one line of context."""
+    recipe = _make_python_recipe(
+        isolated_repo, "core/Bad_Name", manifest=None, include_agents=False
+    )
+    (recipe / "uv.lock").unlink()
+    errs = m.validate_recipe(recipe, _full_policy(), vm.load_schema())
+    assert errs
+    for diag in errs:
+        assert isinstance(diag.doc, Doc)
+        assert diag.doc.url.startswith("docs/recipe-handbook/")
 
 
 # ---------------------------------------------------------------------------
@@ -582,8 +730,36 @@ def test_main_returns_one_on_failure(fake_repo, capsys):
     _make_python_recipe(fake_repo, "core/broken", include_agents=False)
     assert m.main("core") == 1
     out = capsys.readouterr().out
-    assert "::error file=core/broken::" in out
+    # The annotation points at the missing file itself, not the recipe root.
+    assert "::error file=core/broken/AGENTS.md::" in out
     assert "AGENTS.md" in out
+
+
+def test_main_annotates_every_problem_not_just_the_first(fake_repo, capsys):
+    """The old output collapsed a recipe's problems into one annotation
+    plus "(+N more)", so the Files tab was a teaser for the job log."""
+    recipe = _make_python_recipe(fake_repo, "core/broken", include_agents=False)
+    (recipe / "uv.lock").unlink()
+    (recipe / ".env.example").unlink()
+
+    assert m.main("core") == 1
+
+    out = capsys.readouterr().out
+    assert "(+" not in out
+    for missing in ("AGENTS.md", "uv.lock", ".env.example"):
+        assert f"::error file=core/broken/{missing}::" in out
+
+
+def test_main_footer_leads_with_the_authoring_docs(fake_repo, capsys):
+    """policy.yml and the JSON schema are enforcement artifacts — the
+    wrong audience for someone who just wants to fix their recipe."""
+    _make_python_recipe(fake_repo, "core/broken", include_agents=False)
+    assert m.main("core") == 1
+    out = capsys.readouterr().out
+    handbook = out.index("docs/recipe-handbook/README.md")
+    checklist = out.index("docs/recipe-checklist.md")
+    policy = out.index(".github/policy.yml")
+    assert handbook < policy and checklist < policy
 
 
 def test_main_single_recipe_scope(fake_repo):
@@ -597,8 +773,12 @@ def test_main_single_recipe_scope(fake_repo):
 
 
 def test_required_dirs_for_skills():
-    dirs = m.required_dirs_for(_base_policy(), "skills", "python")
-    assert dirs == ["scripts", "assets", "references", "tests/unit"]
+    assert m.required_dirs_for(_base_policy(), "skills", "python") == [
+        ("scripts", "by_root.skills"),
+        ("assets", "by_root.skills"),
+        ("references", "by_root.skills"),
+        ("tests/unit", "by_root.skills"),
+    ]
 
 
 def test_required_dirs_for_core_is_empty():
@@ -618,8 +798,8 @@ def test_required_dirs_for_dedupes():
         }
     }
     assert m.required_dirs_for(policy, "skills", "python") == [
-        "scripts",
-        "assets",
+        ("scripts", "always"),
+        ("assets", "by_root.skills"),
     ]
 
 
@@ -658,14 +838,30 @@ def test_skill_missing_a_required_dir_fails(isolated_repo):
     skill = _make_skill(isolated_repo)
     (skill / "assets").rmdir()
     errors = m.validate_recipe(skill, _full_policy(), vm.load_schema())
-    assert any("[required-dirs]" in e and "assets/" in e for e in errors)
+    (diag,) = [d for d in errors if d.check == "required-dirs"]
+    assert "assets/" in diag.what
+    # The overwhelmingly common report is "the folder is right there" —
+    # so the fix has to lead with git's inability to commit an empty one.
+    assert "git cannot commit an empty directory" in diag.how
+    assert (
+        "touch skills/retail/store-ops/assets/.gitkeep && "
+        "git add skills/retail/store-ops/assets/.gitkeep" in diag.how
+    )
+
+
+def test_missing_dir_says_which_rule_required_it(isolated_repo):
+    skill = _make_skill(isolated_repo)
+    (skill / "scripts").rmdir()
+    (diag,) = m.check_required_dirs(skill, "skills", "python", _full_policy())
+    assert "under skills/" in diag.why
+    assert "policy.required_dirs.by_root.skills" in diag.why
 
 
 def test_skill_missing_eval_yaml_fails(isolated_repo):
     skill = _make_skill(isolated_repo)
     (skill / "EVAL.yaml").unlink()
     errors = m.validate_recipe(skill, _full_policy(), vm.load_schema())
-    assert any("EVAL.yaml" in e for e in errors)
+    assert "EVAL.yaml" in _blob(errors)
 
 
 def test_empty_required_dirs_pass(isolated_repo):
@@ -687,7 +883,7 @@ def test_required_dir_that_is_actually_a_file_is_reported_precisely(
     _write(skill / "scripts", "oops\n")
     errors = m.check_required_dirs(skill, "skills", "python", _full_policy())
     assert len(errors) == 1
-    assert "exists but is a file" in errors[0]
+    assert "exists but is a file" in errors[0].what
 
 
 # ---------------------------------------------------------------------------
@@ -703,7 +899,9 @@ def test_wrong_case_fails_for_a_strict_entry(isolated_repo):
     (skill / "pyproject.toml").unlink()
     _write(skill / "PyProject.toml", "[project]\nname='x'\n")
     errors = m.check_required_files(skill, "skills", "python", _full_policy())
-    assert any("pyproject.toml" in e and "missing" in e for e in errors)
+    assert any(
+        "pyproject.toml" in e.what and "missing" in e.what for e in errors
+    )
 
 
 def test_wrong_case_passes_for_eval_yaml_with_a_note(isolated_repo, capsys):
@@ -764,8 +962,8 @@ def test_case_insensitive_entries_reads_policy():
 def test_committed_policy_declares_the_skill_contract():
     """A future edit must not silently drop part of the contract."""
     policy = m.load_policy()
-    files = m.required_files_for(policy, "skills", "python")
-    dirs = m.required_dirs_for(policy, "skills", "python")
+    files = _names(m.required_files_for(policy, "skills", "python"))
+    dirs = _names(m.required_dirs_for(policy, "skills", "python"))
     for f in (
         "README.md",
         "SKILL.md",
@@ -775,8 +973,12 @@ def test_committed_policy_declares_the_skill_contract():
         "tests/test_runnability.py",
     ):
         assert f in files, f
-    for d in ("scripts", "assets", "references", "tests/unit"):
-        assert d in dirs, d
+    # scripts/ is the only required DIRECTORY: an empty directory passes,
+    # so a rule satisfied by a .gitkeep enforces nothing. assets/,
+    # references/ and tests/unit/ remain the convention and are still
+    # created by the scaffold — see the comment above required_dirs in
+    # .github/policy.yml.
+    assert dirs == ["scripts"]
 
 
 def test_committed_policy_keeps_tool_read_files_case_strict():

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -40,6 +40,7 @@ import validate_manifest
 import validate_placement
 import validate_readme
 import validate_structure
+from ci_message import EXIT_CI_FAULT, EXIT_OK, EXIT_VIOLATIONS, guard
 
 SUBCOMMANDS = {
     "manifest": ("Manifest validation", validate_manifest.main),
@@ -69,14 +70,23 @@ def run_all(scope: str | None) -> int:
     print(f"\n{'=' * 60}")
     print("  Summary")
     print(f"{'=' * 60}")
-    all_passed = True
+    statuses = {
+        EXIT_OK: "[PASS]",
+        EXIT_VIOLATIONS: "[FAIL]",
+        EXIT_CI_FAULT: "[CI FAULT]",
+    }
     for label, exit_code in results:
-        status = "[PASS]" if exit_code == 0 else "[FAIL]"
-        print(f"  {status} {label}")
-        if exit_code != 0:
-            all_passed = False
+        print(f"  {statuses.get(exit_code, '[FAIL]')} {label}")
 
-    return 0 if all_passed else 1
+    # A CI fault outranks a violation. Collapsing 2 into 1 here would tell
+    # the workflow "the recipe is invalid" when what actually happened is
+    # that one of our own validators crashed — so the contributor gets
+    # fix-it advice for a bug they cannot fix.
+    if any(code == EXIT_CI_FAULT for _, code in results):
+        return EXIT_CI_FAULT
+    if any(code != EXIT_OK for _, code in results):
+        return EXIT_VIOLATIONS
+    return EXIT_OK
 
 
 def looks_like_scope(arg: str) -> bool:
@@ -84,7 +94,7 @@ def looks_like_scope(arg: str) -> bool:
     return "/" in arg or arg in RECIPE_ROOTS or arg == "all"
 
 
-def main() -> int:
+def _dispatch() -> int:
     args = sys.argv[1:]
 
     # Strip --help / -h and let Python handle it manually so we can keep
@@ -137,5 +147,17 @@ def main() -> int:
     return tool_main(scope)
 
 
+def main() -> int:
+    """Guarded entrypoint.
+
+    This is what `validate = "validate:main"` in pyproject.toml binds, so
+    it — not the `__main__` block below — is the boundary CI actually
+    crosses when it runs `uv run validate structure`. The guard has to live
+    here or a crash in a sub-validator escapes as a bare traceback and the
+    workflow reads it as the contributor's recipe being invalid.
+    """
+    return guard("validate", _dispatch)
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(guard("validate", _dispatch))

--- a/tools/validate_manifest.py
+++ b/tools/validate_manifest.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 import jsonschema
 import yaml
-from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, report
+from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, guard, report
 
 REPO_ROOT = Path(__file__).parent.parent
 SCHEMA_PATH = REPO_ROOT / ".github" / "schemas" / "manifest-schema.json"
@@ -708,4 +708,4 @@ if __name__ == "__main__":
         ),
     )
     args = parser.parse_args()
-    sys.exit(main(args.scope))
+    sys.exit(guard("validate_manifest.py", lambda: main(args.scope)))

--- a/tools/validate_manifest.py
+++ b/tools/validate_manifest.py
@@ -29,12 +29,14 @@ Exit codes:
 """
 
 import argparse
+import difflib
 import json
 import sys
 from pathlib import Path
 
 import jsonschema
 import yaml
+from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, report
 
 REPO_ROOT = Path(__file__).parent.parent
 SCHEMA_PATH = REPO_ROOT / ".github" / "schemas" / "manifest-schema.json"
@@ -50,6 +52,17 @@ OWNERSHIP_TEAM_PLACEHOLDER = "TODO: Replace with your team name"
 OWNERSHIP_POC_PLACEHOLDER = "TODO: Replace with your GitHub user ID"
 
 LANGUAGE_NAMESPACE_DIRS = {"python", "java", "go", "typescript", "kotlin"}
+
+# Every validator's footer opens with these. A contributor who has just
+# failed a check needs to know how a recipe is meant to be BUILT; .github/
+# policy.yml and the JSON schema answer "what exactly is the rule", which
+# is the maintainer's question. Leading with the enforcement artifacts sent
+# people to read YAML they had never seen to work out what to type.
+AUTHORING_DOCS = (
+    "Start here:\n"
+    "  docs/recipe-handbook/README.md  how a recipe is put together\n"
+    "  docs/recipe-checklist.md        the pre-PR checklist"
+)
 
 # Roots whose second path component is ALWAYS a namespace, whatever it is
 # called. core/ and contrib/ take an OPTIONAL language namespace, matched by
@@ -115,81 +128,367 @@ def load_schema() -> dict:
         return json.load(f)
 
 
-def validate_manifest(manifest_path: Path, schema: dict) -> list[str]:
-    """Returns a list of error strings. Empty list means valid."""
-    errors = []
+def repo_relative(path: Path, repo_root: Path | None = None) -> str:
+    """Repo-relative spelling of `path`, for a diagnostic's `file=`.
+
+    An absolute path is noise on a contributor's screen and GitHub cannot
+    anchor an annotation to one. Falls back to the path as given when it
+    lies outside the repo — only reachable from tests that point the
+    tooling at a scratch tree.
+    """
+    base = Path(repo_root) if repo_root is not None else REPO_ROOT
+    try:
+        return str(Path(path).resolve().relative_to(base.resolve()))
+    except ValueError:
+        return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Turning jsonschema errors into something a contributor can act on
+#
+# jsonschema speaks JSONPath and its own vocabulary: "[$.description] 'short'
+# is too short" names neither the YAML field nor the threshold it failed.
+# The threshold is sitting in the schema we already loaded, so withholding
+# it only buys the contributor a second CI round trip to discover it.
+# ---------------------------------------------------------------------------
+
+
+def _field_label(json_path: str) -> str:
+    """`$` -> "top level"; `$.ownership.team` -> "ownership.team"."""
+    if json_path in ("", "$"):
+        return "top level"
+    return json_path.removeprefix("$.").removeprefix("$")
+
+
+def _quote(value: object, limit: int = 60) -> str:
+    """Render an offending value short enough to sit inside a message."""
+    text = str(value)
+    if len(text) > limit:
+        text = text[: limit - 1] + "…"
+    return repr(text) if isinstance(value, str) else text
+
+
+def _did_you_mean(name: str, candidates: list[str]) -> str:
+    match = difflib.get_close_matches(name, candidates, n=1, cutoff=0.7)
+    return f"Did you mean '{match[0]}'? " if match else ""
+
+
+def _additional_properties(err) -> tuple[str, str, str]:
+    allowed = sorted((err.schema or {}).get("properties") or {})
+    instance = err.instance if isinstance(err.instance, dict) else {}
+    extras = [k for k in instance if k not in allowed] or ["(unknown)"]
+    where = _field_label(err.json_path)
+    listed = ", ".join(f"'{k}'" for k in extras)
+    what = (
+        f"Unrecognised field{'s' if len(extras) > 1 else ''} "
+        f"{listed} at the {where} of {MANIFEST_FILENAME}."
+    )
+    why = (
+        f"The manifest schema is closed (additionalProperties: false at "
+        f"{err.json_path}), so an unknown key is never ignored — it is "
+        f"either a typo or a field that does not exist."
+    )
+    suggestion = "".join(_did_you_mean(k, allowed) for k in extras)
+    how = (
+        f"{suggestion}Rename or remove it.\n"
+        f"Fields allowed at the {where}: {', '.join(allowed) or '(none)'}"
+    )
+    return what, why, how
+
+
+def _bound(err) -> tuple[str, str, str] | None:
+    """Threshold-style failures — the ones worth printing the number for."""
+    label = _field_label(err.json_path)
+    limit = err.validator_value
+    kind = err.validator
+    if kind in ("minLength", "maxLength"):
+        actual = len(err.instance) if isinstance(err.instance, str) else "?"
+        direction = "at least" if kind == "minLength" else "at most"
+        what = (
+            f"Field '{label}' is {actual} characters long; the schema "
+            f"requires {direction} {limit}."
+        )
+    elif kind in ("minItems", "maxItems"):
+        actual = len(err.instance) if isinstance(err.instance, list) else "?"
+        direction = "at least" if kind == "minItems" else "at most"
+        what = (
+            f"Field '{label}' has {actual} entries; the schema requires "
+            f"{direction} {limit}."
+        )
+    elif kind in ("minimum", "maximum"):
+        direction = "at least" if kind == "minimum" else "at most"
+        what = (
+            f"Field '{label}' is {_quote(err.instance)}; the schema "
+            f"requires {direction} {limit}."
+        )
+    else:
+        return None
+
+    why = (
+        f"{SCHEMA_PATH.name} sets {kind}: {limit} on {label}. Current "
+        f"value: {_quote(err.instance)}."
+    )
+    purpose = (err.schema or {}).get("description")
+    how = f"Replace the value so it satisfies {kind}: {limit}."
+    if purpose:
+        how += f"\nWhat this field is for: {purpose}"
+    return what, why, how
+
+
+def _enum(err) -> tuple[str, str, str]:
+    label = _field_label(err.json_path)
+    allowed = [str(v) for v in (err.validator_value or [])]
+    what = (
+        f"Field '{label}' is {_quote(err.instance)}, which is not one of "
+        f"the values the schema allows."
+    )
+    why = (
+        f"{SCHEMA_PATH.name} restricts {label} to an enum: "
+        f"{', '.join(allowed)}."
+    )
+    suggestion = (
+        _did_you_mean(str(err.instance), allowed)
+        if isinstance(err.instance, str)
+        else ""
+    )
+    how = f"{suggestion}Set {label} to one of: {', '.join(allowed)}."
+    return what, why, how
+
+
+def _required(err, schema: dict) -> tuple[str, str, str]:
+    instance = err.instance if isinstance(err.instance, dict) else {}
+    missing = [p for p in (err.validator_value or []) if p not in instance]
+    label = _field_label(err.json_path)
+    where = "top level" if label == "top level" else f"'{label}' block"
+    named = ", ".join(f"'{p}'" for p in missing) or err.message
+    verb = "are" if len(missing) > 1 else "is"
+    what = (
+        f"Required field{'s' if len(missing) > 1 else ''} {named} {verb} "
+        f"missing from the {where} of {MANIFEST_FILENAME}."
+    )
+    why = (
+        f"{SCHEMA_PATH.name} lists {', '.join(err.validator_value or [])} "
+        f"as required at {err.json_path}."
+    )
+    props = (err.schema or schema).get("properties") or {}
+    lines = [
+        f"  {name}: {props[name].get('description', '')[:70]}"
+        for name in missing
+        if name in props
+    ]
+    how = "\n".join(["Add the missing field(s):", *lines] if lines else [])
+    return (
+        what,
+        why,
+        (how or "Add the missing field(s).")
+        + "\nOr run the `generate-manifest` AI skill to write a complete one.",
+    )
+
+
+def _type(err) -> tuple[str, str, str]:
+    label = _field_label(err.json_path)
+    expected = err.validator_value
+    if isinstance(expected, list):
+        expected = " or ".join(str(e) for e in expected)
+    what = (
+        f"Field '{label}' is {_quote(err.instance)}; the schema requires "
+        f"a {expected}."
+    )
+    why = f"{SCHEMA_PATH.name} declares {label} as type: {expected}."
+    how = f"Change the value of {label} to a {expected}."
+    return what, why, how
+
+
+def _schema_diagnostic(err, schema: dict, file: str) -> Diagnostic:
+    """One jsonschema error, translated out of JSONPath and into YAML."""
+    handlers = {
+        "additionalProperties": lambda: _additional_properties(err),
+        "enum": lambda: _enum(err),
+        "required": lambda: _required(err, schema),
+        "type": lambda: _type(err),
+    }
+    parts = _bound(err)
+    if parts is None:
+        handler = handlers.get(err.validator)
+        parts = (
+            handler()
+            if handler
+            else (
+                f"Field '{_field_label(err.json_path)}' in "
+                f"{MANIFEST_FILENAME} is invalid: {err.message}",
+                f"{SCHEMA_PATH.name} applies the '{err.validator}' rule to "
+                f"{err.json_path}.",
+                f"Compare the field against {SCHEMA_PATH.name} and correct "
+                f"the value.",
+            )
+        )
+    what, why, how = parts
+    return Diagnostic(
+        check="manifest-schema",
+        what=what,
+        why=why,
+        how=how,
+        doc=Doc.MANIFEST,
+        file=file,
+    )
+
+
+def validate_manifest(manifest_path: Path, schema: dict) -> list[Diagnostic]:
+    """Returns a list of diagnostics. Empty list means valid."""
+    file = repo_relative(manifest_path)
     try:
         with open(manifest_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        errors.append(f"YAML parse error: {e}")
-        return errors
+        # The parser's own report is multi-line and carries the line and
+        # column. That detail used to be truncated at the first newline on
+        # its way into an annotation; the Diagnostic renderer percent-
+        # encodes newlines, so it survives to the Files tab intact.
+        # PyYAML names the stream by the absolute path it was opened with,
+        # which on a CI runner is a temp path the reader does not
+        # recognise — swap it for the repo-relative one.
+        detail = str(e).replace(str(manifest_path), file)
+        return [
+            Diagnostic(
+                check="manifest-yaml",
+                what=f"{MANIFEST_FILENAME} is not valid YAML.",
+                why=(
+                    "Nothing else can be checked until the file parses — "
+                    "schema validation, language detection and the "
+                    "required-file rules all read the parsed document."
+                ),
+                how=(
+                    f"Fix the syntax the parser reports below, then re-run "
+                    f"`uv run validate manifest`.\n"
+                    f"YAML parse error: {detail}"
+                ),
+                doc=Doc.MANIFEST,
+                file=file,
+            )
+        ]
 
     if data is None:
-        errors.append("manifest.yaml is empty")
-        return errors
+        # yaml.safe_load returns None for a zero-byte file AND for one that
+        # holds nothing but comments — the second is the confusing case,
+        # because the author can see text in their editor.
+        required = ", ".join(schema.get("required") or [])
+        return [
+            Diagnostic(
+                check="manifest-empty",
+                what=(
+                    f"{MANIFEST_FILENAME} has no content — it is either "
+                    f"empty or contains only comments."
+                ),
+                why=(
+                    "A manifest is how the tooling learns the recipe's "
+                    "language, type and owner; a commented-out manifest "
+                    "declares none of them."
+                ),
+                how=(
+                    f"Run the `generate-manifest` AI skill, or write the "
+                    f"required top-level fields by hand: {required}."
+                ),
+                doc=Doc.MANIFEST,
+                file=file,
+            )
+        ]
 
     validator = jsonschema.Draft7Validator(schema)
-    for err in sorted(validator.iter_errors(data), key=str):
-        errors.append(f"  [{err.json_path}] {err.message}")
+    diagnostics = [
+        _schema_diagnostic(err, schema, file)
+        for err in sorted(validator.iter_errors(data), key=str)
+    ]
 
-    # Check that placeholder values have been replaced with real ones
+    # Placeholder values satisfy the schema but mean nobody has claimed the
+    # recipe, so they are checked separately from it.
     if isinstance(data, dict):
         ownership = data.get("ownership")
         if isinstance(ownership, dict):
-            if ownership.get("team") == OWNERSHIP_TEAM_PLACEHOLDER:
-                errors.append(
-                    "  [ownership.team] is still set to the placeholder value "
-                    f'"{OWNERSHIP_TEAM_PLACEHOLDER}". '
-                    "Please replace it with a real team name."
-                )
-            if ownership.get("poc") == OWNERSHIP_POC_PLACEHOLDER:
-                errors.append(
-                    "  [ownership.poc] is still set to the placeholder value "
-                    f'"{OWNERSHIP_POC_PLACEHOLDER}". '
-                    "Please replace it with a real GitHub ID."
+            for field, placeholder, fix in (
+                (
+                    "team",
+                    OWNERSHIP_TEAM_PLACEHOLDER,
+                    "the name of the team that owns this recipe",
+                ),
+                (
+                    "poc",
+                    OWNERSHIP_POC_PLACEHOLDER,
+                    "the GitHub user ID of the person accountable for it",
+                ),
+            ):
+                if ownership.get(field) != placeholder:
+                    continue
+                diagnostics.append(
+                    Diagnostic(
+                        check="ownership-placeholder",
+                        what=(
+                            f"ownership.{field} is still the scaffold "
+                            f'placeholder "{placeholder}".'
+                        ),
+                        why=(
+                            "Ownership is how a question about this recipe "
+                            "reaches someone who can answer it; a "
+                            "placeholder routes it nowhere."
+                        ),
+                        how=f"Set ownership.{field} to {fix}.",
+                        doc=Doc.OWNERSHIP_PLACEHOLDER,
+                        file=file,
+                    )
                 )
 
-        # A description left as a "TODO ..." placeholder (e.g. the scaffold
-        # template's default) is long enough to satisfy the schema's
-        # minLength, so it would otherwise slip through. Guard it explicitly,
-        # mirroring the ownership checks above. A prefix match (rather than an
-        # exact string) keeps this robust to wording changes and catches any
-        # hand-written "TODO ..." description too.
+        # A "TODO ..." description is long enough to satisfy the schema's
+        # minLength, so it would otherwise slip through. A prefix match
+        # (rather than an exact string) keeps this robust to wording changes
+        # and catches any hand-written "TODO ..." description too.
         description = data.get("description")
         if isinstance(
             description, str
         ) and description.strip().upper().startswith("TODO"):
-            errors.append(
-                "  [description] is still a TODO placeholder. Please replace "
-                "it with a real description of what the recipe demonstrates."
+            diagnostics.append(
+                Diagnostic(
+                    check="description-placeholder",
+                    what=(
+                        "manifest.description is still a TODO placeholder: "
+                        f"{_quote(description)}."
+                    ),
+                    why=(
+                        "The description is what the recipe catalogue shows "
+                        "to someone deciding whether to use this recipe."
+                    ),
+                    how=(
+                        "Replace it with one or two sentences saying what "
+                        "the recipe demonstrates and what it is good for."
+                    ),
+                    doc=Doc.MANIFEST,
+                    file=file,
+                )
             )
 
-    return errors
+    return diagnostics
 
 
 def _collect_scoped_path(scope: str) -> list[Path]:
     """Resolve a scope that points at a specific path (not a bare root).
 
     Handles a language namespace dir (recurse one level) or a single recipe
-    directory. Exits the process on an invalid path.
+    directory. Returns [] for anything it cannot resolve rather than
+    calling sys.exit: killing the process from inside a collector meant the
+    contributor got a bare "[ERROR] Not a valid recipe directory:
+    /Users/…/core/foo" with no statement of what a recipe directory IS.
+    empty_scope_diagnostic answers that, and can only do so if it is
+    reached.
     """
     target = REPO_ROOT / scope
     if not target.exists():
-        print(f"[ERROR] Directory not found: {target}")
-        sys.exit(1)
+        return []
     # Namespace directory (e.g. core/python, skills/retail) — recurse one
     # level. Matched on the scope's own components rather than just the
     # basename, so `skills/retail` is a namespace while the solution beneath
     # it, `skills/retail/store-ops`, is not.
     if is_namespace_path(scope.strip("/").split("/")):
-        recipe_dirs = sorted(c for c in target.iterdir() if is_recipe_dir(c))
-        if not recipe_dirs:
-            print(f"[INFO] No recipe directories found under '{scope}/'.")
-        return recipe_dirs
+        return sorted(c for c in target.iterdir() if is_recipe_dir(c))
     if not is_recipe_dir(target):
-        print(f"[ERROR] Not a valid recipe directory: {target}")
-        sys.exit(1)
+        return []
     return [target]
 
 
@@ -252,70 +551,147 @@ def collect_recipe_dirs(scope: str | None) -> list[Path]:
     return dirs
 
 
+def empty_scope_diagnostic(
+    scope: str | None, recipe_dirs: list
+) -> Diagnostic | None:
+    """Diagnostic for an EXPLICIT scope that matched no recipes, else None.
+
+    Without this, `uv run validate structure skills` prints
+    "[PASS] All 0 recipe(s) passed structural checks." and exits 0 — a
+    green check for a run that validated nothing. A typo'd scope does the
+    same. Both are far likelier to be a mistake than a deliberate request
+    to check nothing, and a silent pass is the worst possible answer to
+    either.
+
+    An unscoped (or "all") run is exempt: scanning a root that is
+    legitimately empty — `skills/` before the first vertical skill lands —
+    is normal, and `_collect_root` already prints an [INFO] for it.
+    """
+    if recipe_dirs or scope is None or scope == "all":
+        return None
+
+    rel = scope.strip("/")
+    target = REPO_ROOT / rel
+    shape = (
+        f"A scope names a root ({', '.join(RECIPE_ROOTS)}), a namespace "
+        f"inside one (core/python, skills/retail), or one recipe directory."
+    )
+    drop_the_scope = (
+        "Check the path for a typo, or drop the scope to run against the "
+        "whole tree:\n  uv run validate"
+    )
+
+    if not target.exists():
+        what = f"Scope '{rel}' does not exist."
+        why = f"Nothing was validated. {shape}"
+        how = drop_the_scope
+    elif not target.is_dir():
+        what = f"Scope '{rel}' is a file, not a directory."
+        why = f"Nothing was validated. {shape}"
+        how = drop_the_scope
+    elif rel in RECIPE_ROOTS or is_namespace_path(rel.split("/")):
+        what = f"'{rel}/' holds no recipe directories."
+        why = (
+            f"'{rel}/' is a container, and every child of it was either "
+            f"empty or not a recipe. Nothing was validated."
+        )
+        how = drop_the_scope
+    elif not is_recipe_dir(target):
+        what = (
+            f"'{rel}' is not a recipe directory — it contains no "
+            f"{MANIFEST_FILENAME}."
+        )
+        why = (
+            f"{MANIFEST_FILENAME} is what makes a directory a recipe: it "
+            f"declares the language, type and owner that every other check "
+            f"reads. Without it the directory is a container."
+        )
+        how = (
+            f"If '{rel}' is meant to be a recipe, add {MANIFEST_FILENAME} — "
+            f"run the `generate-manifest` AI skill.\n"
+            f"If it is a container, scope to a recipe inside it instead."
+        )
+    else:
+        what = f"Scope '{rel}' matched no recipe directories."
+        why = f"Nothing was validated. {shape}"
+        how = drop_the_scope
+
+    return Diagnostic(
+        check="scope",
+        what=what,
+        why=why,
+        how=how,
+        doc=Doc.MANIFEST,
+    )
+
+
+def report_empty_scope(scope: str | None, recipe_dirs: list) -> bool:
+    """Report the empty-scope problem if it applies. True means 'stop'."""
+    diagnostic = empty_scope_diagnostic(scope, recipe_dirs)
+    if diagnostic is None:
+        return False
+    report(
+        [diagnostic],
+        header=f"Scope '{scope}' validated nothing.",
+        passed_message="",
+        next_step=f"{AUTHORING_DOCS}\n\nUsage:\n  uv run validate --help",
+    )
+    return True
+
+
+def missing_manifest_diagnostic(manifest_path: Path) -> Diagnostic:
+    """The one check every other check depends on.
+
+    Shared with validate_structure so both tools word it identically —
+    a contributor who sees it twice in one CI run should not have to work
+    out whether they are two different problems.
+    """
+    return Diagnostic(
+        check="manifest-missing",
+        what=f"{MANIFEST_FILENAME} is missing.",
+        why=(
+            "Every recipe is required to ship one: it declares the "
+            "language, type, status and owner, and the language-specific "
+            "required-file rules are resolved from manifest.language. "
+            "Without it those checks cannot run at all."
+        ),
+        how=(
+            "Run the `generate-manifest` AI skill, or copy the minimum "
+            "example from docs/recipe-handbook/anatomy.md#manifestyaml."
+        ),
+        doc=Doc.MANIFEST,
+        file=repo_relative(manifest_path),
+    )
+
+
 def main(scope: str | None = None) -> int:
     schema = load_schema()
     recipe_dirs = collect_recipe_dirs(scope)
+    if report_empty_scope(scope, recipe_dirs):
+        return EXIT_VIOLATIONS
 
-    missing = []
-    invalid = {}
-
+    diagnostics: list[Diagnostic] = []
     for recipe_dir in recipe_dirs:
         manifest_path = recipe_dir / MANIFEST_FILENAME
         if not manifest_path.exists():
-            missing.append(str(recipe_dir.relative_to(REPO_ROOT)))
+            diagnostics.append(missing_manifest_diagnostic(manifest_path))
         else:
-            errors = validate_manifest(manifest_path, schema)
-            if errors:
-                invalid[str(manifest_path.relative_to(REPO_ROOT))] = errors
+            diagnostics.extend(validate_manifest(manifest_path, schema))
 
-    passed = True
-
-    if missing:
-        passed = False
-        print(
-            "\n[FAIL] Missing manifest.yaml in the following recipe"
-            " directories:"
-        )
-        for d in missing:
-            print(f"  - {d}/")
-            # GitHub Actions annotation — surfaces in the PR Files tab
-            print(
-                f"::error file={d}/manifest.yaml::manifest.yaml is missing. "
-                "Create one using the schema at "
-                ".github/schemas/manifest-schema.json"
-            )
-
-    if invalid:
-        passed = False
-        print("\n[FAIL] Invalid manifest.yaml files:")
-        for path, errors in invalid.items():
-            print(f"\n  {path}:")
-            for e in errors:
-                print(f"    {e}")
-            # Emit one annotation per file pointing at the manifest
-            first_error = errors[0].strip()
-            print(
-                f"::error file={path}::{first_error} (+{len(errors) - 1} more)"
-                if len(errors) > 1
-                else f"::error file={path}::{first_error}"
-            )
-
-    if not passed:
-        print(
-            "\n========================================"
-            "\n  ACTION REQUIRED: invalid manifest(s)"
-            "\n========================================"
-            "\n"
-            "\nFix the manifest.yaml file(s) listed above, then push again."
-            "\n"
-            "\nReference:"
-            "\n  Schema:  .github/schemas/manifest-schema.json"
-        )
-        return 1
-
-    checked = len(recipe_dirs)
-    print(f"\n[PASS] All {checked} recipe manifest(s) are present and valid.")
-    return 0
+    return report(
+        diagnostics,
+        header="manifest.yaml problems",
+        passed_message=(
+            f"All {len(recipe_dirs)} recipe manifest(s) are present and valid."
+        ),
+        next_step=(
+            f"{AUTHORING_DOCS}\n"
+            f"\nRe-run locally:\n"
+            f"  uv run validate manifest <recipe-path>\n"
+            f"\nThe rule itself lives in "
+            f".github/schemas/manifest-schema.json."
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/tools/validate_placement.py
+++ b/tools/validate_placement.py
@@ -37,7 +37,7 @@ import sys
 from pathlib import Path
 
 import validate_manifest as vm
-from ci_message import Diagnostic, Doc, report
+from ci_message import Diagnostic, Doc, guard, report
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -199,4 +199,4 @@ def main(scope: str | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(guard("validate_placement.py", main))

--- a/tools/validate_placement.py
+++ b/tools/validate_placement.py
@@ -37,6 +37,7 @@ import sys
 from pathlib import Path
 
 import validate_manifest as vm
+from ci_message import Diagnostic, Doc, report
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -63,8 +64,8 @@ def find_manifests(root: Path) -> list[Path]:
     return found
 
 
-def describe_violation(rel_parts: list[str]) -> str | None:
-    """Return an error message for a manifest path, or None if it is valid.
+def describe_violation(rel_parts: list[str]) -> Diagnostic | None:
+    """Return a diagnostic for a manifest path, or None if it is valid.
 
     `rel_parts` are the manifest's path components relative to the repo
     root, e.g. ["skills", "retail", "store-ops", "manifest.yaml"].
@@ -75,20 +76,46 @@ def describe_violation(rel_parts: list[str]) -> str | None:
     root = rel_parts[0]
     recipe_dir = "/".join(rel_parts[:-1])
     expected = f"{root}/<vertical>/<solution>/{vm.MANIFEST_FILENAME}"
+    why = (
+        f"Every {root}/ recipe must live at {expected}. The vertical "
+        f"(retail/, hr/, finance/) is mandatory: it is what surfaces "
+        f"ownership and lets a team see its whole surface at a glance."
+    )
 
     if len(rel_parts) < EXPECTED_PARTS:
         solution = rel_parts[-2] if len(rel_parts) > 1 else "<solution>"
-        return (
-            f"'{recipe_dir}' sits directly under '{root}/' with no vertical. "
-            f"Every {root}/ recipe must live at {expected} — move it to "
-            f"'{root}/<vertical>/{solution}' (e.g. "
-            f"'{root}/retail/{solution}'), choosing the vertical that owns "
-            f"it."
+        return Diagnostic(
+            check="placement",
+            what=(
+                f"'{recipe_dir}' sits directly under '{root}/' with no "
+                f"vertical."
+            ),
+            why=why,
+            how=(
+                f"Move it one level down, into the vertical that owns it:\n"
+                f"  git mv {recipe_dir} {root}/<vertical>/{solution}\n"
+                f"e.g. {root}/retail/{solution}"
+            ),
+            doc=Doc.PLACEMENT,
+            file="/".join(rel_parts),
         )
 
-    return (
-        f"'{recipe_dir}' is nested too deeply. Every {root}/ recipe must "
-        f"live at {expected}, one directory below its vertical."
+    # rel_parts[1] is the vertical (the only component whose role is fixed
+    # by position at this depth); rel_parts[-2] is the directory actually
+    # holding the manifest, which is the thing that has to move.
+    correct = f"{root}/{rel_parts[1]}/{rel_parts[-2]}"
+    return Diagnostic(
+        check="placement",
+        what=f"'{recipe_dir}' is nested too deeply.",
+        why=f"{why} It must sit exactly one directory below its vertical.",
+        how=(
+            f"Move it up to the solution level:\n"
+            f"  git mv {recipe_dir} {correct}\n"
+            f"…or, if it belongs to a different vertical, move it to "
+            f"{root}/<vertical>/{rel_parts[-2]} instead."
+        ),
+        doc=Doc.PLACEMENT,
+        file="/".join(rel_parts),
     )
 
 
@@ -96,26 +123,24 @@ def check_root(
     root_name: str,
     repo_root: Path = REPO_ROOT,
     scope: str | None = None,
-) -> list[str]:
-    """Return an error string for every misplaced recipe under a root.
+) -> list[Diagnostic]:
+    """Return a diagnostic for every misplaced recipe under a root.
 
     `scope`, when given, restricts reporting to manifests beneath that
     repo-relative path, so `validate placement core/python/foo` cannot fail
     on an unrelated problem elsewhere in the tree.
     """
-    errors: list[str] = []
+    diagnostics: list[Diagnostic] = []
     for manifest in find_manifests(repo_root / root_name):
         rel = manifest.relative_to(repo_root)
         if scope and not (
             str(rel) == scope or str(rel).startswith(f"{scope}/")
         ):
             continue
-        message = describe_violation(list(rel.parts))
-        if message is None:
-            continue
-        print(f"::error file={rel}::{message}")
-        errors.append(message)
-    return errors
+        diagnostic = describe_violation(list(rel.parts))
+        if diagnostic is not None:
+            diagnostics.append(diagnostic)
+    return diagnostics
 
 
 def main(scope: str | None = None) -> int:
@@ -125,9 +150,18 @@ def main(scope: str | None = None) -> int:
     unscoped one that CI runs. A scope is honoured anyway — it is what the
     other `validate` subcommands accept, and narrowing keeps
     `uv run validate <a-core-recipe>` from failing on an unrelated skill.
+
+    `"all"` means the same thing as no scope at all. It has to be handled
+    explicitly: `validate.py` classifies the literal string "all" as a
+    SCOPE (looks_like_scope) rather than a subcommand, so `uv run validate
+    all` reaches here as scope="all". Treating that as a path prefix made
+    every root fail the prefix test below, skip its scan, and return 0 —
+    `validate.py` then printed "[PASS] Placement validation" for a check
+    that had not run. `validate_manifest.collect_recipe_dirs` already
+    folds "all" into None the same way.
     """
-    prefix = scope.strip("/") if scope else None
-    all_errors: list[str] = []
+    prefix = None if scope in (None, "all") else scope.strip("/")
+    diagnostics: list[Diagnostic] = []
     for root_name in CHECKED_ROOTS:
         # A scope pointing outside this root (e.g. core/python/foo) means
         # there is nothing here for it to say.
@@ -142,30 +176,26 @@ def main(scope: str | None = None) -> int:
         # Pass REPO_ROOT explicitly: check_root's default argument is bound
         # at import time, so relying on it would ignore any later rebinding
         # of the module global (which is how the tests point at a fixture).
-        errors = check_root(root_name, repo_root=REPO_ROOT, scope=prefix)
-        if errors:
-            print(f"\n[FAIL] Misplaced recipes under '{root_name}/':\n")
-            for message in errors:
-                print(f"  - {message}")
-            all_errors.extend(errors)
-        else:
-            print(f"[PASS] All '{root_name}/' recipes are correctly placed.")
+        diagnostics.extend(
+            check_root(root_name, repo_root=REPO_ROOT, scope=prefix)
+        )
 
-    if not all_errors:
-        return 0
-
-    count = len(all_errors)
-    noun = "recipe" if count == 1 else "recipes"
-    print("")
-    print("=" * 60)
-    print(f"  ACTION REQUIRED: {count} misplaced {noun}")
-    print("=" * 60)
-    print("")
-    print("Move each recipe to the path shown above, then re-run:")
-    print("")
-    print("  uv run python tools/validate_placement.py")
-    print("")
-    return 1
+    return report(
+        diagnostics,
+        header="Misplaced recipes",
+        passed_message=(
+            f"Every recipe under "
+            f"{', '.join(f'{r}/' for r in CHECKED_ROOTS)} is correctly "
+            f"placed."
+        ),
+        next_step=(
+            f"{vm.AUTHORING_DOCS}\n"
+            f"\nMove each recipe to the path shown above, then re-run:\n"
+            f"  uv run validate placement\n"
+            f"\nThe layout itself is described in "
+            f"docs/recipe-handbook/anatomy.md."
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/tools/validate_readme.py
+++ b/tools/validate_readme.py
@@ -36,6 +36,7 @@ import sys
 from pathlib import Path
 
 import validate_manifest
+from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, report
 
 REPO_ROOT = validate_manifest.REPO_ROOT
 README_FILENAME = "README.md"
@@ -90,119 +91,242 @@ def _has_section(content: str, keywords: frozenset[str]) -> bool:
     return False
 
 
-def validate_readme(readme_path: Path) -> list[str]:
-    """Returns a list of error strings. Empty list means valid."""
-    errors = []
+def _keyword_list(keywords: frozenset[str]) -> str:
+    """Render a keyword set the way it should be typed into a heading."""
+    return ", ".join(sorted(kw.title() for kw in keywords))
+
+
+def validate_readme(readme_path: Path) -> list[Diagnostic]:
+    """Returns a list of diagnostics. Empty list means valid."""
+    file = validate_manifest.repo_relative(readme_path)
+    diagnostics: list[Diagnostic] = []
 
     try:
         content = readme_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        # UnicodeDecodeError is a ValueError, NOT an OSError, so the
+        # `except OSError` below never saw it: a latin-1 README used to
+        # abort the whole run with a traceback, taking every other recipe's
+        # results with it.
+        return [
+            Diagnostic(
+                check="readme-encoding",
+                what=(
+                    f"README.md is not valid UTF-8 — byte 0x"
+                    f"{e.object[e.start]:02x} at offset {e.start} "
+                    f"({e.reason})."
+                ),
+                why=(
+                    "Every file in this repo is read as UTF-8, by CI and by "
+                    "GitHub's own renderer. A README saved as latin-1 or "
+                    "cp1252 cannot be read by either."
+                ),
+                how=(
+                    "Re-save README.md as UTF-8. From the recipe "
+                    "directory:\n"
+                    "  iconv -f latin1 -t utf-8 README.md > README.utf8.md "
+                    "&& mv README.utf8.md README.md"
+                ),
+                doc=Doc.README_MISSING,
+                file=file,
+            )
+        ]
     except OSError as e:
-        errors.append(f"Cannot read README.md: {e}")
-        return errors
+        return [
+            Diagnostic(
+                check="readme-unreadable",
+                what=f"README.md could not be read: {e}.",
+                why=(
+                    "The README is a required file, so a recipe whose "
+                    "README cannot be opened cannot be validated."
+                ),
+                how=(
+                    "Check the file's permissions and that it is a regular "
+                    "file, not a broken symlink."
+                ),
+                doc=Doc.README_MISSING,
+                file=file,
+            )
+        ]
 
     if not content.strip():
-        errors.append("README.md is empty")
-        return errors
+        return [
+            Diagnostic(
+                check="readme-empty",
+                what="README.md is empty.",
+                why=(
+                    "The README is the recipe's front door: it is what a "
+                    "reader sees first and the only place the setup and run "
+                    "steps are written down."
+                ),
+                how=(
+                    "Write at least a description, a setup section, and a "
+                    "run section with the exact command in a fenced code "
+                    f"block. Minimum length is {MIN_WORD_COUNT} words."
+                ),
+                doc=Doc.README_MISSING,
+                file=file,
+            )
+        ]
 
     # No TODO: placeholders — catches unfilled scaffold or draft text.
-    if re.search(r"TODO:", content):
-        errors.append(
-            "  [description] README.md contains TODO: placeholders — "
-            "replace with real content before submitting."
+    todos = sorted({m.group(0) for m in re.finditer(r"TODO:.*", content)})
+    if todos:
+        preview = "\n".join(f"  {line[:70]}" for line in todos[:5])
+        diagnostics.append(
+            Diagnostic(
+                check="readme-todo",
+                what=(
+                    f"README.md still contains {len(todos)} TODO: "
+                    f"placeholder(s)."
+                ),
+                why=(
+                    "A TODO: line is scaffold text nobody replaced, so the "
+                    "reader is being shown an instruction meant for the "
+                    "author."
+                ),
+                how=f"Replace each of these with real content:\n{preview}",
+                doc=Doc.README_TODO,
+                file=file,
+            )
         )
 
     # Minimum word count — proxy for a real description being present.
     word_count = len(content.split())
     if word_count < MIN_WORD_COUNT:
-        errors.append(
-            f"  [description] README.md is too short ({word_count} words, "
-            f"minimum {MIN_WORD_COUNT}) — add a description, setup, and run "
-            "section."
+        diagnostics.append(
+            Diagnostic(
+                check="readme-length",
+                what=(
+                    f"README.md is {word_count} words; the minimum is "
+                    f"{MIN_WORD_COUNT}."
+                ),
+                why=(
+                    "Word count is a proxy for a real description being "
+                    "present — a README this short has never yet turned out "
+                    "to explain what the recipe does."
+                ),
+                how=(
+                    f"Add roughly {MIN_WORD_COUNT - word_count} more words: "
+                    f"what the recipe demonstrates, what it needs to run, "
+                    f"and what a successful run looks like. Aim for 200-300."
+                ),
+                doc=Doc.README_SHORT,
+                file=file,
+            )
         )
 
     # Setup section — must have a heading matching a setup keyword.
     if not _has_section(content, _SETUP_KEYWORDS):
-        errors.append(
-            "  [setup] README.md is missing a setup section — add a heading "
-            "containing one of: Setup, Prerequisites, Installation, "
-            "Requirements, Configuration, Getting Started, Before You Begin."
+        diagnostics.append(
+            Diagnostic(
+                check="readme-setup",
+                what="README.md has no setup section.",
+                why=(
+                    "No heading in the file contains any of the words that "
+                    "mark one, so a reader has nowhere to look for the "
+                    "prerequisites."
+                ),
+                how=(
+                    f"Add a heading whose text contains one of: "
+                    f"{_keyword_list(_SETUP_KEYWORDS)}."
+                ),
+                doc=Doc.README_SETUP,
+                file=file,
+            )
         )
 
     # Run section — must have a heading matching a run keyword.
     if not _has_section(content, _RUN_KEYWORDS):
-        errors.append(
-            "  [run] README.md is missing a run section — add a heading "
-            "containing one of: Run, Running, Usage, Quickstart, Start, "
-            "Deploy, How to Run."
+        diagnostics.append(
+            Diagnostic(
+                check="readme-run",
+                what="README.md has no run section.",
+                why=(
+                    "No heading in the file contains any of the words that "
+                    "mark one, so a reader cannot find how to start the "
+                    "agent."
+                ),
+                how=(
+                    f"Add a heading whose text contains one of: "
+                    f"{_keyword_list(_RUN_KEYWORDS)}."
+                ),
+                doc=Doc.README_RUN,
+                file=file,
+            )
         )
 
     # At least one fenced code block — the run command must be shown.
     if "```" not in content:
-        errors.append(
-            "  [run] README.md has no fenced code block — show the exact "
-            "command to start the agent in a ``` block."
+        diagnostics.append(
+            Diagnostic(
+                check="readme-run",
+                what="README.md has no fenced code block.",
+                why=(
+                    "The exact command to start the agent has to be "
+                    "copy-pasteable; prose describing it is not."
+                ),
+                how=(
+                    "Put the run command in a fenced block:\n"
+                    "  ```bash\n"
+                    "  uv run adk web\n"
+                    "  ```"
+                ),
+                doc=Doc.README_RUN,
+                file=file,
+            )
         )
 
-    return errors
+    return diagnostics
 
 
 def main(scope: str | None = None) -> int:
     recipe_dirs = validate_manifest.collect_recipe_dirs(scope)
+    if validate_manifest.report_empty_scope(scope, recipe_dirs):
+        return EXIT_VIOLATIONS
 
-    missing = []
-    invalid = {}
-
+    diagnostics: list[Diagnostic] = []
     for recipe_dir in recipe_dirs:
         readme_path = recipe_dir / README_FILENAME
         if not readme_path.exists():
-            missing.append(str(recipe_dir.relative_to(REPO_ROOT)))
+            diagnostics.append(
+                Diagnostic(
+                    check="readme-missing",
+                    what=f"{README_FILENAME} is missing.",
+                    why=(
+                        "README.md is required of every recipe "
+                        "(policy.required_files.always) — it is the only "
+                        "place a reader learns what the recipe does and how "
+                        "to run it."
+                    ),
+                    how=(
+                        "Add a README.md with three sections: a description "
+                        "of what the recipe demonstrates, a setup section "
+                        "(prerequisites, auth, env vars), and a run section "
+                        "with the exact command in a fenced code block. "
+                        f"Minimum length is {MIN_WORD_COUNT} words."
+                    ),
+                    doc=Doc.README_MISSING,
+                    file=validate_manifest.repo_relative(readme_path),
+                )
+            )
         else:
-            errors = validate_readme(readme_path)
-            if errors:
-                invalid[str(readme_path.relative_to(REPO_ROOT))] = errors
+            diagnostics.extend(validate_readme(readme_path))
 
-    passed = True
-
-    if missing:
-        passed = False
-        print("\n[FAIL] Missing README.md in the following recipe directories:")
-        for d in missing:
-            print(f"  - {d}/")
-            print(
-                f"::error file={d}/README.md::README.md is missing. "
-                "Add a README.md with a description, setup, and run section."
-            )
-
-    if invalid:
-        passed = False
-        print("\n[FAIL] Invalid README.md files:")
-        for path, errors in invalid.items():
-            print(f"\n  {path}:")
-            for e in errors:
-                print(f"    {e}")
-            first_error = errors[0].strip()
-            print(
-                f"::error file={path}::{first_error} (+{len(errors) - 1} more)"
-                if len(errors) > 1
-                else f"::error file={path}::{first_error}"
-            )
-
-    if not passed:
-        print(
-            "\n========================================"
-            "\n  ACTION REQUIRED: invalid README(s)"
-            "\n========================================"
-            "\n"
-            "\nFix the README.md file(s) listed above, then push again."
-            "\n"
-            "\nReference:"
-            "\n  Docs:  docs/recipe-handbook/anatomy.md"
-        )
-        return 1
-
-    checked = len(recipe_dirs)
-    print(f"\n[PASS] All {checked} recipe README(s) are present and valid.")
-    return 0
+    return report(
+        diagnostics,
+        header="README.md problems",
+        passed_message=(
+            f"All {len(recipe_dirs)} recipe README(s) are present and valid."
+        ),
+        next_step=(
+            f"{validate_manifest.AUTHORING_DOCS}\n"
+            f"\nRe-run locally:\n"
+            f"  uv run validate readme <recipe-path>\n"
+            f"\nWhat a README must contain: "
+            f"docs/recipe-handbook/anatomy.md."
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/tools/validate_readme.py
+++ b/tools/validate_readme.py
@@ -36,7 +36,7 @@ import sys
 from pathlib import Path
 
 import validate_manifest
-from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, report
+from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, guard, report
 
 REPO_ROOT = validate_manifest.REPO_ROOT
 README_FILENAME = "README.md"
@@ -343,4 +343,4 @@ if __name__ == "__main__":
         ),
     )
     args = parser.parse_args()
-    sys.exit(main(args.scope))
+    sys.exit(guard("validate_readme.py", lambda: main(args.scope)))

--- a/tools/validate_structure.py
+++ b/tools/validate_structure.py
@@ -63,7 +63,7 @@ from pathlib import Path
 
 import validate_manifest as vm
 import yaml
-from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, report
+from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, guard, report
 
 REPO_ROOT = Path(__file__).parent.parent
 POLICY_PATH = REPO_ROOT / ".github" / "policy.yml"
@@ -875,4 +875,4 @@ if __name__ == "__main__":
         ),
     )
     args = parser.parse_args()
-    sys.exit(main(args.scope))
+    sys.exit(guard("validate_structure.py", lambda: main(args.scope)))

--- a/tools/validate_structure.py
+++ b/tools/validate_structure.py
@@ -18,8 +18,8 @@ Checks performed, in order, for each recipe:
      manifest.yaml itself is NOT listed in policy.required_files; check 1
      is authoritative for it, and duplicating the rule would double-report.
   6. Required directories present — the same three-way union over
-     policy.required_dirs. Vertical skills use this for scripts/,
-     assets/, references/ and tests/unit/. An empty directory passes.
+     policy.required_dirs. Vertical skills use this for scripts/.
+     An empty directory passes.
 
 Name matching for checks 5 and 6 is done in Python rather than by asking
 the filesystem, so a case-mismatched file fails identically on macOS and
@@ -57,11 +57,13 @@ import argparse
 import fnmatch
 import re
 import sys
+from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
 
 import validate_manifest as vm
 import yaml
+from ci_message import EXIT_VIOLATIONS, Diagnostic, Doc, report
 
 REPO_ROOT = Path(__file__).parent.parent
 POLICY_PATH = REPO_ROOT / ".github" / "policy.yml"
@@ -98,45 +100,145 @@ def load_policy() -> dict:
 
 def _resolve_required(
     policy: dict, section: str, root: str, language: str | None
-) -> list[str]:
+) -> list[tuple[str, str]]:
     """Union of `always`, `by_root[root]`, and `by_language[language]`
-    from the named policy section. Missing sections and missing keys
-    degrade silently to an empty list so partial policy configs remain
-    usable (e.g. a root with no entries yet)."""
+    from the named policy section, each entry paired with the rule that
+    contributed it (`always`, `by_root.<root>`, `by_language.<language>`).
+
+    The provenance travels with the entry because it is the answer to the
+    only question the contributor actually has: not "is README.md
+    required" but "why is it required of MY recipe". Recovering it later
+    from the entry name alone is impossible — the same name can arrive
+    from more than one rule.
+
+    Missing sections and missing keys degrade silently to an empty list so
+    partial policy configs remain usable (e.g. a root with no entries yet).
+    """
     config = policy.get(section) or {}
-    entries: list[str] = []
-    entries.extend(config.get("always") or [])
-    entries.extend((config.get("by_root") or {}).get(root) or [])
+    entries: list[tuple[str, str]] = []
+    for name in config.get("always") or []:
+        entries.append((name, "always"))
+    for name in (config.get("by_root") or {}).get(root) or []:
+        entries.append((name, f"by_root.{root}"))
     if language:
-        entries.extend((config.get("by_language") or {}).get(language) or [])
+        for name in (config.get("by_language") or {}).get(language) or []:
+            entries.append((name, f"by_language.{language}"))
     # Preserve order but drop duplicates — an entry could be listed under
-    # multiple sources without meaning it's required twice.
+    # multiple sources without meaning it's required twice. The FIRST
+    # source wins, which keeps the reported rule stable as policy grows.
     seen: set[str] = set()
-    deduped: list[str] = []
-    for entry in entries:
-        if entry not in seen:
-            seen.add(entry)
-            deduped.append(entry)
+    deduped: list[tuple[str, str]] = []
+    for name, source in entries:
+        if name not in seen:
+            seen.add(name)
+            deduped.append((name, source))
     return deduped
 
 
 def required_files_for(
     policy: dict, root: str, language: str | None
-) -> list[str]:
-    """Files every recipe under this root/language must ship."""
+) -> list[tuple[str, str]]:
+    """(file, rule) pairs every recipe under this root/language must ship."""
     return _resolve_required(policy, "required_files", root, language)
 
 
 def required_dirs_for(
     policy: dict, root: str, language: str | None
-) -> list[str]:
-    """Directories every recipe under this root/language must ship.
+) -> list[tuple[str, str]]:
+    """(directory, rule) pairs every recipe under this root/language ships.
 
     Separate from required_files because the two need different existence
     tests; a `scripts` entry in required_files could never be satisfied by
     a directory.
     """
     return _resolve_required(policy, "required_dirs", root, language)
+
+
+def _provenance(
+    section: str, source: str, root: str, language: str | None
+) -> str:
+    """Why THIS recipe has to ship the entry, naming the policy key."""
+    rule = f"policy.{section}.{source}"
+    if source.startswith("by_language."):
+        return f"Required because manifest.language is '{language}' ({rule})."
+    if source.startswith("by_root."):
+        return f"Required for every recipe under {root}/ ({rule})."
+    return f"Required for every recipe in the repository ({rule})."
+
+
+# Concrete fixes, keyed by required entry. A message that says a file is
+# missing and stops there leaves the contributor to discover that a
+# generator exists at all — which is the difference between a two-minute
+# fix and an afternoon of hand-writing a lockfile.
+_FILE_REMEDIATION: dict[str, str] = {
+    "manifest.yaml": "Run the `generate-manifest` AI skill.",
+    ".env.example": (
+        "Run the `extract-python-environment-variables` AI skill — it "
+        "finds every os.environ/os.getenv read in the recipe and writes "
+        "the file for you."
+    ),
+    "tests/test_runnability.py": (
+        "Run the `generate-python-runnability-test` AI skill — it writes "
+        "the import-and-assert-root_agent smoke test."
+    ),
+    "pyproject.toml": (
+        "Run the `align-recipe-pyproject` AI skill — it writes a "
+        "pyproject.toml that already satisfies the repo's checks."
+    ),
+    "README.md": (
+        "Add a README.md covering three things: what the recipe does, how "
+        "to set it up, and the exact command to run it (in a fenced code "
+        "block)."
+    ),
+    "AGENTS.md": (
+        "Add an AGENTS.md holding the maintainer-facing context an AI "
+        "coding assistant needs: layout, conventions, and how to test."
+    ),
+    "SKILL.md": (
+        "Add a SKILL.md — the conversational installer for a vertical "
+        "skill: it runs the interview, writes the design spec, and "
+        "performs setup."
+    ),
+    "EVAL.yaml": (
+        "Add an EVAL.yaml holding the eval rubrics that prove the skill "
+        "performs — see docs/recipe-handbook/anatomy.md."
+    ),
+    "go.mod": (
+        "Every Go recipe is its own module: run `go mod init` in the "
+        "recipe directory."
+    ),
+}
+
+
+def _file_remediation(rel: str, recipe_rel: str) -> str:
+    """The fix for one missing required file."""
+    if rel == "uv.lock":
+        # Needs the recipe path, so it cannot live in the static table.
+        return f"cd {recipe_rel} && uv lock"
+    return _FILE_REMEDIATION.get(
+        rel,
+        (
+            f"Add {rel} to the recipe. There is no generator for this one — "
+            f"docs/recipe-checklist.md lists what it has to contain."
+        ),
+    )
+
+
+def _dir_remediation(rel: str, recipe_rel: str) -> str:
+    """The fix for a missing required directory.
+
+    Always leads with the git detail: the overwhelmingly common report is
+    "the folder is right there in my editor". It is, locally — git simply
+    never committed it, because git tracks files and an empty directory
+    has none.
+    """
+    return (
+        f"git cannot commit an empty directory, so a folder with nothing "
+        f"in it never reaches CI. Add a placeholder and commit it:\n"
+        f"  touch {recipe_rel}/{rel}/.gitkeep && "
+        f"git add {recipe_rel}/{rel}/.gitkeep\n"
+        f"If the directory should have content, add the content instead."
+    )
 
 
 def case_insensitive_entries(policy: dict) -> set[str]:
@@ -203,28 +305,64 @@ def is_large_recipe(manifest_path: Path) -> bool:
 
 
 # ===========================================================================
-# Individual checks (each returns list[str]; empty list means pass)
+# Individual checks (each returns list[Diagnostic]; empty list means pass)
 # ===========================================================================
 
 
-def check_folder_name(recipe_dir: Path, max_length: int) -> list[str]:
+def _suggest_folder_name(name: str) -> str:
+    """A legal name close to the one the author tried to use."""
+    cleaned = re.sub(r"[^a-z-]+", "-", name.lower()).strip("-")
+    return re.sub(r"-{2,}", "-", cleaned) or "my-recipe"
+
+
+def check_folder_name(recipe_dir: Path, max_length: int) -> list[Diagnostic]:
     """Folder basename must match ^[a-z][a-z-]*$ and stay within the
     length limit. Two independent violations are reported independently
     so the maintainer sees both in one CI run."""
     name = recipe_dir.name
-    errors: list[str] = []
+    rel = vm.repo_relative(recipe_dir, REPO_ROOT)
+    parent = str(Path(rel).parent)
+    diagnostics: list[Diagnostic] = []
     if not _FOLDER_NAME_RE.match(name):
-        errors.append(
-            f"Folder name '{name}' is invalid. Only lowercase letters and "
-            "hyphens are allowed (must start with a letter; no underscores, "
-            "digits, or uppercase)."
+        suggestion = _suggest_folder_name(name)
+        diagnostics.append(
+            Diagnostic(
+                check="folder-name",
+                what=f"Folder name '{name}' is invalid.",
+                why=(
+                    "Recipe folder names must match ^[a-z][a-z-]*$ — "
+                    "lowercase letters and hyphens only, starting with a "
+                    "letter. The name is used verbatim in URLs, package "
+                    "names and shell commands, where underscores, digits "
+                    "and capitals all behave differently across platforms."
+                ),
+                how=f"git mv {rel} {parent}/{suggestion}",
+                doc=Doc.FOLDER_NAME,
+                file=rel,
+            )
         )
     if len(name) > max_length:
-        errors.append(
-            f"Folder name '{name}' is {len(name)} characters long; the "
-            f"maximum allowed is {max_length}."
+        diagnostics.append(
+            Diagnostic(
+                check="folder-name",
+                what=(
+                    f"Folder name '{name}' is {len(name)} characters; the "
+                    f"maximum is {max_length}."
+                ),
+                why=(
+                    f"policy.recipe_naming.max_folder_name_length is "
+                    f"{max_length}, so the path stays readable in CI logs "
+                    f"and short enough for every filesystem in play."
+                ),
+                how=(
+                    f"Rename the folder to at most {max_length} characters, "
+                    f"e.g. git mv {rel} {parent}/{name[:max_length]}"
+                ),
+                doc=Doc.FOLDER_NAME,
+                file=rel,
+            )
         )
-    return errors
+    return diagnostics
 
 
 def _iter_excluded_dirs_files(policy: dict) -> tuple[set[str], set[str]]:
@@ -276,13 +414,52 @@ def _walk_counted_files(recipe_dir: Path, policy: dict) -> list[Path]:
     return counted
 
 
+def _fmt_bytes(count: int) -> str:
+    if count >= 1024 * 1024:
+        return f"{count / (1024 * 1024):.1f} MB"
+    if count >= 1024:
+        return f"{count // 1024} KB"
+    return f"{count} B"
+
+
+def _worst_contributors(
+    items: Iterable[tuple[str, int]], overage: int, limit: int = 5
+) -> list[tuple[str, int]]:
+    """The biggest contributors, cut off once removing them clears the
+    overage.
+
+    Always padding the list out to `limit` puts a 60 MB blob next to a
+    7-byte README, which makes the culprit harder to spot, not easier.
+    The truncated list is also a promise: delete exactly these and the
+    check passes.
+    """
+    picked: list[tuple[str, int]] = []
+    for name, weight in sorted(items, key=lambda kv: -kv[1])[:limit]:
+        picked.append((name, weight))
+        overage -= weight
+        if overage <= 0:
+            break
+    return picked
+
+
+def _describe_tier(tier_limits: dict | None) -> str:
+    if not isinstance(tier_limits, dict):
+        return "not defined for this root"
+    return (
+        f"max_files={tier_limits.get('max_files')}, "
+        f"max_size_mb={tier_limits.get('max_size_mb')}"
+    )
+
+
 def check_size_and_count(
     recipe_dir: Path, root: str, policy: dict, manifest_path: Path
-) -> list[str]:
+) -> list[Diagnostic]:
     """Enforce the size (MB) and file-count tiers from policy.yml.
     Tier is chosen by `root` (core vs contrib) then by manifest.large.
     Recipes under roots not covered by recipe_size_limits (e.g. a
     future 'skills' root without limits) skip these checks."""
+    rel = vm.repo_relative(recipe_dir, REPO_ROOT)
+    manifest_rel = vm.repo_relative(manifest_path, REPO_ROOT)
     limits_by_root = policy.get("recipe_size_limits") or {}
     root_limits = limits_by_root.get(root)
     if not isinstance(root_limits, dict):
@@ -296,16 +473,31 @@ def check_size_and_count(
     # Fail loudly when `large: true` is set but the requested tier is not
     # defined for this root. Previously the code silently fell back to
     # `default` via a boolean chain, so the recipe author got no signal
-    # that their opt-in was being ignored. Either add a `large:` block
-    # under `recipe_size_limits.<root>` in policy.yml or drop `large:
-    # true` from the manifest — the current combination is a bug.
+    # that their opt-in was being ignored.
     if tier_limits is None:
         if tier != "default":
             return [
-                f"manifest.large=true, but recipe_size_limits.{root} in "
-                ".github/policy.yml does not define a 'large' tier. Add a "
-                f"'{root}.large' block in policy.yml with max_files / "
-                "max_size_mb, or remove 'large: true' from the manifest."
+                Diagnostic(
+                    check="size",
+                    what=(
+                        f"manifest.large is true, but .github/policy.yml "
+                        f"defines no 'large' size tier for {root}/."
+                    ),
+                    why=(
+                        f"recipe_size_limits.{root} defines only: "
+                        f"{', '.join(sorted(root_limits)) or '(nothing)'}. "
+                        f"The opt-in would be silently ignored, so it is "
+                        f"reported instead of quietly falling back."
+                    ),
+                    how=(
+                        f"Remove `large: true` from {vm.MANIFEST_FILENAME} "
+                        f"and stay within the default tier, or ask a "
+                        f"maintainer to add a `{root}.large` block "
+                        f"(max_files / max_size_mb) to .github/policy.yml."
+                    ),
+                    doc=Doc.SIZE_LIMIT,
+                    file=manifest_rel,
+                )
             ]
         # No `default` tier and no `large` tier requested — nothing to
         # enforce, matches the no-root-limits case.
@@ -314,26 +506,111 @@ def check_size_and_count(
     max_files = tier_limits.get("max_files")
     max_size_mb = tier_limits.get("max_size_mb")
 
-    counted = _walk_counted_files(recipe_dir, policy)
+    counted = [
+        p for p in _walk_counted_files(recipe_dir, policy) if p.is_file()
+    ]
+    sizes = {p: p.stat().st_size for p in counted}
+    total_bytes = sum(sizes.values())
     file_count = len(counted)
-    total_bytes = sum(p.stat().st_size for p in counted if p.is_file())
-    total_kb = total_bytes // 1024
 
-    errors: list[str] = []
+    # The walk above already knows every offending path and its size.
+    # Reporting only the total made the contributor re-derive that with
+    # `du -a | sort -n`, on a tree whose exclusions they cannot see.
+    tier_note = (
+        f"The {root}/{tier} tier applies: the recipe is under {root}/ and "
+        f"its manifest {'sets' if is_large else 'does not set'} "
+        f"`large: true`"
+    )
+    escape_hatch = (
+        "This recipe is already on the relaxed `large: true` tier — there "
+        "is no higher one, so the content itself has to come down."
+        if is_large
+        else (
+            f"If the recipe genuinely needs the room, set `large: true` in "
+            f"{vm.MANIFEST_FILENAME} to opt into the relaxed tier "
+            f"({_describe_tier(root_limits.get('large'))})."
+        )
+    )
+    excluded_note = (
+        "Paths listed under policy.excluded_paths (.venv/, __pycache__/, "
+        "uv.lock, build output …) are not counted."
+    )
+
+    diagnostics: list[Diagnostic] = []
     if max_size_mb is not None:
         max_bytes = int(max_size_mb) * 1024 * 1024
         if total_bytes > max_bytes:
-            errors.append(
-                f"Recipe folder exceeds {max_size_mb} MB "
-                f"({total_kb} KB, excluding paths listed in "
-                ".github/policy.yml). Remove large files or binaries."
+            listing = "\n".join(
+                f"  {_fmt_bytes(size):>9}  {name}"
+                for name, size in _worst_contributors(
+                    (
+                        (str(path.relative_to(recipe_dir)), size)
+                        for path, size in sizes.items()
+                    ),
+                    total_bytes - max_bytes,
+                )
+            )
+            diagnostics.append(
+                Diagnostic(
+                    check="size",
+                    what=(
+                        f"Recipe folder is {_fmt_bytes(total_bytes)}; the "
+                        f"limit is {max_size_mb} MB."
+                    ),
+                    why=(
+                        f"{tier_note} "
+                        f"(policy.recipe_size_limits.{root}.{tier}"
+                        f".max_size_mb = {max_size_mb}). {excluded_note}"
+                    ),
+                    how=(
+                        f"Largest counted files:\n{listing}\n"
+                        f"Move data and media out to a storage bucket and "
+                        f"link them from README.md, or delete generated "
+                        f"output that should not be committed.\n"
+                        f"{escape_hatch}"
+                    ),
+                    doc=Doc.SIZE_LIMIT,
+                    file=rel,
+                )
             )
     if max_files is not None and file_count > int(max_files):
-        errors.append(
-            f"Recipe folder contains {file_count} files, exceeding the "
-            f"limit of {max_files}."
+        # Directories, not individual filenames: when a recipe is 400 files
+        # over the limit, five arbitrary paths say nothing, while the
+        # directory holding 380 of them says everything.
+        per_dir = Counter(
+            str(path.parent.relative_to(recipe_dir)) for path in counted
         )
-    return errors
+        listing = "\n".join(
+            f"  {n:>5} file{'s' if n != 1 else ''}  "
+            f"{name if name != '.' else '(recipe root)'}"
+            for name, n in _worst_contributors(
+                per_dir.items(), file_count - int(max_files)
+            )
+        )
+        diagnostics.append(
+            Diagnostic(
+                check="size",
+                what=(
+                    f"Recipe folder contains {file_count} counted files; "
+                    f"the limit is {max_files}."
+                ),
+                why=(
+                    f"{tier_note} "
+                    f"(policy.recipe_size_limits.{root}.{tier}.max_files = "
+                    f"{max_files}). {excluded_note}"
+                ),
+                how=(
+                    f"Directories contributing the most files:\n{listing}\n"
+                    f"Delete generated output, or add the directory that "
+                    f"holds it to policy.excluded_paths if it is tool "
+                    f"output that every recipe produces.\n"
+                    f"{escape_hatch}"
+                ),
+                doc=Doc.SIZE_LIMIT,
+                file=rel,
+            )
+        )
+    return diagnostics
 
 
 def _find_entry(
@@ -381,52 +658,100 @@ def _note_inexact(rel: str, found: Path) -> None:
 
 def check_required_files(
     recipe_dir: Path, root: str, language: str | None, policy: dict
-) -> list[str]:
+) -> list[Diagnostic]:
     """Every path in the union list must exist as a file (not a dir).
     Paths are recipe-relative and may include subdirectories
     (e.g. tests/test_runnability.py)."""
-    required = required_files_for(policy, root, language)
+    recipe_rel = vm.repo_relative(recipe_dir, REPO_ROOT)
     lenient = case_insensitive_entries(policy)
-    errors: list[str] = []
-    for rel in required:
+    diagnostics: list[Diagnostic] = []
+    for rel, source in required_files_for(policy, root, language):
         found, exact = _find_entry(
             recipe_dir, rel, case_insensitive=rel in lenient
         )
+        why = _provenance("required_files", source, root, language)
+        fix = _file_remediation(rel, recipe_rel)
         if found is None:
-            errors.append(f"Required file '{rel}' is missing.")
+            diagnostics.append(
+                Diagnostic(
+                    check="required-files",
+                    what=f"Required file '{rel}' is missing.",
+                    why=why,
+                    how=fix,
+                    doc=Doc.REQUIRED_FILES,
+                    file=f"{recipe_rel}/{rel}",
+                )
+            )
         elif not found.is_file():
-            errors.append(f"Required file '{rel}' exists but is not a file.")
+            diagnostics.append(
+                Diagnostic(
+                    check="required-files",
+                    what=(
+                        f"Required file '{rel}' exists but is a "
+                        f"{'directory' if found.is_dir() else 'non-file'}."
+                    ),
+                    why=why,
+                    how=(
+                        f"Remove or rename {recipe_rel}/{rel}, then add the "
+                        f"file.\n{fix}"
+                    ),
+                    doc=Doc.REQUIRED_FILES,
+                    file=f"{recipe_rel}/{rel}",
+                )
+            )
         elif not exact:
             _note_inexact(rel, found)
-    return errors
+    return diagnostics
 
 
 def check_required_dirs(
     recipe_dir: Path, root: str, language: str | None, policy: dict
-) -> list[str]:
+) -> list[Diagnostic]:
     """Every path in the union list must exist as a directory.
 
-    An empty directory passes: some required folders (assets/,
-    references/) legitimately have nothing in them for a given recipe,
-    and git cannot commit an empty directory anyway, so in practice they
-    carry a .gitkeep.
+    An empty directory passes: some required folders legitimately have
+    nothing in them for a given recipe, and git cannot commit an empty
+    directory anyway, so in practice they carry a .gitkeep.
     """
-    required = required_dirs_for(policy, root, language)
+    recipe_rel = vm.repo_relative(recipe_dir, REPO_ROOT)
     lenient = case_insensitive_entries(policy)
-    errors: list[str] = []
-    for rel in required:
+    diagnostics: list[Diagnostic] = []
+    for rel, source in required_dirs_for(policy, root, language):
         found, exact = _find_entry(
             recipe_dir, rel, case_insensitive=rel in lenient
         )
+        why = _provenance("required_dirs", source, root, language)
         if found is None:
-            errors.append(f"Required directory '{rel}/' is missing.")
+            diagnostics.append(
+                Diagnostic(
+                    check="required-dirs",
+                    what=f"Required directory '{rel}/' is missing.",
+                    why=why,
+                    how=_dir_remediation(rel, recipe_rel),
+                    doc=Doc.REQUIRED_FILES,
+                    file=f"{recipe_rel}/{rel}",
+                )
+            )
         elif not found.is_dir():
             # Reporting this as "missing" would send the author hunting
             # for something that is right there under the wrong kind.
-            errors.append(f"Required directory '{rel}/' exists but is a file.")
+            diagnostics.append(
+                Diagnostic(
+                    check="required-dirs",
+                    what=f"Required directory '{rel}/' exists but is a file.",
+                    why=why,
+                    how=(
+                        f"Rename or delete the file at {recipe_rel}/{rel}, "
+                        f"then create a directory in its place:\n"
+                        f"  mkdir -p {recipe_rel}/{rel}"
+                    ),
+                    doc=Doc.REQUIRED_FILES,
+                    file=f"{recipe_rel}/{rel}",
+                )
+            )
         elif not exact:
             _note_inexact(rel, found)
-    return errors
+    return diagnostics
 
 
 # ===========================================================================
@@ -434,24 +759,41 @@ def check_required_dirs(
 # ===========================================================================
 
 
-def validate_recipe(recipe_dir: Path, policy: dict, schema: dict) -> list[str]:
+def validate_recipe(
+    recipe_dir: Path, policy: dict, schema: dict
+) -> list[Diagnostic]:
     """Run every applicable check on one recipe. Returns the list of
-    error strings (empty list means everything passed). Errors are
-    prefixed with the check name so the CI output stays parseable."""
-    errors: list[str] = []
+    diagnostics (empty list means everything passed)."""
+    diagnostics: list[Diagnostic] = []
+    rel = vm.repo_relative(recipe_dir, REPO_ROOT)
 
     root = recipe_root_of(recipe_dir)
     if root is None or root not in RECIPE_ROOTS:
+        roots = ", ".join(f"{r}/" for r in RECIPE_ROOTS)
         return [
-            f"Recipe path must live under one of {RECIPE_ROOTS}; "
-            f"got '{recipe_dir}'."
+            Diagnostic(
+                check="placement",
+                what=f"'{rel}' is not inside a recipe root.",
+                why=(
+                    f"Recipes are only collected from {roots}, so a "
+                    f"directory anywhere else is never validated, indexed "
+                    f"or published — it would look fine and reach nobody."
+                ),
+                how=(
+                    "Move it under one of them: core/ for curated recipes, "
+                    "contrib/ for community ones, "
+                    "skills/<vertical>/<solution> for a vertical skill."
+                ),
+                doc=Doc.PLACEMENT,
+                file=rel,
+            )
         ]
 
     # Check 1: manifest.yaml presence.
     manifest_path = recipe_dir / vm.MANIFEST_FILENAME
     manifest_present = manifest_path.is_file()
     if not manifest_present:
-        errors.append(f"[manifest] {vm.MANIFEST_FILENAME} is missing.")
+        diagnostics.append(vm.missing_manifest_diagnostic(manifest_path))
         # Continue with the checks that don't need the manifest —
         # folder-name and (best-effort) size — so the maintainer sees
         # every problem in one shot rather than fix-and-retry chains.
@@ -459,18 +801,17 @@ def validate_recipe(recipe_dir: Path, policy: dict, schema: dict) -> list[str]:
     # Check 2: manifest.yaml schema (only if the file exists — a missing
     # manifest is already reported by check 1).
     if manifest_present:
-        for err in vm.validate_manifest(manifest_path, schema):
-            errors.append(f"[manifest] {err.strip()}")
+        diagnostics.extend(vm.validate_manifest(manifest_path, schema))
 
     # Check 3: folder name.
     naming = policy.get("recipe_naming") or {}
     max_length = int(naming.get("max_folder_name_length", 30))
-    for err in check_folder_name(recipe_dir, max_length):
-        errors.append(f"[folder-name] {err}")
+    diagnostics.extend(check_folder_name(recipe_dir, max_length))
 
     # Check 4: folder size + file count.
-    for err in check_size_and_count(recipe_dir, root, policy, manifest_path):
-        errors.append(f"[size] {err}")
+    diagnostics.extend(
+        check_size_and_count(recipe_dir, root, policy, manifest_path)
+    )
 
     # Check 5: required files (union of always + by_root + by_language).
     # Language detection is intentionally decoupled from schema validation:
@@ -478,16 +819,13 @@ def validate_recipe(recipe_dir: Path, policy: dict, schema: dict) -> list[str]:
     # here we simply use whatever the manifest declares (or None) so this
     # check still runs even if the manifest has unrelated schema issues.
     language = detect_language(manifest_path) if manifest_present else None
-    for err in check_required_files(recipe_dir, root, language, policy):
-        errors.append(f"[required-files] {err}")
+    diagnostics.extend(check_required_files(recipe_dir, root, language, policy))
 
     # Check 6: required directories. Same union, different existence test —
-    # a vertical skill must ship scripts/, assets/, references/ and
-    # tests/unit/, none of which required_files could express.
-    for err in check_required_dirs(recipe_dir, root, language, policy):
-        errors.append(f"[required-dirs] {err}")
+    # a `scripts` entry under required_files could never be satisfied.
+    diagnostics.extend(check_required_dirs(recipe_dir, root, language, policy))
 
-    return errors
+    return diagnostics
 
 
 # ===========================================================================
@@ -499,42 +837,28 @@ def main(scope: str | None = None) -> int:
     policy = load_policy()
     schema = vm.load_schema()
     recipe_dirs = vm.collect_recipe_dirs(scope)
+    if vm.report_empty_scope(scope, recipe_dirs):
+        return EXIT_VIOLATIONS
 
-    failed: dict[str, list[str]] = {}
+    diagnostics: list[Diagnostic] = []
     for recipe_dir in recipe_dirs:
-        errors = validate_recipe(recipe_dir, policy, schema)
-        if errors:
-            failed[str(recipe_dir.relative_to(REPO_ROOT))] = errors
+        diagnostics.extend(validate_recipe(recipe_dir, policy, schema))
 
-    if failed:
-        print("\n[FAIL] Recipes with structural problems:")
-        for rel, errors in failed.items():
-            print(f"\n  {rel}/:")
-            for e in errors:
-                print(f"    - {e}")
-            # One GitHub annotation per recipe, pointing at the recipe root.
-            first = errors[0]
-            extra = f" (+{len(errors) - 1} more)" if len(errors) > 1 else ""
-            print(f"::error file={rel}::{first}{extra}")
-
-        print(
-            "\n========================================"
-            "\n  ACTION REQUIRED: recipe structure invalid"
-            "\n========================================"
-            "\n"
-            "\nFix the issue(s) listed above, then push again."
-            "\n"
-            "\nReference:"
-            "\n  Policy:  .github/policy.yml (required_files, "
-            "recipe_size_limits, recipe_naming)"
-            "\n  Schema:  .github/schemas/manifest-schema.json"
-        )
-        return 1
-
-    print(
-        f"\n[PASS] All {len(recipe_dirs)} recipe(s) passed structural checks."
+    return report(
+        diagnostics,
+        header="Recipes with structural problems",
+        passed_message=(
+            f"All {len(recipe_dirs)} recipe(s) passed structural checks."
+        ),
+        next_step=(
+            f"{vm.AUTHORING_DOCS}\n"
+            f"\nRe-run locally:\n"
+            f"  uv run validate structure <recipe-path>\n"
+            f"\nThe rules themselves live in .github/policy.yml "
+            f"(required_files, required_dirs, recipe_size_limits, "
+            f"recipe_naming)."
+        ),
     )
-    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

CI could tell a contributor *what* was wrong, but not *why the rule applied* or *how to fix it* — and when one of our own checkers crashed, it blamed the contributor for it. This introduces one shared way to report a failure and routes every check through it.

**`tools/ci_message.py`** — a `Diagnostic` type whose constructor refuses to build a message that doesn't answer four questions: `what` (naming the exact file/field/value), `why` (which rule fired and why it applies to *this* recipe), `how` (a command to run or the exact text to add), and `doc` (an anchor into the troubleshooting handbook). Two renderers share one Diagnostic: a multi-line block for the job log, and a `::error` annotation for the Files tab with newlines preserved via `%0A`.

The acid test each message has to pass: *could a contributor who has never opened `policy.yml` fix this in one attempt, without asking anyone?*

## Contributor fault vs CI fault

`Diagnostic` is for things a contributor can fix. When our own tooling breaks, `InfraFault` says so plainly and — critically — carries no `file`, so it never paints a red marker on someone's source for our bug.

This is now enforced by a three-value exit code contract (`0` pass / `1` contributor-fixable / `2` CI fault) that every checker and every call site honours:

- `ci_message.guard()` wraps each entrypoint, so an unhandled exception becomes exit 2 instead of a bare traceback. This replaces three copies of hand-rolled `try/except` boilerplate.
- `tools/validate.py` had two live bugs here. `run_all()` did `return 0 if all_passed else 1`, flattening a crash into "your recipe is invalid". And because `pyproject.toml` binds `validate = "validate:main"`, a guard on the `__main__` block would never have fired for `uv run validate structure` — which is exactly how CI invokes it.
- `validate-recipe-structure.yml` collapsed both cases into `|| FAILED=1`, printing *"ACTION REQUIRED: here is how to fix your recipe"* underneath a traceback nobody can act on. It now branches on `0/1/2/undefined`, as the sibling workflows already did.

## Less ceremony

`assets/`, `references/` and `tests/unit/` are no longer required directories. An empty directory passed the check, so the rule enforced nothing — but git can't commit an empty directory, so authors added a `.gitkeep` purely to satisfy a check that already said it didn't care what was inside. They remain the convention and the scaffold still creates them; prompting an author to fill a folder is the scaffold's job, not CI's.

## Tests

452 passing. Beyond per-check coverage, three properties are asserted as regression guards:

- no checker hand-builds a `::error` string instead of going through `Diagnostic`
- no entrypoint exits without a crash guard
- every `Doc` enum member resolves to a real heading in `troubleshooting.md`, so a link can't 404 onto a contributor's screen

The exit-code and crash-containment tests were mutation-tested — reverting each fix fails the test that covers it.

## Not covered

The shell changes in `validate-recipe-structure.yml` aren't unit-testable; `shellcheck` is clean at warning level and the `case` arms were verified by hand. Real coverage there would need `act` or a workflow-level integration test.