### PR TITLE
Editable documents in the side panel

### DIFF
--- a/core/python/long-horizon-harness/horizon/a2a/datapart.py
+++ b/core/python/long-horizon-harness/horizon/a2a/datapart.py
@@ -33,6 +33,72 @@ import json
 A2A_DATA_PART_START_TAG = b"<a2a_datapart_json>"
 A2A_DATA_PART_END_TAG = b"</a2a_datapart_json>"
 
+# Discriminator the web client stamps on a highlighted-selection payload.
+# Mirrors SELECTION_DATA_KIND in web/components/chat/workspace-href.ts.
+_SELECTION_KIND = "lha.selection"
+
+# Discriminator for files dragged from the workspace tree into the composer.
+# Mirrors FILEREF_DATA_KIND in web/components/chat/workspace-href.ts.
+_FILEREF_KIND = "lha.fileref"
+
+
+def _render_fileref(payload: dict) -> str | None:
+    """Prose for workspace files the user attached from the tree.
+
+    Only paths travel: the files are already in the workspace, so re-sending
+    their bytes would duplicate them. Says what was pointed at, not what to do
+    with it — the user's own message carries the instruction.
+    """
+    paths = payload.get("paths")
+    if not isinstance(paths, list) or not paths:
+        return None
+    clean = [p for p in paths if isinstance(p, str) and p]
+    if len(clean) != len(paths):
+        return None
+    listed = "\n".join(f"- {p}" for p in clean)
+    noun = "file" if len(clean) == 1 else "files"
+    return (
+        f"[The user attached {len(clean)} workspace {noun} to this message. "
+        "Read them if the request concerns them:]\n"
+        f"{listed}"
+    )
+
+
+def _render_selection(payload: dict) -> str | None:
+    """Prose for a text selection the user highlighted in the web UI.
+
+    Hands over character offsets rather than asking the model to locate the
+    text: the same words may appear many times in a file, and a search anchor
+    cannot tell which one was pointed at. Deliberately states what was
+    selected, not what to do with it — the user's own message carries the
+    instruction.
+    """
+    path = payload.get("path")
+    snippet = payload.get("snippet")
+    start = payload.get("start")
+    end = payload.get("end")
+    if not isinstance(path, str) or not isinstance(snippet, str):
+        return None
+    if not isinstance(start, int) or not isinstance(end, int):
+        return None
+    start_line = payload.get("start_line")
+    end_line = payload.get("end_line")
+    where = path
+    if isinstance(start_line, int) and isinstance(end_line, int):
+        where += (
+            f", line {start_line}"
+            if start_line == end_line
+            else f", lines {start_line}-{end_line}"
+        )
+    return (
+        f"[The user highlighted this exact text in {where}:]\n"
+        f"{snippet}\n"
+        f"[It spans characters {start}-{end}. To act on exactly that span, "
+        f"call patch with start={start}, end={end}, and old_string set to the "
+        "highlighted text above — do not search for the text, as it may occur "
+        "elsewhere in the file.]"
+    )
+
 
 def unwrap_a2a_datapart_text(data: bytes | None) -> str | None:
     """Return readable text for a wrapped DataPart blob, else ``None``.
@@ -50,6 +116,15 @@ def unwrap_a2a_datapart_text(data: bytes | None) -> str | None:
     except (ValueError, UnicodeDecodeError):
         return None
     payload = obj.get("data", obj) if isinstance(obj, dict) else obj
+    if isinstance(payload, dict):
+        kind = payload.get("lha_kind")
+        rendered = None
+        if kind == _SELECTION_KIND:
+            rendered = _render_selection(payload)
+        elif kind == _FILEREF_KIND:
+            rendered = _render_fileref(payload)
+        if rendered is not None:
+            return rendered
     return "[UI action] " + json.dumps(payload, ensure_ascii=False)
 
 

--- a/core/python/long-horizon-harness/horizon/api/uploads.py
+++ b/core/python/long-horizon-harness/horizon/api/uploads.py
@@ -21,6 +21,7 @@ Routes mounted under ``/lha``:
   POST   /lha/workspace/folder    — create a top-level workspace folder (project)
   GET    /lha/workspace/tree      — list a directory within the workspace
   GET    /lha/workspace/download  — stream a file back, or a zip if path is a dir
+  PUT    /lha/workspace/file      — overwrite an existing text file's contents
   DELETE /lha/workspace/file      — unlink a file, or ``rmtree`` if ``recursive=true``
 
 All routes run outside an agent turn, so they resolve the user's
@@ -58,10 +59,14 @@ from pydantic import BaseModel
 from horizon.auth import current_user_id
 from horizon.conversation import session_start
 from horizon.environment import Environment
+from horizon.tools.file_ops import _has_binary_extension, _is_write_denied
 
 logger = logging.getLogger(__name__)
 
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+# Browser-side editing is for prose/code, not blobs. Anything larger is a
+# download-and-edit-locally case, not a textarea case.
+MAX_EDIT_BYTES = 2 * 1024 * 1024
 MAX_FILENAME_LEN = 255
 MAX_TREE_ENTRIES = 500
 WORKSPACE_ROOT = "/workspace"
@@ -313,6 +318,10 @@ class NewFolderBody(BaseModel):
     name: str
 
 
+class WriteFileBody(BaseModel):
+    content: str
+
+
 def attach_uploads_routes(app: FastAPI) -> None:
     """Mount ``POST /lha/uploads``, ``POST /lha/workspace/folder``, and
     ``GET /lha/workspace/tree``.
@@ -481,6 +490,66 @@ def attach_uploads_routes(app: FastAPI) -> None:
             media_type="application/octet-stream",
             headers={"Content-Disposition": _disposition(target.name)},
         )
+
+    @router.put("/workspace/file")
+    async def workspace_write(
+        body: WriteFileBody,
+        path: Annotated[str, Query(...)],
+        user_id: Annotated[str, Depends(current_user_id)],
+    ) -> dict[str, Any]:
+        """Overwrite an existing workspace text file from the browser editor.
+
+        Edit-only by design: creation stays on ``POST /lha/uploads`` so this
+        route can't be used to drop new files anywhere under the workspace.
+        Mirrors the agent's own write guards (``_is_write_denied`` protected
+        paths, binary-extension reject) so the UI can't route around them.
+        """
+        data = body.content.encode("utf-8")
+        if len(data) > MAX_EDIT_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"content exceeds {MAX_EDIT_BYTES} bytes",
+            )
+
+        env = await session_start._ensure_environment(user_id)
+        target = _resolve_workspace_path(env, path)
+
+        if _is_write_denied(str(target)):
+            raise HTTPException(
+                status_code=403,
+                detail=f"{path} is on the protected paths list",
+            )
+        if _has_binary_extension(str(target)):
+            raise HTTPException(
+                status_code=415, detail=f"{path} is not a text file"
+            )
+
+        # Existence probe doubles as the is-a-directory guard: env.read_file
+        # raises IsADirectoryError before we clobber anything.
+        try:
+            await env.read_file(target)
+        except FileNotFoundError as err:
+            raise HTTPException(
+                status_code=404, detail=f"{path} not found"
+            ) from err
+        except IsADirectoryError as err:
+            raise HTTPException(
+                status_code=400, detail=f"{path} is a directory"
+            ) from err
+        except OSError as err:
+            raise HTTPException(
+                status_code=500, detail=f"failed to read {path}: {err}"
+            ) from err
+
+        try:
+            await env.write_file(target, data)
+        except OSError as err:
+            logger.warning("workspace write failed for %s: %s", target, err)
+            raise HTTPException(
+                status_code=500, detail=f"write failed: {err}"
+            ) from err
+
+        return {"path": _to_workspace_path(env, target), "size": len(data)}
 
     @router.delete("/workspace/file", status_code=204)
     async def workspace_delete(

--- a/core/python/long-horizon-harness/horizon/tools/file_ops.py
+++ b/core/python/long-horizon-harness/horizon/tools/file_ops.py
@@ -480,12 +480,55 @@ async def _post_edit_diagnostics(path: str) -> str | None:
     return "ruff diagnostics (informational — the edit was applied):\n" + body
 
 
+def _replace_range(
+    original: str,
+    start: int | None,
+    end: int | None,
+    expected: str,
+    new_string: str,
+) -> tuple[str, int, str | None]:
+    """Splice ``new_string`` over ``original[start:end]``.
+
+    Position identifies the span, so repeated content is not ambiguous the way
+    a search anchor is. ``expected`` is a guard, not a search key: the caller
+    computed these offsets against some version of the file, and if that
+    version is gone the offsets point somewhere arbitrary. Refusing beats
+    silently editing the wrong text.
+
+    Returns ``(updated, replacements, error)``; ``error`` non-None means the
+    file must be left untouched.
+    """
+    if start is None or end is None:
+        return original, 0, "start and end must be given together"
+    if start < 0 or end < start:
+        return original, 0, f"invalid range: start={start}, end={end}"
+    if end > len(original):
+        return (
+            original,
+            0,
+            f"range end={end} is past the end of the file ({len(original)} "
+            "characters) — re-read the file and retry",
+        )
+    found = original[start:end]
+    if found != expected:
+        return (
+            original,
+            0,
+            "the text at that range has changed since those offsets were "
+            f"taken (expected {expected!r}, found {found!r}) — re-read the "
+            "file and retry",
+        )
+    return original[:start] + new_string + original[end:], 1, None
+
+
 async def patch(
     path: str,
     old_string: str,
     new_string: str,
     *,
     replace_all: bool = False,
+    start: int | None = None,
+    end: int | None = None,
     tool_context: Any | None = None,
 ) -> dict[str, Any]:
     """Replace old_string with new_string in path.
@@ -494,6 +537,14 @@ async def patch(
     swap every occurrence. The file is left untouched on any error. Relative
     paths resolve under your current workspace focus (see `/workspace`);
     prefix with `/` to reach the whole workspace.
+
+    Pass ``start`` and ``end`` (character offsets into the file) to target one
+    exact span instead of searching for it. Use this when you were given
+    offsets — e.g. text the user highlighted in the UI — since a span picked
+    by position stays unambiguous even when the same text occurs elsewhere in
+    the file. ``old_string`` is then the content you expect to find there: the
+    edit is refused if it doesn't match, so a file that shifted underneath
+    fails loudly instead of corrupting the wrong span.
     """
     target, err = _resolve_in_session_window(path, tool_context)
     if err is not None:
@@ -514,17 +565,34 @@ async def patch(
         return _error(f"Failed to read {path}: {exc}")
 
     original = raw.decode("utf-8", errors="replace")
-    resolution = find_replacement(original, old_string, replace_all=replace_all)
-    if resolution.error is not None:
-        return _error(f"{resolution.error} (file: {path})")
-    assert resolution.search is not None
 
-    search = resolution.search
-    updated = (
-        original.replace(search, new_string)
-        if replace_all
-        else original.replace(search, new_string, 1)
-    )
+    if (start is not None or end is not None) and replace_all:
+        return _error(
+            "replace_all cannot be combined with start/end: a range names one "
+            "span, so there is nothing to repeat."
+        )
+
+    if start is not None or end is not None:
+        updated, count, range_err = _replace_range(
+            original, start, end, old_string, new_string
+        )
+        if range_err is not None:
+            return _error(f"{range_err} (file: {path})")
+    else:
+        resolution = find_replacement(
+            original, old_string, replace_all=replace_all
+        )
+        if resolution.error is not None:
+            return _error(f"{resolution.error} (file: {path})")
+        assert resolution.search is not None
+
+        search = resolution.search
+        updated = (
+            original.replace(search, new_string)
+            if replace_all
+            else original.replace(search, new_string, 1)
+        )
+        count = resolution.count
 
     try:
         await env.write_file(target, updated)
@@ -534,7 +602,7 @@ async def patch(
     result: dict[str, Any] = {
         "success": True,
         "path": str(target),
-        "replacements": resolution.count,
+        "replacements": count,
     }
     if str(target).endswith(".py"):
         diagnostics = await _post_edit_diagnostics(str(target))

--- a/core/python/long-horizon-harness/tests/unit/test_a2a_datapart.py
+++ b/core/python/long-horizon-harness/tests/unit/test_a2a_datapart.py
@@ -22,6 +22,8 @@ text before they reach it.
 
 from __future__ import annotations
 
+import json
+
 from horizon.a2a.datapart import (
     A2A_DATA_PART_END_TAG,
     A2A_DATA_PART_START_TAG,
@@ -58,3 +60,108 @@ def test_tolerates_malformed_json_inside_tags() -> None:
     # Garbage between the tags must not raise — degrade to None so callers
     # fall back to their generic handling.
     assert unwrap_a2a_datapart_text(_wrap(b"{not json")) is None
+
+
+def _wrap_payload(payload: dict) -> bytes:
+    return (
+        A2A_DATA_PART_START_TAG
+        + json.dumps({"data": payload}).encode("utf-8")
+        + A2A_DATA_PART_END_TAG
+    )
+
+
+class TestSelectionPayload:
+    """A highlighted selection travels as a DataPart so the chat bubble can
+    draw a quote card; the model still needs prose, built here."""
+
+    def test_renders_prose_with_a_line_range(self) -> None:
+        text = unwrap_a2a_datapart_text(
+            _wrap_payload(
+                {
+                    "lha_kind": "lha.selection",
+                    "path": "/workspace/cats.md",
+                    "start": 40,
+                    "end": 51,
+                    "start_line": 6,
+                    "end_line": 8,
+                    "snippet": "# dogs\nwoof",
+                }
+            )
+        )
+        assert text is not None
+        assert "/workspace/cats.md, lines 6-8" in text
+        assert "# dogs\nwoof" in text
+        # Offsets, not a search: the same text may occur elsewhere.
+        assert "start=40" in text and "end=51" in text
+        # The instruction is the user's own message, not this block.
+        assert "replace" not in text.lower()
+        # No JSON leaks through to the model.
+        assert "lha_kind" not in text
+        assert "[UI action]" not in text
+
+    def test_single_line_reads_as_line_not_range(self) -> None:
+        text = unwrap_a2a_datapart_text(
+            _wrap_payload(
+                {
+                    "lha_kind": "lha.selection",
+                    "path": "/workspace/cats.md",
+                    "start": 40,
+                    "end": 46,
+                    "start_line": 6,
+                    "end_line": 6,
+                    "snippet": "# dogs",
+                }
+            )
+        )
+        assert text is not None
+        assert "line 6" in text
+        assert "lines 6" not in text
+
+    def test_malformed_selection_falls_back_to_the_generic_dump(self) -> None:
+        # Better an opaque payload than a confidently wrong anchor.
+        text = unwrap_a2a_datapart_text(
+            _wrap_payload(
+                {"lha_kind": "lha.selection", "path": "/workspace/cats.md"}
+            )
+        )
+        assert text is not None
+        assert text.startswith("[UI action] ")
+
+    def test_other_payloads_are_untouched(self) -> None:
+        text = unwrap_a2a_datapart_text(_wrap_payload({"foo": "bar"}))
+        assert text == '[UI action] {"foo": "bar"}'
+
+
+class TestFileRefPayload:
+    """Files dragged from the tree travel as paths, not as bytes."""
+
+    def test_lists_the_attached_paths(self) -> None:
+        text = unwrap_a2a_datapart_text(
+            _wrap_payload(
+                {
+                    "lha_kind": "lha.fileref",
+                    "paths": ["alphabet.md", "docs/plan.md"],
+                }
+            )
+        )
+        assert text is not None
+        assert "alphabet.md" in text and "docs/plan.md" in text
+        assert "2 workspace files" in text
+        assert "[UI action]" not in text
+
+    def test_reads_naturally_for_one_file(self) -> None:
+        text = unwrap_a2a_datapart_text(
+            _wrap_payload({"lha_kind": "lha.fileref", "paths": ["a.md"]})
+        )
+        assert text is not None
+        assert "1 workspace file." in text or "1 workspace file " in text
+
+    def test_malformed_falls_back_to_the_generic_dump(self) -> None:
+        for payload in (
+            {"lha_kind": "lha.fileref"},
+            {"lha_kind": "lha.fileref", "paths": []},
+            {"lha_kind": "lha.fileref", "paths": ["ok.md", 42]},
+        ):
+            text = unwrap_a2a_datapart_text(_wrap_payload(payload))
+            assert text is not None
+            assert text.startswith("[UI action] ")

--- a/core/python/long-horizon-harness/tests/unit/test_file_ops.py
+++ b/core/python/long-horizon-harness/tests/unit/test_file_ops.py
@@ -846,3 +846,146 @@ class TestRoundTrips:
 
         read_result = await read_file(str(target))
         assert "value = 42" in read_result["content"]
+
+
+class TestPatchByRange:
+    """Offsets identify the span; ``old_string`` only verifies it.
+
+    The UI hands over character offsets for text the user highlighted, which
+    stays unambiguous in files where the same text repeats — the case a search
+    anchor cannot resolve at all.
+    """
+
+    async def test_edits_the_named_span_even_when_the_text_repeats(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "alpha.md"
+        # "b" three times: a search anchor would refuse this outright.
+        target.write_text("a\nb\nc\nb\nd\nb\n", encoding="utf-8")
+        start = len("a\n")
+
+        result = await patch(str(target), "b", "B", start=start, end=start + 1)
+
+        assert result["success"] is True, result
+        assert result["replacements"] == 1
+        assert target.read_text(encoding="utf-8") == "a\nB\nc\nb\nd\nb\n"
+
+    async def test_edits_a_partial_line(self, tmp_path: Path) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("# dogs\n", encoding="utf-8")
+        start = len("# ")
+
+        result = await patch(
+            str(target), "dogs", "Dogs", start=start, end=start + 4
+        )
+
+        assert result["success"] is True, result
+        assert target.read_text(encoding="utf-8") == "# Dogs\n"
+
+    async def test_refuses_when_the_span_no_longer_matches(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("hello world\n", encoding="utf-8")
+
+        result = await patch(str(target), "hello", "hi", start=6, end=11)
+
+        assert result["success"] is False
+        assert "changed since" in result["error"]
+        # Untouched, rather than a confident edit to the wrong span.
+        assert target.read_text(encoding="utf-8") == "hello world\n"
+
+    async def test_refuses_a_range_past_the_end_of_the_file(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("short\n", encoding="utf-8")
+
+        result = await patch(str(target), "short", "long", start=0, end=999)
+
+        assert result["success"] is False
+        assert "past the end" in result["error"]
+        assert target.read_text(encoding="utf-8") == "short\n"
+
+    async def test_refuses_an_inverted_or_negative_range(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("abcdef\n", encoding="utf-8")
+
+        # Assert the reason, not just the refusal: a negative start otherwise
+        # slips through to the content guard and is rejected for the wrong
+        # reason, leaving the range check untested.
+        inverted = await patch(str(target), "b", "B", start=4, end=2)
+        assert inverted["success"] is False
+        assert "invalid range" in inverted["error"]
+
+        negative = await patch(str(target), "b", "B", start=-1, end=2)
+        assert negative["success"] is False
+        assert "invalid range" in negative["error"]
+
+        assert target.read_text(encoding="utf-8") == "abcdef\n"
+
+    async def test_refuses_a_half_specified_range(self, tmp_path: Path) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("abcdef\n", encoding="utf-8")
+
+        result = await patch(str(target), "b", "B", start=1)
+
+        assert result["success"] is False
+        assert "together" in result["error"]
+        assert target.read_text(encoding="utf-8") == "abcdef\n"
+
+    async def test_an_empty_range_inserts(self, tmp_path: Path) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("ac\n", encoding="utf-8")
+
+        result = await patch(str(target), "", "b", start=1, end=1)
+
+        assert result["success"] is True, result
+        assert target.read_text(encoding="utf-8") == "abc\n"
+
+    async def test_replace_all_with_a_range_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """A range names one span, so repeating it means nothing. Silently
+        ignoring the flag would do something the caller did not ask for."""
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("a\nb\nb\n", encoding="utf-8")
+
+        result = await patch(
+            str(target), "b", "B", start=2, end=3, replace_all=True
+        )
+
+        assert result["success"] is False
+        assert "replace_all" in result["error"]
+        assert target.read_text(encoding="utf-8") == "a\nb\nb\n"
+
+    async def test_search_mode_is_unchanged_when_no_range_is_given(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import patch
+
+        target = tmp_path / "doc.md"
+        target.write_text("hello world\n", encoding="utf-8")
+
+        result = await patch(str(target), "world", "there")
+
+        assert result["success"] is True, result
+        assert target.read_text(encoding="utf-8") == "hello there\n"

--- a/core/python/long-horizon-harness/tests/unit/test_lha_uploads.py
+++ b/core/python/long-horizon-harness/tests/unit/test_lha_uploads.py
@@ -603,3 +603,107 @@ def test_delete_missing_user_id_is_401(env_at_tmp: LocalEnvironment) -> None:
     finally:
         os.environ.pop("LHA_AUTH_MODE", None)
         os.environ.pop("LHA_IAP_AUDIENCE", None)
+
+
+# ---------------------------------------------------------------------------
+# PUT /lha/workspace/file — browser-side editing of an existing text file.
+# ---------------------------------------------------------------------------
+
+
+def test_write_overwrites_existing_file(env_at_tmp: LocalEnvironment) -> None:
+    target = env_at_tmp.working_dir / "report.md"
+    target.write_text("# old\n", encoding="utf-8")
+
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/report.md"},
+        json={"content": "# new\n\nedited\n"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"path": "/workspace/report.md", "size": 14}
+    assert target.read_text(encoding="utf-8") == "# new\n\nedited\n"
+
+
+def test_write_missing_file_is_404(env_at_tmp: LocalEnvironment) -> None:
+    """Edit-only: creation stays on POST /lha/uploads so this route can't
+    be used to drop new files anywhere under the workspace."""
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/nope.md"},
+        json={"content": "x"},
+    )
+    assert resp.status_code == 404
+    assert not (env_at_tmp.working_dir / "nope.md").exists()
+
+
+def test_write_directory_is_400(env_at_tmp: LocalEnvironment) -> None:
+    (env_at_tmp.working_dir / "docs").mkdir()
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/docs"},
+        json={"content": "x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_write_outside_workspace_is_400(env_at_tmp: LocalEnvironment) -> None:
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/../../etc/passwd"},
+        json={"content": "pwned"},
+    )
+    assert resp.status_code == 400
+
+
+def test_write_binary_extension_is_415(env_at_tmp: LocalEnvironment) -> None:
+    target = env_at_tmp.working_dir / "logo.png"
+    target.write_bytes(b"\x89PNG\r\n")
+
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/logo.png"},
+        json={"content": "not a png"},
+    )
+    assert resp.status_code == 415
+    assert target.read_bytes() == b"\x89PNG\r\n"
+
+
+def test_write_protected_path_is_403(
+    env_at_tmp: LocalEnvironment, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The browser route honours the same protected-paths list as the
+    agent's own write tool — the UI must not be a way around it."""
+    target = env_at_tmp.working_dir / "secrets.txt"
+    target.write_text("keep", encoding="utf-8")
+    monkeypatch.setattr("horizon.api.uploads._is_write_denied", lambda _p: True)
+
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/secrets.txt"},
+        json={"content": "clobbered"},
+    )
+    assert resp.status_code == 403
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_write_oversized_content_is_413(env_at_tmp: LocalEnvironment) -> None:
+    from horizon.api.uploads import MAX_EDIT_BYTES
+
+    target = env_at_tmp.working_dir / "big.md"
+    target.write_text("small", encoding="utf-8")
+
+    client = TestClient(_build_app())
+    resp = client.put(
+        "/lha/workspace/file",
+        params={"path": "/workspace/big.md"},
+        json={"content": "x" * (MAX_EDIT_BYTES + 1)},
+    )
+    assert resp.status_code == 413
+    assert target.read_text(encoding="utf-8") == "small"

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/attachment-chip-path.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/attachment-chip-path.test.tsx
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageBubble } from "../message-bubble";
+import { ArtifactViewer } from "../artifact-viewer/artifact-viewer";
+import { ViewerProvider } from "../artifact-viewer/viewer-context";
+import { BusyProvider } from "../busy-context";
+import { __resetWorkspaceFiles } from "@/lib/workspace-files";
+import type { ChatMessage } from "../chat-shell";
+
+const BODY = "# Cats\n\nThey purr.\n";
+/** What the message froze at send time; the file has moved on since. */
+const STALE = "# STALE\n\nold copy\n";
+
+let tree: { name: string; kind: string; mtime: number }[] = [];
+
+function stubBackend() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/lha/workspace/tree")) {
+        return new Response(JSON.stringify({ entries: tree }), { status: 200 });
+      }
+      return new Response(BODY, { status: 200 });
+    }),
+  );
+}
+
+function attachment(name: string): ChatMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    createdAt: 0,
+    segments: [
+      {
+        kind: "file",
+        file: { name, mimeType: "text/markdown", bytes: btoa(STALE) },
+      },
+    ],
+  } as unknown as ChatMessage;
+}
+
+function setup(name: string) {
+  return render(
+    <BusyProvider value={false}>
+      <ViewerProvider>
+        <MessageBubble message={attachment(name)} />
+        <ArtifactViewer />
+      </ViewerProvider>
+    </BusyProvider>,
+  );
+}
+
+describe("attachment chip", () => {
+  beforeEach(() => {
+    __resetWorkspaceFiles();
+    tree = [{ name: "cats.md", kind: "file", mtime: 1 }];
+    stubBackend();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("opens a workspace file as editable, not a read-only snapshot", async () => {
+    setup("cats.md");
+    // Wait for the workspace listing, which is what supplies the path.
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
+
+    fireEvent.click(await screen.findByRole("button", { name: /cats\.md/ }));
+
+    // "Source" is the editable label; "Raw" is the read-only one.
+    expect(
+      await screen.findByRole("button", { name: /^source$/i }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^raw$/i })).toBeNull();
+  });
+
+  it("stays read-only for an attachment that is not a workspace file", async () => {
+    setup("elsewhere.md");
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /elsewhere\.md/ }),
+    );
+
+    expect(await screen.findByRole("button", { name: /^raw$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^source$/i })).toBeNull();
+  });
+});
+
+describe("attachment of a file that is still being edited", () => {
+  beforeEach(() => {
+    __resetWorkspaceFiles();
+    tree = [{ name: "cats.md", kind: "file", mtime: 1 }];
+    stubBackend();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shows what is on disk, not the bytes frozen in the message", async () => {
+    // The agent has rewritten cats.md since it sent this attachment.
+    render(
+      <BusyProvider value={false}>
+        <ViewerProvider>
+          <MessageBubble message={attachment("cats.md")} />
+          <ArtifactViewer />
+        </ViewerProvider>
+      </BusyProvider>,
+    );
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
+    fireEvent.click(await screen.findByRole("button", { name: /cats\.md/ }));
+
+    // BODY is what the fake backend serves; the message carries STALE.
+    expect(await screen.findByRole("heading", { name: "Cats" })).toBeTruthy();
+    expect(screen.queryByText(/STALE/)).toBeNull();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/markdown-file-mention.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/markdown-file-mention.test.tsx
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Markdown } from "../markdown";
+import { ArtifactViewer } from "../artifact-viewer/artifact-viewer";
+import { ViewerProvider } from "../artifact-viewer/viewer-context";
+import { __resetWorkspaceFiles } from "@/lib/workspace-files";
+
+// One file at the root, one nested — the walk goes two levels deep.
+function stubTree() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/lha/workspace/tree")) {
+        const body = url.includes(encodeURIComponent("/workspace/docs"))
+          ? { entries: [{ name: "plan.md", kind: "file" }] }
+          : {
+              entries: [
+                { name: "cats.md", kind: "file" },
+                { name: "docs", kind: "dir" },
+              ],
+            };
+        return new Response(JSON.stringify(body), { status: 200 });
+      }
+      return new Response("", { status: 200 });
+    }),
+  );
+}
+
+function setup(text: string) {
+  return render(
+    <ViewerProvider>
+      <Markdown text={text} />
+      <ArtifactViewer />
+    </ViewerProvider>,
+  );
+}
+
+describe("backticked filename mentions", () => {
+  beforeEach(() => {
+    __resetWorkspaceFiles();
+    stubTree();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("linkifies a filename that exists in the workspace", async () => {
+    setup("I have created `cats.md` in your workspace.");
+    const link = await screen.findByRole("button", { name: "cats.md" });
+    fireEvent.click(link);
+    expect(screen.getByRole("tab", { name: /cats\.md/i })).toBeTruthy();
+  });
+
+  it("linkifies a nested file found by the two-level walk", async () => {
+    setup("See `docs/plan.md` for the outline.");
+    expect(
+      await screen.findByRole("button", { name: "docs/plan.md" }),
+    ).toBeTruthy();
+  });
+
+  it("leaves a filename that does not exist as plain code", async () => {
+    setup("Check `ghost.md` for details.");
+    // Wait for the listing so this isn't just passing on a pending fetch.
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "ghost.md" })).toBeNull(),
+    );
+    expect(screen.getByText("ghost.md").tagName).toBe("CODE");
+  });
+
+  it("leaves a backticked shell command alone", async () => {
+    setup("Run `npm run build` first.");
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /npm run build/ })).toBeNull();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/markdown-workspace-link.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/markdown-workspace-link.test.tsx
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Markdown } from "../markdown";
+import { ArtifactViewer } from "../artifact-viewer/artifact-viewer";
+import { ViewerProvider } from "../artifact-viewer/viewer-context";
+
+function setup(text: string) {
+  return render(
+    <ViewerProvider>
+      <Markdown text={text} />
+      <ArtifactViewer />
+    </ViewerProvider>,
+  );
+}
+
+describe("markdown workspace links", () => {
+  // Opening a tab kicks off the viewer's content fetch; leaving it real
+  // makes happy-dom abort it on teardown and log the rejection.
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 200 })),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("opens a bare relative link in the side panel", () => {
+    setup("I wrote [cats.md](cats.md) for you.");
+    expect(screen.getByText(/no file open/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "cats.md" }));
+
+    // The viewer now owns a tab for it instead of the empty state.
+    expect(screen.getByRole("tab", { name: /cats\.md/i })).toBeTruthy();
+    expect(screen.queryByText(/no file open/i)).toBeNull();
+  });
+
+  it("keeps external links as real anchors in a new tab", () => {
+    setup("See [the docs](https://example.com/docs).");
+    const link = screen.getByRole("link", { name: "the docs" });
+    expect(link.getAttribute("href")).toBe("https://example.com/docs");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("does not turn a rooted app link into a panel link", () => {
+    setup("Open [sessions](/lha/sessions).");
+    expect(screen.getByRole("link", { name: "sessions" })).toBeTruthy();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/selection-chip.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/selection-chip.test.tsx
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { InputBox } from "../input-box";
+
+type Props = React.ComponentProps<typeof InputBox>;
+
+function setup(over: Partial<Props> = {}) {
+  const onClearSelection = vi.fn();
+  render(
+    <InputBox
+      value=""
+      onValueChange={() => {}}
+      onSend={() => {}}
+      attachments={[]}
+      onAddFiles={() => {}}
+      onRemoveAttachment={() => {}}
+      attachmentError={null}
+      queued={[]}
+      onRemoveQueued={() => {}}
+      selectionChip={{ label: "Cats are small …" }}
+      onClearSelection={onClearSelection}
+      {...over}
+    />,
+  );
+  return { onClearSelection };
+}
+
+describe("selection chip", () => {
+  it("shows the snippet label", () => {
+    setup();
+    expect(screen.getByText(/Cats are small …/)).toBeTruthy();
+  });
+
+  it("clears on the x button", () => {
+    const { onClearSelection } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /clear selection/i }));
+    expect(onClearSelection).toHaveBeenCalled();
+  });
+
+  it("is absent when there is no selection", () => {
+    setup({ selectionChip: null });
+    expect(
+      screen.queryByRole("button", { name: /clear selection/i }),
+    ).toBeNull();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/selection-quote.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/selection-quote.test.tsx
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MessageBubble } from "../message-bubble";
+import { ViewerProvider } from "../artifact-viewer/viewer-context";
+import { SELECTION_DATA_KIND } from "../workspace-href";
+import type { ChatMessage } from "../chat-shell";
+
+function bubble(segments: unknown[]) {
+  const message = {
+    id: "m1",
+    role: "user",
+    createdAt: 0,
+    segments,
+  } as unknown as ChatMessage;
+  return render(
+    <ViewerProvider>
+      <MessageBubble message={message} />
+    </ViewerProvider>,
+  );
+}
+
+const selection = {
+  lha_kind: SELECTION_DATA_KIND,
+  path: "/workspace/cats.md",
+  start: 40,
+  end: 46,
+  start_line: 6,
+  end_line: 6,
+  snippet: "# dogs",
+};
+
+describe("selection quote in a user bubble", () => {
+  it("shows the file, the line, and the snippet", () => {
+    bubble([
+      { kind: "data", mime: undefined, data: selection },
+      { kind: "text", text: "make upper case the first letter" },
+    ]);
+    expect(screen.getByText("cats.md")).toBeTruthy();
+    expect(screen.getByText(/line 6/)).toBeTruthy();
+    expect(screen.getByText("# dogs")).toBeTruthy();
+    expect(screen.getByText(/make upper case the first letter/)).toBeTruthy();
+  });
+
+  it("shows the snippet verbatim rather than rendering it as markdown", () => {
+    // The old text-prefix approach turned "# dogs" into an <h1>.
+    bubble([{ kind: "data", mime: undefined, data: selection }]);
+    expect(screen.queryByRole("heading")).toBeNull();
+  });
+
+  it("leaks none of the model-facing framing", () => {
+    bubble([{ kind: "data", mime: undefined, data: selection }]);
+    const text = document.body.textContent ?? "";
+    expect(text).not.toContain("<<<");
+    expect(text).not.toContain("lha_kind");
+  });
+
+  it("reads as a range when the selection spans lines", () => {
+    bubble([
+      {
+        kind: "data",
+        mime: undefined,
+        data: { ...selection, start_line: 6, end_line: 8 },
+      },
+    ]);
+    expect(screen.getByText(/lines 6–8/)).toBeTruthy();
+  });
+
+  it("opens the file under the path every other route uses", () => {
+    // A different string here would key a second editable tab for the same
+    // file, each autosaving over the other.
+    bubble([{ kind: "data", mime: undefined, data: selection }]);
+    const btn = screen.getByRole("button", { name: "cats.md" });
+    expect(btn.getAttribute("title")).toBe(
+      "Open /workspace/cats.md in the side panel",
+    );
+  });
+
+  it("still dumps an unrecognised data part as JSON", () => {
+    bubble([{ kind: "data", mime: undefined, data: { foo: "bar" } }]);
+    expect(screen.getByText(/"foo": "bar"/)).toBeTruthy();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/use-message-queue.test.ts
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/use-message-queue.test.ts
@@ -22,7 +22,7 @@ describe("useMessageQueue", () => {
     const { result } = renderHook(() => useMessageQueue({ busy: true, send }));
     act(() => result.current.enqueue("  hello  "));
     act(() => result.current.enqueue("   "));
-    expect(result.current.queue).toEqual(["hello"]);
+    expect(result.current.queue).toEqual([{ text: "hello", parts: [] }]);
   });
 
   it("removes a queued entry by index", () => {
@@ -31,7 +31,7 @@ describe("useMessageQueue", () => {
     act(() => result.current.enqueue("a"));
     act(() => result.current.enqueue("b"));
     act(() => result.current.removeQueued(0));
-    expect(result.current.queue).toEqual(["b"]);
+    expect(result.current.queue).toEqual([{ text: "b", parts: [] }]);
   });
 
   it("clears the queue", () => {
@@ -52,7 +52,7 @@ describe("useMessageQueue", () => {
     act(() => result.current.enqueue("b"));
     rerender({ busy: false });
     expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith("a\n\nb");
+    expect(send).toHaveBeenCalledWith("a\n\nb", undefined);
     expect(result.current.queue).toEqual([]);
   });
 

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/workspace-drag.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/workspace-drag.test.tsx
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarWorkspaceTree } from "../sidebar-workspace-tree";
+import { ViewerProvider } from "../artifact-viewer/viewer-context";
+import { FILEREF_DRAG_MIME, parseFileRefDrag } from "../workspace-href";
+
+function stubTree() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const nested = url.includes(encodeURIComponent("/workspace/docs"));
+      return new Response(
+        JSON.stringify({
+          entries: nested
+            ? [{ name: "plan.md", kind: "file", size: 1 }]
+            : [
+                { name: "alphabet.md", kind: "file", size: 1 },
+                { name: "docs", kind: "dir" },
+              ],
+        }),
+        { status: 200 },
+      );
+    }),
+  );
+}
+
+function setup() {
+  render(
+    <ViewerProvider>
+      <SidebarWorkspaceTree
+        isExpanded
+        workspaceVersion={0}
+        optimisticRows={[]}
+        onReconciled={() => {}}
+      />
+    </ViewerProvider>,
+  );
+}
+
+/** The row's name button; the open-in-new-tab anchor shares its title. */
+async function nameButton(name: string) {
+  const matches = await screen.findAllByTitle(`Open ${name}`);
+  const btn = matches.find((el) => el.tagName === "BUTTON");
+  if (!btn) throw new Error(`no draggable row for ${name}`);
+  return btn;
+}
+
+/** Minimal stand-in: happy-dom has no DataTransfer. */
+function dataTransfer() {
+  const store: Record<string, string> = {};
+  return {
+    setData: (t: string, v: string) => {
+      store[t] = v;
+    },
+    getData: (t: string) => store[t] ?? "",
+    effectAllowed: "",
+    types: [] as string[],
+    store,
+  };
+}
+
+describe("dragging a workspace file", () => {
+  beforeEach(stubTree);
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("carries the name, size and the path the agent's tools expect", async () => {
+    setup();
+    const row = await nameButton("alphabet.md");
+    const dt = dataTransfer();
+    fireEvent.dragStart(row, { dataTransfer: dt });
+
+    expect(parseFileRefDrag(dt.store[FILEREF_DRAG_MIME])).toEqual({
+      // /workspace-prefixed: the one form that resolves the same whether or
+      // not the chat has a project window set.
+      path: "/workspace/alphabet.md",
+      name: "alphabet.md",
+      size: 1,
+    });
+  });
+
+  it("sets no text/plain, which would double up with the chip", async () => {
+    // A textarea inserts dropped text itself, so carrying text/plain too
+    // would type the name alongside showing the chip.
+    setup();
+    const row = await nameButton("alphabet.md");
+    const dt = dataTransfer();
+    fireEvent.dragStart(row, { dataTransfer: dt });
+
+    expect(Object.keys(dt.store)).toEqual([FILEREF_DRAG_MIME]);
+  });
+
+  it("keeps the folder for a nested file", async () => {
+    setup();
+    fireEvent.click(await screen.findByText("docs"));
+    const row = await nameButton("plan.md");
+    const dt = dataTransfer();
+    fireEvent.dragStart(row, { dataTransfer: dt });
+
+    expect(parseFileRefDrag(dt.store[FILEREF_DRAG_MIME])?.path).toBe(
+      "/workspace/docs/plan.md",
+    );
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/__tests__/workspace-href.test.ts
+++ b/core/python/long-horizon-harness/web/components/chat/__tests__/workspace-href.test.ts
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  normalizeWorkspacePath,
+  workspacePathFromHref,
+  workspacePathFromMention,
+} from "../workspace-href";
+
+describe("normalizeWorkspacePath", () => {
+  it("canonicalises relative and rooted forms to the same path", () => {
+    // Tabs are keyed by path — these must not open two tabs for one file.
+    expect(normalizeWorkspacePath("report.md")).toBe("/workspace/report.md");
+    expect(normalizeWorkspacePath("./report.md")).toBe("/workspace/report.md");
+    expect(normalizeWorkspacePath("/workspace/report.md")).toBe(
+      "/workspace/report.md",
+    );
+  });
+
+  it("keeps nested paths", () => {
+    expect(normalizeWorkspacePath("docs/a/b.md")).toBe(
+      "/workspace/docs/a/b.md",
+    );
+  });
+
+  it("rejects absolute host paths", () => {
+    // write_file echoes these back on the local backend; they aren't
+    // addressable through the workspace API.
+    expect(
+      normalizeWorkspacePath("/Users/me/.lha/users/u/report.md"),
+    ).toBeNull();
+    expect(normalizeWorkspacePath("/etc/passwd")).toBeNull();
+  });
+
+  it("rejects traversal and empties", () => {
+    expect(normalizeWorkspacePath("../secrets")).toBeNull();
+    expect(normalizeWorkspacePath("a/../b")).toBeNull();
+    expect(normalizeWorkspacePath("")).toBeNull();
+    expect(normalizeWorkspacePath("/workspace")).toBeNull();
+  });
+});
+
+describe("workspacePathFromHref", () => {
+  it("treats a bare relative href as a workspace file", () => {
+    expect(workspacePathFromHref("plot.html")).toBe("/workspace/plot.html");
+  });
+
+  it("leaves real links alone", () => {
+    for (const href of [
+      "https://example.com",
+      "http://example.com",
+      "mailto:a@b.c",
+      "tel:123",
+      "javascript:alert(1)",
+      "data:text/html,x",
+      "//evil.com",
+      "/lha/sessions",
+      "#anchor",
+      "?q=1",
+    ]) {
+      expect(workspacePathFromHref(href)).toBeNull();
+    }
+  });
+
+  it("returns null for a missing href", () => {
+    expect(workspacePathFromHref(undefined)).toBeNull();
+  });
+});
+
+describe("workspacePathFromMention", () => {
+  it("accepts a backticked filename", () => {
+    expect(workspacePathFromMention("cats.md")).toBe("/workspace/cats.md");
+    expect(workspacePathFromMention("docs/plan.md")).toBe(
+      "/workspace/docs/plan.md",
+    );
+    expect(workspacePathFromMention(" report.md ")).toBe(
+      "/workspace/report.md",
+    );
+  });
+
+  it("ignores prose and shell lines", () => {
+    // Models backtick commands far more often than filenames.
+    for (const text of [
+      "ls -la",
+      "npm run build",
+      "a sentence.md with spaces",
+      "cats",
+      "3.14",
+      "v1.2",
+      "",
+    ]) {
+      expect(workspacePathFromMention(text)).toBeNull();
+    }
+  });
+
+  it("ignores urls, schemes and traversal", () => {
+    expect(workspacePathFromMention("https://example.com/a.md")).toBeNull();
+    expect(workspacePathFromMention("mailto:a@b.co")).toBeNull();
+    expect(workspacePathFromMention("../secrets.md")).toBeNull();
+  });
+
+  it("ignores an over-long extension (not a filename)", () => {
+    expect(workspacePathFromMention("v1.wontbeanextension")).toBeNull();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/artifact-viewer.editing.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/artifact-viewer.editing.test.tsx
@@ -1,0 +1,179 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArtifactViewer } from "../artifact-viewer";
+import { ViewerProvider, useViewer } from "../viewer-context";
+import { BusyProvider } from "../../busy-context";
+
+// A live workspace file (has `path`) vs a frozen artifact snapshot.
+const wsFile = {
+  name: "report.md",
+  mimeType: "text/markdown",
+  bytes: btoa("# Report"),
+  path: "/workspace/report.md",
+};
+const snapshot = {
+  name: "spec.md",
+  mimeType: "text/markdown",
+  bytes: btoa("# Spec"),
+};
+
+function Opener({ file }: { file?: object } = {}) {
+  const { openArtifact } = useViewer();
+  return (
+    <>
+      <button onClick={() => openArtifact((file ?? wsFile) as never)}>
+        open-ws
+      </button>
+      <button onClick={() => openArtifact(snapshot)}>open-snapshot</button>
+    </>
+  );
+}
+
+function setup(busy = false) {
+  return render(
+    <BusyProvider value={busy}>
+      <ViewerProvider>
+        <Opener />
+        <ArtifactViewer />
+      </ViewerProvider>
+    </BusyProvider>,
+  );
+}
+
+const sourceButton = () => screen.getByRole("button", { name: /^source$/i });
+
+describe("ArtifactViewer editing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("labels the source toggle 'Source' for a workspace file", () => {
+    setup();
+    fireEvent.click(screen.getByText("open-ws"));
+    expect(sourceButton()).toBeTruthy();
+  });
+
+  it("labels it 'Raw' for an artifact snapshot, with no editor", () => {
+    setup();
+    fireEvent.click(screen.getByText("open-snapshot"));
+    expect(screen.getByRole("button", { name: /^raw$/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /^raw$/i }));
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("autosaves a workspace file after the debounce", async () => {
+    setup();
+    fireEvent.click(screen.getByText("open-ws"));
+    fireEvent.click(sourceButton());
+
+    const box = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "# Edited" } });
+    expect(screen.getByText(/unsaved/i)).toBeTruthy();
+
+    // No request until the debounce elapses.
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(String(url)).toContain("/lha/workspace/file");
+    expect(String(url)).toContain(encodeURIComponent("/workspace/report.md"));
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toEqual({ content: "# Edited" });
+  });
+
+  it("coalesces a typing burst into one request", async () => {
+    setup();
+    fireEvent.click(screen.getByText("open-ws"));
+    fireEvent.click(sourceButton());
+    const box = screen.getByRole("textbox");
+
+    for (const v of ["a", "ab", "abc"]) {
+      fireEvent.change(box, { target: { value: v } });
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+    }
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    const [, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(JSON.parse(String(init?.body))).toEqual({ content: "abc" });
+  });
+
+  it("locks the editor while the agent owns the turn", () => {
+    setup(true);
+    fireEvent.click(screen.getByText("open-ws"));
+    fireEvent.click(sourceButton());
+    const box = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(box.readOnly).toBe(true);
+    expect(screen.getByText(/agent working/i)).toBeTruthy();
+  });
+});
+
+describe("files the editor must not rewrite", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("x", { status: 200 })),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("stays read-only when the bytes are not valid UTF-8", async () => {
+    // decodeText replaces invalid sequences with U+FFFD, so a latin-1 file
+    // decodes "fine" — and saving that decode back destroys the bytes it
+    // could not represent.
+    const latin1 = btoa("caf\xe9 au lait");
+    render(
+      <BusyProvider value={false}>
+        <ViewerProvider>
+          <Opener
+            file={{
+              name: "notes.csv",
+              mimeType: "text/csv",
+              bytes: latin1,
+              path: "/workspace/notes.csv",
+            }}
+          />
+          <ArtifactViewer />
+        </ViewerProvider>
+      </BusyProvider>,
+    );
+    fireEvent.click(screen.getByText("open-ws"));
+
+    // No Source toggle means no editor, so nothing can save the mangled
+    // decode back over the original bytes.
+    expect(
+      await screen.findByRole("tab", { name: /notes\.csv/i }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^source$/i })).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/artifact-viewer.reload.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/artifact-viewer.reload.test.tsx
@@ -1,0 +1,172 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { StrictMode } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArtifactViewer } from "../artifact-viewer";
+import { ViewerProvider, useViewer } from "../viewer-context";
+import { BusyProvider } from "../../busy-context";
+
+const wsFile = {
+  name: "cats.md",
+  mimeType: "text/markdown",
+  path: "/workspace/cats.md",
+};
+
+// The file the server hands back; mutate to simulate the agent rewriting it.
+let onDisk = "# Cats";
+
+function Opener() {
+  const { openArtifact } = useViewer();
+  return <button onClick={() => openArtifact(wsFile)}>open</button>;
+}
+
+function setup(busy: boolean) {
+  return render(
+    <BusyProvider value={busy}>
+      <ViewerProvider>
+        <Opener />
+        <ArtifactViewer />
+      </ViewerProvider>
+    </BusyProvider>,
+  );
+}
+
+describe("ArtifactViewer staleness", () => {
+  beforeEach(() => {
+    onDisk = "# Cats";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(onDisk, { status: 200 })),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("fetches contents for a tab opened from a path", async () => {
+    setup(false);
+    fireEvent.click(screen.getByText("open"));
+    expect(await screen.findByRole("heading", { name: "Cats" })).toBeTruthy();
+  });
+
+  it("refetches when the file is re-opened", async () => {
+    setup(false);
+    fireEvent.click(screen.getByText("open"));
+    await screen.findByRole("heading", { name: "Cats" });
+
+    // The agent appends a section behind our back.
+    onDisk = "# Cats\n\n# Dogs";
+    fireEvent.click(screen.getByText("open"));
+
+    expect(await screen.findByRole("heading", { name: "Dogs" })).toBeTruthy();
+  });
+
+  it("survives a re-render while the refetch is in flight", async () => {
+    // A turn ending re-renders this tree repeatedly (status strip, message
+    // list). If the fetch effect tears down on those renders, the response is
+    // dropped and the panel silently keeps stale content.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        await gate;
+        return new Response(onDisk, { status: 200 });
+      }),
+    );
+
+    const view = (busy: boolean, nonce: number) => (
+      <BusyProvider value={busy}>
+        <ViewerProvider>
+          <Opener />
+          <ArtifactViewer />
+          <span>{nonce}</span>
+        </ViewerProvider>
+      </BusyProvider>
+    );
+
+    const { rerender } = render(view(false, 0));
+    fireEvent.click(screen.getByText("open"));
+
+    // Unrelated re-renders land while the request is still open.
+    for (let i = 1; i <= 3; i++) rerender(view(false, i));
+    release();
+
+    expect(await screen.findByRole("heading", { name: "Cats" })).toBeTruthy();
+  });
+
+  it("refetches when a turn ends", async () => {
+    const { rerender } = setup(false);
+    fireEvent.click(screen.getByText("open"));
+    await screen.findByRole("heading", { name: "Cats" });
+
+    const view = (busy: boolean) => (
+      <BusyProvider value={busy}>
+        <ViewerProvider>
+          <Opener />
+          <ArtifactViewer />
+        </ViewerProvider>
+      </BusyProvider>
+    );
+
+    // Turn starts, agent rewrites the file, turn ends.
+    rerender(view(true));
+    onDisk = "# Cats\n\n# Dogs";
+    rerender(view(false));
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Dogs" })).toBeTruthy(),
+    );
+  });
+});
+
+describe("ArtifactViewer under StrictMode", () => {
+  beforeEach(() => {
+    onDisk = "# Cats";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(onDisk, { status: 200 })),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("loads contents when it mounts with a tab already open", async () => {
+    // Mirrors the real app: the right pane shows the side panels until a file
+    // is opened, so ArtifactViewer *mounts* with the tab already present.
+    // StrictMode double-invokes effects on mount with a cleanup between, so a
+    // fetch that records its key before awaiting is cancelled by its own
+    // cleanup and skipped on the second pass — leaving the tab blank forever.
+    function Pane() {
+      const { tabs, openArtifact } = useViewer();
+      return (
+        <>
+          <button onClick={() => openArtifact(wsFile)}>open</button>
+          {tabs.length > 0 && <ArtifactViewer />}
+        </>
+      );
+    }
+
+    render(
+      <StrictMode>
+        <BusyProvider value={false}>
+          <ViewerProvider>
+            <Pane />
+          </ViewerProvider>
+        </BusyProvider>
+      </StrictMode>,
+    );
+    fireEvent.click(screen.getByText("open"));
+    expect(await screen.findByRole("heading", { name: "Cats" })).toBeTruthy();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/artifact-viewer.selection.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/artifact-viewer.selection.test.tsx
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArtifactViewer } from "../artifact-viewer";
+import { ViewerProvider, useViewer } from "../viewer-context";
+import { BusyProvider } from "../../busy-context";
+
+const FILE_TEXT = "alpha\nbravo\ncharlie\n";
+
+const wsFile = {
+  name: "cats.md",
+  mimeType: "text/markdown",
+  bytes: btoa(FILE_TEXT),
+  path: "/workspace/cats.md",
+};
+
+function Opener() {
+  const { openArtifact } = useViewer();
+  return <button onClick={() => openArtifact(wsFile)}>open</button>;
+}
+
+function setup(onSelectionChange: (s: unknown) => void) {
+  return render(
+    <BusyProvider value={false}>
+      <ViewerProvider onSelectionChange={onSelectionChange}>
+        <Opener />
+        <ArtifactViewer />
+      </ViewerProvider>
+    </BusyProvider>,
+  );
+}
+
+function openSource() {
+  fireEvent.click(screen.getByText("open"));
+  fireEvent.click(screen.getByRole("button", { name: /^source$/i }));
+  return screen.getByRole("textbox") as HTMLTextAreaElement;
+}
+
+describe("Source view selection capture", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(FILE_TEXT, { status: 200 })),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("captures a highlighted span as a unique anchor", () => {
+    const spy = vi.fn();
+    setup(spy);
+    const box = openSource();
+    box.setSelectionRange(6, 11); // "bravo"
+    fireEvent.select(box);
+    expect(spy).toHaveBeenLastCalledWith({
+      path: "/workspace/cats.md",
+      anchor: {
+        start: 6,
+        end: 11,
+        snippet: "bravo",
+        startLine: 2,
+        endLine: 2,
+      },
+    });
+  });
+
+  it("reports null when the selection collapses", () => {
+    const spy = vi.fn();
+    setup(spy);
+    const box = openSource();
+    box.setSelectionRange(6, 6);
+    fireEvent.select(box);
+    expect(spy).toHaveBeenLastCalledWith(null);
+  });
+
+  it("reports null on the first keystroke", () => {
+    const spy = vi.fn();
+    setup(spy);
+    const box = openSource();
+    box.setSelectionRange(6, 11);
+    fireEvent.select(box);
+    spy.mockClear();
+
+    fireEvent.change(box, { target: { value: `${FILE_TEXT}x` } });
+    expect(spy).toHaveBeenLastCalledWith(null);
+  });
+});
+
+describe("ViewerProvider selection forwarding", () => {
+  it("clears the selection when the conversation changes", () => {
+    const spy = vi.fn();
+    function Setter() {
+      const { setPendingSelection } = useViewer();
+      return (
+        <button
+          onClick={() =>
+            setPendingSelection({
+              path: "/workspace/cats.md",
+              anchor: {
+                start: 6,
+                end: 11,
+                snippet: "bravo",
+                startLine: 2,
+                endLine: 2,
+              },
+            })
+          }
+        >
+          set
+        </button>
+      );
+    }
+    const view = (key: string) => (
+      <ViewerProvider resetKey={key} onSelectionChange={spy}>
+        <Setter />
+      </ViewerProvider>
+    );
+    const { rerender } = render(view("chat-a"));
+    fireEvent.click(screen.getByText("set"));
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ path: "/workspace/cats.md" }),
+    );
+    spy.mockClear();
+
+    rerender(view("chat-b"));
+    expect(spy).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/auto-open-new-file.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/auto-open-new-file.test.tsx
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoOpenNewFile } from "../auto-open-new-file";
+import { ArtifactViewer } from "../artifact-viewer";
+import { ViewerProvider, useViewer } from "../viewer-context";
+import { BusyProvider } from "../../busy-context";
+
+// The workspace the fake backend reports, mutated between turns.
+let tree: { name: string; kind: string; mtime: number }[] = [];
+let missing = new Set<string>();
+
+function stubBackend() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/lha/workspace/tree")) {
+        return new Response(JSON.stringify({ entries: tree }), { status: 200 });
+      }
+      if (url.includes("/lha/workspace/download")) {
+        const path = decodeURIComponent(
+          new URL(url, "http://x").searchParams.get("path") ?? "",
+        );
+        if (missing.has(path)) return new Response("", { status: 404 });
+        return new Response("# Body", { status: 200 });
+      }
+      return new Response("", { status: 200 });
+    }),
+  );
+}
+
+function file(name: string, mtime: number) {
+  return { name, kind: "file", mtime };
+}
+
+function Opener({ path }: { path: string }) {
+  const { openArtifact, tabs } = useViewer();
+  return tabs.length === 0 ? (
+    <button
+      onClick={() =>
+        openArtifact({
+          name: path.split("/").pop()!,
+          mimeType: "text/markdown",
+          path,
+        })
+      }
+    >
+      preopen
+    </button>
+  ) : null;
+}
+
+function Harness({ busy, preopen }: { busy: boolean; preopen?: string }) {
+  return (
+    <BusyProvider value={busy}>
+      <ViewerProvider>
+        <AutoOpenNewFile />
+        {preopen && <Opener path={preopen} />}
+        <ArtifactViewer />
+      </ViewerProvider>
+    </BusyProvider>
+  );
+}
+
+describe("AutoOpenNewFile", () => {
+  beforeEach(() => {
+    tree = [];
+    missing = new Set();
+    stubBackend();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  /**
+   * Settle the initial listing before a turn, so "nothing happened" cases are
+   * genuinely waiting for the diff rather than passing before it resolves.
+   */
+  async function settled(el: React.ReactElement) {
+    const r = render(el);
+    await waitFor(() =>
+      expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(0),
+    );
+    return r;
+  }
+
+  it("opens a file the turn created", async () => {
+    const { rerender } = await settled(<Harness busy={false} />);
+
+    rerender(<Harness busy={true} />);
+    tree = [file("animals.md", 100)];
+    rerender(<Harness busy={false} />);
+
+    expect(
+      await screen.findByRole("tab", { name: /animals\.md/i }),
+    ).toBeTruthy();
+  });
+
+  it("opens every file the turn created, newest in front", async () => {
+    const { rerender } = await settled(<Harness busy={false} />);
+
+    rerender(<Harness busy={true} />);
+    tree = [file("first.md", 100), file("second.md", 200)];
+    rerender(<Harness busy={false} />);
+
+    expect(
+      await screen.findByRole("tab", { name: /second\.md/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /first\.md/i })).toBeTruthy();
+    // Opened oldest-first, so the newest is the one selected.
+    expect(
+      screen
+        .getByRole("tab", { name: /second\.md/i })
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+  });
+
+  it("adds a new file alongside one you already have open", async () => {
+    tree = [file("other.md", 50)];
+    const { rerender } = await settled(
+      <Harness busy={false} preopen="/workspace/other.md" />,
+    );
+    fireEvent.click(await screen.findByText("preopen"));
+
+    rerender(<Harness busy={true} preopen="/workspace/other.md" />);
+    tree = [file("other.md", 50), file("report.md", 200)];
+    rerender(<Harness busy={false} preopen="/workspace/other.md" />);
+
+    expect(
+      await screen.findByRole("tab", { name: /report\.md/i }),
+    ).toBeTruthy();
+    // The tab you had stays; it is just no longer in front.
+    expect(screen.getByRole("tab", { name: /other\.md/i })).toBeTruthy();
+  });
+
+  it("never opens the agent's own working files", async () => {
+    // plan.md is usually written last, so without this it would sit in front
+    // of the thing that was actually asked for.
+    const { rerender } = await settled(<Harness busy={false} />);
+
+    rerender(<Harness busy={true} />);
+    tree = [file("report.md", 100), file("plan.md", 300)];
+    rerender(<Harness busy={false} />);
+
+    expect(
+      await screen.findByRole("tab", { name: /report\.md/i }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("tab", { name: /plan\.md/i })).toBeNull();
+  });
+
+  it("does nothing when a turn only touches working files", async () => {
+    tree = [file("report.md", 100)];
+    const { rerender } = await settled(<Harness busy={false} />);
+
+    rerender(<Harness busy={true} />);
+    tree = [file("report.md", 100), file("plan.md", 300)];
+    rerender(<Harness busy={false} />);
+
+    await waitFor(() =>
+      expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(1),
+    );
+    expect(screen.getByText(/no file open/i)).toBeTruthy();
+  });
+
+  it("swaps the tab over on a rename", async () => {
+    // `mv` produces no write tool call: the old file's tab 404s and closes,
+    // and the new name opens as a file the turn created.
+    tree = [file("oldname.md", 50)];
+    const { rerender } = await settled(
+      <Harness busy={false} preopen="/workspace/oldname.md" />,
+    );
+    fireEvent.click(await screen.findByText("preopen"));
+
+    rerender(<Harness busy={true} preopen="/workspace/oldname.md" />);
+    tree = [file("newname.md", 300)];
+    missing.add("/workspace/oldname.md");
+    rerender(<Harness busy={false} preopen="/workspace/oldname.md" />);
+
+    expect(
+      await screen.findByRole("tab", { name: /newname\.md/i }),
+    ).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.queryByRole("tab", { name: /oldname\.md/i })).toBeNull(),
+    );
+  });
+
+  it("does nothing when the turn created no files", async () => {
+    tree = [file("existing.md", 10)];
+    const { rerender } = await settled(<Harness busy={false} />);
+
+    rerender(<Harness busy={true} />);
+    rerender(<Harness busy={false} />);
+
+    await waitFor(() =>
+      expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(1),
+    );
+    expect(screen.getByText(/no file open/i)).toBeTruthy();
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/renderers.test.ts
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/__tests__/renderers.test.ts
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 import { describe, expect, it } from "vitest";
-import {
-  decodeText,
-  pickRenderer,
-  supportsPreview,
-} from "../renderers";
+import { decodeText, pickRenderer, supportsPreview } from "../renderers";
 
 describe("pickRenderer", () => {
   it("resolves by mime type", () => {
@@ -31,7 +27,9 @@ describe("pickRenderer", () => {
   });
 
   it("falls back to the filename extension when mime is generic", () => {
-    expect(pickRenderer("application/octet-stream", "readme.md")).toBe("markdown");
+    expect(pickRenderer("application/octet-stream", "readme.md")).toBe(
+      "markdown",
+    );
     expect(pickRenderer("application/octet-stream", "main.py")).toBe("code");
     expect(pickRenderer("application/octet-stream", "page.html")).toBe("html");
     expect(pickRenderer("application/octet-stream", "data.json")).toBe("json");
@@ -52,14 +50,38 @@ describe("pickRenderer", () => {
 describe("decodeText", () => {
   it("decodes base64 bytes to utf-8 text", () => {
     const b64 = btoa("# hello");
-    expect(decodeText({ id: "a", name: "a.md", mimeType: "text/markdown", bytes: b64 })).toBe(
-      "# hello",
-    );
+    expect(
+      decodeText({
+        id: "a",
+        revision: 0,
+        name: "a.md",
+        mimeType: "text/markdown",
+        bytes: b64,
+      }),
+    ).toBe("# hello");
   });
 
   it("returns null when there are no bytes", () => {
     expect(
-      decodeText({ id: "a", name: "a.md", mimeType: "text/markdown", url: "http://x" }),
+      decodeText({
+        id: "a",
+        revision: 0,
+        name: "a.md",
+        mimeType: "text/markdown",
+        url: "http://x",
+      }),
     ).toBeNull();
+  });
+});
+
+describe("pdf", () => {
+  it("routes a pdf to its own renderer, by mime or extension", () => {
+    expect(pickRenderer("application/pdf", "report.pdf")).toBe("pdf");
+    // Opened from the tree, where only the filename is known.
+    expect(pickRenderer("", "report.pdf")).toBe("pdf");
+  });
+
+  it("has no source toggle", () => {
+    expect(supportsPreview("pdf")).toBe(false);
   });
 });

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/artifact-viewer.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/artifact-viewer.tsx
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Braces,
   Code,
@@ -22,16 +22,30 @@ import {
   FileText,
   Globe,
   Image as ImageIcon,
+  FileType,
+  Lock,
   Music,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { resolveAnchor } from "@/lib/selection-anchor";
+import {
+  applyMarkdownCommand,
+  type MarkdownCommand,
+} from "@/lib/markdown-commands";
+import { MarkdownToolbar } from "./markdown-toolbar";
+import { useBusy } from "../busy-context";
 import { CopyButton } from "../copy-button";
+import { Textarea } from "@/components/ui/textarea";
 import { useViewer } from "./viewer-context";
 import {
   ArtifactBody,
   dataUrl,
   decodeText,
+  encodeText,
+  isLosslessText,
+  isTextKind,
   pickRenderer,
   supportsPreview,
   type RendererKind,
@@ -45,6 +59,7 @@ const KIND_ICON: Record<RendererKind, typeof FileText> = {
   audio: Music,
   html: Globe,
   json: Braces,
+  pdf: FileType,
   download: FileIcon,
 };
 
@@ -55,16 +70,245 @@ const TEXT_KINDS: ReadonlySet<RendererKind> = new Set([
   "html",
 ]);
 
-export function ArtifactViewer() {
-  const { tabs, activeId, activateTab, closeTab } = useViewer();
-  const [mode, setMode] = useState<ViewMode>("preview");
+// Long enough that a normal typing burst is one request, short enough that
+// closing the panel right after a sentence doesn't feel like a gamble.
+const AUTOSAVE_DEBOUNCE_MS = 800;
 
-  // A freshly-activated tab always opens in its rendered view.
-  useEffect(() => {
-    setMode("preview");
-  }, [activeId]);
+type SaveState = "idle" | "pending" | "saving" | "saved" | "error";
+
+export function ArtifactViewer() {
+  const {
+    tabs,
+    activeId,
+    activateTab,
+    closeTab,
+    reloadTab,
+    setBytes,
+    setPendingSelection,
+  } = useViewer();
+  const [mode, setMode] = useState<ViewMode>("preview");
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const busy = useBusy();
+  // Read from effects that must not re-run per tab-list change.
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
 
   const active = tabs.find((t) => t.id === activeId) ?? null;
+
+  // Tree-opened tabs arrive with a path but no bytes. Refetch on every
+  // revision bump too: the agent rewrites files behind our back, so cached
+  // bytes are only trustworthy until the next turn ends.
+  const activePath = active?.path;
+  const revision = active?.revision ?? 0;
+  // Set only once a response has actually been applied. Marking it when the
+  // request starts strands the tab under StrictMode: the first effect pass is
+  // cancelled by its own cleanup, and the second pass sees the key already
+  // recorded and returns without refetching.
+  const loadedKey = useRef<string | null>(null);
+  const fetchKey = activeId && activePath ? `${activeId}:${revision}` : null;
+  const hasBytes = active?.bytes != null;
+  // Deps are the fetch *target* only. Anything derived from lastFetched would
+  // flip false the moment the effect starts, and the next unrelated re-render
+  // (a turn ending re-renders this tree constantly) would tear down the
+  // in-flight request and drop its response.
+  useEffect(() => {
+    if (!activeId || !activePath || !fetchKey) return;
+    if (loadedKey.current === fetchKey) return;
+    const fileName = activePath.split("/").pop() || activePath;
+    let cancelled = false;
+    // Bytes handed to us at revision 0 are fresh by construction; only a bump
+    // (re-open, or a turn ending) means the copy we hold may be behind.
+    if (hasBytes && revision === 0) return;
+    void (async () => {
+      try {
+        const r = await fetch(
+          `/lha/workspace/download?path=${encodeURIComponent(activePath)}`,
+          { cache: "no-store" },
+        );
+        // The file is gone — renamed or deleted out from under us. Keeping
+        // the tab would show contents that no longer exist anywhere.
+        if (r.status === 404) {
+          if (!cancelled) closeTab(activeId);
+          return;
+        }
+        if (!r.ok) {
+          // Silence here meant the panel kept showing bytes that no longer
+          // matched disk, and the next keystroke saved them back over
+          // whatever had replaced them.
+          if (!cancelled) {
+            toast.error(`Couldn't refresh ${fileName}`, {
+              description: `The panel may be out of date (${r.status}).`,
+            });
+          }
+          return;
+        }
+        const buf = new Uint8Array(await r.arrayBuffer());
+        let bin = "";
+        for (const b of buf) bin += String.fromCharCode(b);
+        if (cancelled) return;
+        loadedKey.current = fetchKey;
+        setBytes(activeId, btoa(bin));
+      } catch (e) {
+        if (!cancelled) {
+          toast.error(`Couldn't refresh ${fileName}`, {
+            description: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // hasBytes/revision are read-through guards for the first run of a given
+    // fetchKey, which already encodes the revision.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId, activePath, fetchKey, setBytes, closeTab]);
+
+  // Autosave is fire-and-forget, so it can't close over render state: a tab
+  // switch or unmount has to be able to flush the last keystrokes after the
+  // component has already moved on. Everything it needs lives in this ref.
+  const pendingRef = useRef<{
+    id: string;
+    path: string;
+    name: string;
+    content: string;
+  } | null>(null);
+
+  const flush = useCallback(async () => {
+    const p = pendingRef.current;
+    if (!p) return;
+    pendingRef.current = null;
+    setSaveState("saving");
+    try {
+      const r = await fetch(
+        `/lha/workspace/file?path=${encodeURIComponent(p.path)}`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content: p.content }),
+        },
+      );
+      if (!r.ok) {
+        const detail = await r.text().catch(() => "");
+        // Put it back so the next debounce or tab switch retries it — but
+        // only if nothing newer arrived while the request was in flight,
+        // or this would resurrect stale text over the user's latest edit.
+        pendingRef.current ??= p;
+        setSaveState("error");
+        toast.error(`Couldn't save ${p.name} (${r.status})`, {
+          description: detail.slice(0, 200) || undefined,
+        });
+        return;
+      }
+      setBytes(p.id, encodeText(p.content));
+      // Drop the draft once it matches disk, so a later reload (the agent
+      // editing the same file) isn't masked by a stale local copy. Skipped
+      // if the user kept typing during the request — that draft is newer.
+      setDraft((d) => (d === p.content ? null : d));
+      setSaveState("saved");
+    } catch (e) {
+      pendingRef.current ??= p;
+      setSaveState("error");
+      toast.error(`Couldn't save ${p.name}`, {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [setBytes]);
+
+  // Debounced autosave. The cleanup cancels the timer on every keystroke and
+  // flushes on tab switch/unmount, so the trailing edit is never dropped.
+  useEffect(() => {
+    if (!pendingRef.current) return;
+    const t = setTimeout(() => void flush(), AUTOSAVE_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(t);
+    };
+  }, [draft, flush]);
+
+  // A freshly-activated tab opens in its rendered view. Flush first: the
+  // draft we're about to drop belongs to the tab we're leaving.
+  useEffect(() => {
+    return () => {
+      void flush();
+    };
+  }, [activeId, flush]);
+
+  // A turn starting beats the debounce to the punch — otherwise the pending
+  // write could land after the agent's own and clobber it.
+  useEffect(() => {
+    if (busy) void flush();
+  }, [busy, flush]);
+
+  // A turn ending is the one signal that the agent may have rewritten the
+  // open file. There's no file-changed event to subscribe to, so re-read it.
+  const wasBusy = useRef(busy);
+  useEffect(() => {
+    const ended = wasBusy.current && !busy;
+    wasBusy.current = busy;
+    if (!ended) return;
+    for (const t of tabsRef.current) {
+      if (t.path) reloadTab(t.id);
+    }
+  }, [busy, reloadTab]);
+
+  useEffect(() => {
+    setMode("preview");
+    setDraft(null);
+    setSaveState("idle");
+  }, [activeId]);
+
+  // Leaving the panel must not strand a chip pointing at a file you can no
+  // longer see.
+  useEffect(() => {
+    return () => setPendingSelection(null);
+  }, [setPendingSelection]);
+
+  // The native highlight vanishes when focus moves to the composer, so the
+  // captured anchor — surfaced as a chip — becomes the only remaining cue.
+  const handleSelect = (el: HTMLTextAreaElement) => {
+    if (!active?.path) return;
+    const { selectionStart, selectionEnd, value } = el;
+    if (selectionEnd <= selectionStart) {
+      setPendingSelection(null);
+      return;
+    }
+    const r = resolveAnchor(value, selectionStart, selectionEnd);
+    setPendingSelection(r.ok ? { path: active.path, anchor: r.anchor } : null);
+  };
+
+  // The command needs the live caret, which lives on the DOM node rather than
+  // in React state.
+  const editorRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const runCommand = (cmd: MarkdownCommand) => {
+    const el = editorRef.current;
+    if (!el || locked) return;
+    const next = applyMarkdownCommand(
+      { text: el.value, start: el.selectionStart, end: el.selectionEnd },
+      cmd,
+    );
+    setPendingSelection(null);
+    handleChange(next.text);
+    // React re-renders from `draft`, so the caret has to be restored after
+    // the new value lands or it snaps to the end of the document.
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(next.start, next.end);
+    });
+  };
+
+  const handleChange = (value: string) => {
+    if (!active?.path) return;
+    setDraft(value);
+    pendingRef.current = {
+      id: active.id,
+      path: active.path,
+      name: active.name,
+      content: value,
+    };
+    setSaveState("pending");
+  };
 
   if (!active) {
     return (
@@ -77,6 +321,28 @@ export function ArtifactViewer() {
   const kind = pickRenderer(active.mimeType, active.name);
   const canPreview = supportsPreview(kind);
   const copyable = TEXT_KINDS.has(kind);
+  // Only live workspace files are editable — artifact snapshots are frozen
+  // copies with nowhere to write back to. Source view is the editor for
+  // those, so there's no separate "edit" mode to toggle.
+  // Lossless, not merely decodable: saving a U+FFFD-mangled decode of a
+  // non-UTF-8 file would destroy the bytes it could not represent.
+  const editable =
+    Boolean(active.path) && isTextKind(kind) && isLosslessText(active);
+  const editing = mode === "raw" && editable;
+  // Autosave means an in-flight turn can't be allowed to overlap typing:
+  // the agent may rewrite the file under us and our next debounce would
+  // clobber it. Lock the textarea instead, and show why.
+  const locked = editing && busy;
+  // "source" is only worth a toggle when there's a rendered view to switch
+  // away from, or when it doubles as the editor.
+  const showModes = canPreview || editable;
+  const saveLabel: Record<SaveState, string | null> = {
+    idle: null,
+    pending: "Unsaved…",
+    saving: "Saving…",
+    saved: "Saved",
+    error: "Save failed",
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -127,26 +393,62 @@ export function ArtifactViewer() {
           {active.name}
         </span>
         <div className="flex shrink-0 items-center gap-1">
-          {canPreview && (
+          {showModes && (
             <div className="flex items-center rounded-md border border-border/60 p-0.5 text-[11px]">
               {(["preview", "raw"] as const).map((m) => (
                 <button
                   key={m}
                   type="button"
-                  onClick={() => setMode(m)}
+                  onClick={() => {
+                    // Not setDraft(null): the pending write would still land
+                    // 800ms later while both views showed the pre-edit bytes.
+                    void flush();
+                    setMode(m);
+                  }}
+                  title={
+                    m === "raw" && editable && busy
+                      ? "The agent is working — editing resumes when the turn ends"
+                      : undefined
+                  }
                   className={cn(
-                    "rounded px-2 py-0.5 capitalize transition-colors",
+                    "rounded px-2 py-0.5 transition-colors",
                     mode === m
                       ? "bg-muted text-foreground"
                       : "text-muted-foreground hover:text-foreground",
                   )}
                 >
-                  {m}
+                  {m === "raw" ? (editable ? "Source" : "Raw") : "Preview"}
                 </button>
               ))}
             </div>
           )}
-          {copyable && <CopyButton getText={() => decodeText(active) ?? ""} />}
+          {locked && (
+            <span
+              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground"
+              title="The agent may be rewriting this file — editing resumes when the turn ends"
+            >
+              <Lock className="h-3 w-3" />
+              Agent working
+            </span>
+          )}
+          {editing && !locked && saveLabel[saveState] && (
+            <span
+              className={cn(
+                "text-[11px]",
+                saveState === "error"
+                  ? "text-destructive"
+                  : "text-muted-foreground",
+              )}
+              aria-live="polite"
+            >
+              {saveLabel[saveState]}
+            </span>
+          )}
+          {copyable && (
+            // The draft is what the user is looking at; copying the saved
+            // bytes would silently hand back the pre-edit text.
+            <CopyButton getText={() => draft ?? decodeText(active) ?? ""} />
+          )}
           {(() => {
             const href = dataUrl(active);
             return (
@@ -165,12 +467,36 @@ export function ArtifactViewer() {
         </div>
       </div>
 
+      {/* Markdown only: bold and bullets are meaningless in a .py file. */}
+      {editing && kind === "markdown" && (
+        <MarkdownToolbar onCommand={runCommand} disabled={locked} />
+      )}
+
       <div className="min-h-0 flex-1 overflow-auto">
-        <ArtifactBody
-          tab={active}
-          kind={kind}
-          mode={canPreview ? mode : "preview"}
-        />
+        {editing ? (
+          <Textarea
+            ref={editorRef}
+            value={draft ?? decodeText(active) ?? ""}
+            onChange={(e) => {
+              // Offsets are meaningless the moment the text shifts.
+              setPendingSelection(null);
+              handleChange(e.target.value);
+            }}
+            onSelect={(e) => handleSelect(e.currentTarget)}
+            readOnly={locked}
+            spellCheck={false}
+            className={cn(
+              "h-full min-h-full resize-none rounded-none border-0 bg-transparent p-3 font-mono text-xs focus-visible:ring-0",
+              locked && "cursor-not-allowed opacity-60",
+            )}
+          />
+        ) : (
+          <ArtifactBody
+            tab={active}
+            kind={kind}
+            mode={canPreview || editable ? mode : "preview"}
+          />
+        )}
       </div>
     </div>
   );

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/auto-open-new-file.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/auto-open-new-file.tsx
@@ -1,0 +1,115 @@
+"use client";
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useRef, useState } from "react";
+import {
+  isAgentWorkingFile,
+  listWorkspaceFiles,
+  type WorkspaceFiles,
+} from "@/lib/workspace-files";
+import { useBusy } from "../busy-context";
+import { useViewer } from "./viewer-context";
+
+/**
+ * Opens the files a turn produced, so asking for a report doesn't also require
+ * hunting for it.
+ *
+ * One rule: at the end of a turn, open everything that appeared. Tabs are keyed
+ * by path, so a file that is already open is refreshed rather than duplicated,
+ * and the newest ends up in front. Detection is a listing diff rather than a
+ * scan for `write_file` calls, because a rename is `mv` in the terminal and
+ * produces no write tool call at all.
+ *
+ * One exception: agent working material (`plan.md`, `scripts/`, skills,
+ * dot-files) never opens. It is usually written last, so without this it would
+ * sit in front of the thing that was actually asked for.
+ *
+ * Renders nothing; it lives inside ViewerProvider because ChatShell creates
+ * that provider and so cannot call into it.
+ */
+export function AutoOpenNewFile() {
+  const busy = useBusy();
+  const { openArtifact } = useViewer();
+  const [pending, setPending] = useState<string[]>([]);
+
+  // The listing as of the last settled moment, diffed at the next turn end.
+  const knownRef = useRef<WorkspaceFiles | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void listWorkspaceFiles()
+      .then((m) => {
+        if (!cancelled && knownRef.current === null) knownRef.current = m;
+      })
+      // A transient tree failure must not become an unhandled rejection; the
+      // next turn end tries again.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const wasBusy = useRef(busy);
+  useEffect(() => {
+    const started = !wasBusy.current && busy;
+    const ended = wasBusy.current && !busy;
+    wasBusy.current = busy;
+
+    // Candidates belong to the turn that produced them.
+    if (started) setPending([]);
+    if (!ended) return;
+
+    let cancelled = false;
+    void listWorkspaceFiles()
+      .then((now) => {
+        if (cancelled) return;
+        const before = knownRef.current;
+        knownRef.current = now;
+        if (!before) return; // First listing still in flight; nothing to diff.
+
+        const candidates = [...now.entries()]
+          .filter(([path]) => !isAgentWorkingFile(path))
+          .filter(([path]) => !before.has(path))
+          // Oldest first: each open activates its tab, so the newest lands in
+          // front without needing to reorder afterwards.
+          .sort((a, b) => a[1] - b[1])
+          .map(([path]) => path);
+
+        if (candidates.length > 0) setPending(candidates);
+      })
+      // Leaving the baseline untouched is right: the next turn diffs against
+      // the last listing that actually arrived.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [busy]);
+
+  useEffect(() => {
+    if (pending.length === 0) return;
+    setPending([]);
+    for (const path of pending) {
+      openArtifact({
+        name: path.split("/").pop() || path,
+        // pickRenderer falls back to the extension, which is all a path tells
+        // us.
+        mimeType: "",
+        path,
+        url: `/lha/workspace/download?path=${encodeURIComponent(path)}&inline=1`,
+      });
+    }
+  }, [pending, openArtifact]);
+
+  return null;
+}

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/markdown-toolbar.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/markdown-toolbar.tsx
@@ -1,0 +1,107 @@
+"use client";
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Bold,
+  Code,
+  Heading1,
+  Heading2,
+  Heading3,
+  Italic,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  ListTodo,
+  Quote,
+  SquareCode,
+  Strikethrough,
+  Table as TableIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MarkdownCommand } from "@/lib/markdown-commands";
+
+interface Item {
+  cmd: MarkdownCommand;
+  label: string;
+  Icon: typeof Bold;
+}
+
+// Grouped the way a document toolbar reads: emphasis, structure, blocks.
+const GROUPS: Item[][] = [
+  [
+    { cmd: "bold", label: "Bold", Icon: Bold },
+    { cmd: "italic", label: "Italic", Icon: Italic },
+    { cmd: "strikethrough", label: "Strikethrough", Icon: Strikethrough },
+    { cmd: "code", label: "Inline code", Icon: Code },
+  ],
+  [
+    { cmd: "h1", label: "Heading 1", Icon: Heading1 },
+    { cmd: "h2", label: "Heading 2", Icon: Heading2 },
+    { cmd: "h3", label: "Heading 3", Icon: Heading3 },
+  ],
+  [
+    { cmd: "bullet", label: "Bullet list", Icon: List },
+    { cmd: "ordered", label: "Numbered list", Icon: ListOrdered },
+    { cmd: "task", label: "Task list", Icon: ListTodo },
+    { cmd: "quote", label: "Quote", Icon: Quote },
+  ],
+  [
+    { cmd: "link", label: "Link", Icon: LinkIcon },
+    { cmd: "codeblock", label: "Code block", Icon: SquareCode },
+    { cmd: "table", label: "Table", Icon: TableIcon },
+  ],
+];
+
+export function MarkdownToolbar({
+  onCommand,
+  disabled,
+}: {
+  onCommand: (cmd: MarkdownCommand) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      role="toolbar"
+      aria-label="Formatting"
+      className="flex shrink-0 flex-wrap items-center gap-0.5 border-b border-border/60 px-2 py-1"
+    >
+      {GROUPS.map((group, gi) => (
+        <div key={gi} className="flex items-center gap-0.5">
+          {gi > 0 && <span className="mx-1 h-4 w-px bg-border/60" />}
+          {group.map(({ cmd, label, Icon }) => (
+            <button
+              key={cmd}
+              type="button"
+              aria-label={label}
+              title={label}
+              disabled={disabled}
+              // The editor keeps its selection: without this the textarea
+              // blurs on mousedown and the command has nothing to act on.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onCommand(cmd)}
+              className={cn(
+                "inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors",
+                "hover:bg-muted hover:text-foreground",
+                "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent",
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/renderers.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/renderers.tsx
@@ -28,6 +28,7 @@ export type RendererKind =
   | "audio"
   | "html"
   | "json"
+  | "pdf"
   | "download";
 
 export type ViewMode = "preview" | "raw";
@@ -43,6 +44,7 @@ export function pickRenderer(mimeType: string, name: string): RendererKind {
   if (mime === "text/markdown" || n.endsWith(".md") || n.endsWith(".markdown"))
     return "markdown";
   if (mime.startsWith("image/") || IMG_EXT.test(n)) return "image";
+  if (mime === "application/pdf" || n.endsWith(".pdf")) return "pdf";
   if (mime.startsWith("audio/")) return "audio";
   if (mime === "text/html" || n.endsWith(".html") || n.endsWith(".htm"))
     return "html";
@@ -56,11 +58,43 @@ export function supportsPreview(kind: RendererKind): boolean {
   return kind === "markdown" || kind === "html";
 }
 
+// Kinds whose bytes are UTF-8 text, so they can be fetched into an editor.
+export function isTextKind(kind: RendererKind): boolean {
+  return (
+    kind === "markdown" || kind === "html" || kind === "json" || kind === "code"
+  );
+}
+
+export function encodeText(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
 function bytesToUint8(b64: string): Uint8Array {
   const bin = atob(b64);
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
   return out;
+}
+
+/**
+ * Whether the tab's bytes are valid UTF-8, i.e. whether decoding them is
+ * lossless. `decodeText` replaces invalid sequences with U+FFFD, so a latin-1
+ * `.csv` decodes "successfully" — and saving that decode back would destroy
+ * the original bytes.
+ */
+export function isLosslessText(tab: ArtifactTab): boolean {
+  if (tab.bytes == null) return false;
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(
+      bytesToUint8(tab.bytes) as BufferSource,
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function decodeText(tab: ArtifactTab): string | null {
@@ -96,8 +130,8 @@ function DownloadView({ tab }: { tab: ArtifactTab }) {
   return (
     <div className="flex flex-col items-center gap-3 px-3 py-10 text-center">
       <p className="text-sm text-muted-foreground">
-        <span className="font-mono text-foreground">{tab.name}</span> can&rsquo;t
-        be previewed.
+        <span className="font-mono text-foreground">{tab.name}</span>{" "}
+        can&rsquo;t be previewed.
       </p>
       {href && (
         <a
@@ -136,6 +170,17 @@ function AudioView({ tab }: { tab: ArtifactTab }) {
     <div className="flex items-center justify-center p-4">
       <audio controls src={src} className="w-full max-w-md" />
     </div>
+  );
+}
+
+function PdfView({ tab }: { tab: ArtifactTab }) {
+  // Needs a URL the browser can navigate to: the viewer is the platform's own
+  // PDF plugin, and a base64 data: URL is blocked for it in Chrome. The
+  // workspace route serves PDFs inline under `Content-Security-Policy:
+  // sandbox`, which is exactly what this needs.
+  if (!tab.url) return <DownloadView tab={tab} />;
+  return (
+    <iframe title={tab.name} src={tab.url} className="h-full w-full border-0" />
   );
 }
 
@@ -220,6 +265,8 @@ export function ArtifactBody({
       return <HtmlView tab={tab} mode={mode} />;
     case "image":
       return <ImageView tab={tab} />;
+    case "pdf":
+      return <PdfView tab={tab} />;
     case "audio":
       return <AudioView tab={tab} />;
     case "json":

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/viewer-context.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/viewer-context.tsx
@@ -15,6 +15,7 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -22,6 +23,7 @@ import {
   useRef,
   type ReactNode,
 } from "react";
+import type { SelectionAnchor } from "@/lib/selection-anchor";
 import {
   initialViewerState,
   viewerReducer,
@@ -29,10 +31,27 @@ import {
   type ArtifactTab,
 } from "./viewer-store";
 
+/**
+ * Text highlighted in the Source view, awaiting an instruction in the
+ * composer.
+ */
+export interface PendingSelection {
+  path: string;
+  anchor: SelectionAnchor;
+}
+
 interface ViewerContextValue {
   tabs: ArtifactTab[];
   activeId: string | null;
   openArtifact: (artifact: ArtifactInput) => void;
+  /**
+   * Write-only. Forwards to the provider's `onSelectionChange`; the state
+   * itself lives in ChatShell, which renders this provider and so cannot
+   * consume its context.
+   */
+  setPendingSelection: (s: PendingSelection | null) => void;
+  reloadTab: (id: string) => void;
+  setBytes: (id: string, bytes: string) => void;
   closeTab: (id: string) => void;
   activateTab: (id: string) => void;
   clear: () => void;
@@ -46,32 +65,77 @@ export function ViewerProvider({
   children,
   resetKey,
   onOpen,
+  onSelectionChange,
 }: {
   children: ReactNode;
   resetKey?: string | null;
   onOpen?: () => void;
+  onSelectionChange?: (s: PendingSelection | null) => void;
 }) {
   const [state, dispatch] = useReducer(viewerReducer, initialViewerState);
   const onOpenRef = useRef(onOpen);
   onOpenRef.current = onOpen;
+  const onSelectionRef = useRef(onSelectionChange);
+  onSelectionRef.current = onSelectionChange;
 
   useEffect(() => {
     dispatch({ type: "clear" });
+    // A selection scoped to the old chat's file must not leak into the next.
+    onSelectionRef.current?.(null);
   }, [resetKey]);
+
+  // dispatch is stable, so these are too. Consumers depend on them from
+  // effects (autosave flushes on tab switch) — rebuilding them inside the
+  // useMemo would give every viewer state change a new identity and fire
+  // those effects spuriously.
+  const openArtifact = useCallback((artifact: ArtifactInput) => {
+    dispatch({ type: "open", artifact });
+    onOpenRef.current?.();
+  }, []);
+  const setPendingSelection = useCallback(
+    (s: PendingSelection | null) => onSelectionRef.current?.(s),
+    [],
+  );
+  const reloadTab = useCallback(
+    (id: string) => dispatch({ type: "reload", id }),
+    [],
+  );
+  const setBytes = useCallback(
+    (id: string, bytes: string) => dispatch({ type: "setBytes", id, bytes }),
+    [],
+  );
+  const closeTab = useCallback(
+    (id: string) => dispatch({ type: "close", id }),
+    [],
+  );
+  const activateTab = useCallback(
+    (id: string) => dispatch({ type: "activate", id }),
+    [],
+  );
+  const clear = useCallback(() => dispatch({ type: "clear" }), []);
 
   const value = useMemo<ViewerContextValue>(
     () => ({
       tabs: state.tabs,
       activeId: state.activeId,
-      openArtifact: (artifact) => {
-        dispatch({ type: "open", artifact });
-        onOpenRef.current?.();
-      },
-      closeTab: (id) => dispatch({ type: "close", id }),
-      activateTab: (id) => dispatch({ type: "activate", id }),
-      clear: () => dispatch({ type: "clear" }),
+      openArtifact,
+      setPendingSelection,
+      reloadTab,
+      setBytes,
+      closeTab,
+      activateTab,
+      clear,
     }),
-    [state],
+    [
+      state,
+      openArtifact,
+      setPendingSelection,
+      reloadTab,
+      setBytes,
+      closeTab,
+      activateTab,
+      clear,
+    ],
   );
 
   return (

--- a/core/python/long-horizon-harness/web/components/chat/artifact-viewer/viewer-store.ts
+++ b/core/python/long-horizon-harness/web/components/chat/artifact-viewer/viewer-store.ts
@@ -19,10 +19,22 @@ export interface ArtifactInput {
   bytes?: string;
   /** signed/download URL, when the artifact is fetched. */
   url?: string;
+  /**
+   * ``/workspace/...`` path when the tab points at a live workspace file
+   * (opened from the sidebar tree) rather than a frozen artifact snapshot.
+   * Only these tabs are editable.
+   */
+  path?: string;
 }
 
 export interface ArtifactTab extends ArtifactInput {
   id: string;
+  /**
+   * Bumped whenever the tab's contents may be stale (re-opened, or a turn
+   * just ended). The viewer refetches a workspace file when this changes —
+   * bytes alone can't tell us the agent rewrote the file underneath us.
+   */
+  revision: number;
 }
 
 export interface ViewerState {
@@ -35,11 +47,16 @@ export const initialViewerState: ViewerState = { tabs: [], activeId: null };
 // Identity is content-shaped so re-opening the same artifact activates the
 // existing tab instead of stacking duplicates.
 export function tabId(a: ArtifactInput): string {
+  // A workspace file is identified by path alone: its bytes change on every
+  // save, and a content-shaped id would stack a new tab per edit.
+  if (a.path) return `ws:${a.path}`;
   return `${a.name}|${a.mimeType}|${a.bytes?.length ?? 0}|${a.url ?? ""}`;
 }
 
 export type ViewerAction =
   | { type: "open"; artifact: ArtifactInput }
+  | { type: "reload"; id: string }
+  | { type: "setBytes"; id: string; bytes: string }
   | { type: "close"; id: string }
   | { type: "activate"; id: string }
   | { type: "clear" };
@@ -52,10 +69,26 @@ export function viewerReducer(
     case "open": {
       const id = tabId(action.artifact);
       const exists = state.tabs.some((t) => t.id === id);
+      // Re-opening an already-open file is the user asking for it again —
+      // usually because they expect it to have changed.
       const tabs = exists
-        ? state.tabs
-        : [...state.tabs, { id, ...action.artifact }];
+        ? state.tabs.map((t) =>
+            t.id === id ? { ...t, revision: t.revision + 1 } : t,
+          )
+        : [...state.tabs, { id, revision: 0, ...action.artifact }];
       return { tabs, activeId: id };
+    }
+    case "reload": {
+      const tabs = state.tabs.map((t) =>
+        t.id === action.id ? { ...t, revision: t.revision + 1 } : t,
+      );
+      return { ...state, tabs };
+    }
+    case "setBytes": {
+      const tabs = state.tabs.map((t) =>
+        t.id === action.id ? { ...t, bytes: action.bytes } : t,
+      );
+      return { ...state, tabs };
     }
     case "close": {
       const idx = state.tabs.findIndex((t) => t.id === action.id);

--- a/core/python/long-horizon-harness/web/components/chat/chat-shell.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/chat-shell.tsx
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import {
   type DragEvent,
   useCallback,
@@ -38,7 +37,23 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable";
 import { ArtifactViewer } from "./artifact-viewer/artifact-viewer";
-import { ViewerProvider } from "./artifact-viewer/viewer-context";
+import { AutoOpenNewFile } from "./artifact-viewer/auto-open-new-file";
+import {
+  ViewerProvider,
+  type PendingSelection,
+} from "./artifact-viewer/viewer-context";
+import { anchorLabel } from "@/lib/selection-anchor";
+import type { Part } from "@a2a-js/sdk";
+import { dataPartDict, makeDataPart } from "@/lib/a2a-part";
+import {
+  FILEREF_DATA_KIND,
+  SELECTION_DATA_KIND,
+  isFileRefPayload,
+  isSelectionPayload,
+  type FileRef,
+  type FileRefPayload,
+  type SelectionPayload,
+} from "./workspace-href";
 import { useMediaQuery } from "@/lib/use-media-query";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import type { UploadResult } from "./sidebar-dropzone";
@@ -55,7 +70,13 @@ import { SandboxWarmupBanner } from "./sandbox-warmup-banner";
 import { SessionLostBanner } from "./session-lost-banner";
 import { isTransportError } from "@/lib/is-transport-error";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import {
   Brain,
   CalendarClock,
@@ -137,7 +158,10 @@ export type MessageSegment =
       kind: "confirmation";
       callId: string | null;
       hint: string;
-      originalCall: { name: string; args: Record<string, unknown> | null } | null;
+      originalCall: {
+        name: string;
+        args: Record<string, unknown> | null;
+      } | null;
       payload: Record<string, unknown> | null;
       answer?: { confirmed: boolean; text: string | null };
     }
@@ -215,6 +239,25 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
   // message as a `[Uploaded to /workspace: ...]` prefix so the agent sees the
   // new files on its next turn.
   const [pendingUploadNames, setPendingUploadNames] = useState<string[]>([]);
+  // Text highlighted in the artifact panel, prepended to the next message as
+  // an `[Editing …]` block so the agent can resolve it with `patch`. Owned
+  // here because this component renders ViewerProvider and so can't read its
+  // context; the viewer reports upward via onSelectionChange.
+  const [pendingSelection, setPendingSelection] =
+    useState<PendingSelection | null>(null);
+  // Set when the panel's Export starts a turn, so its result claims the panel
+  // rather than waiting for an empty slot. Cleared once that turn is over.
+  // Workspace files dragged onto the composer. Paths only — the bytes are
+  // already on disk, so an upload would duplicate them.
+  const [fileRefs, setFileRefs] = useState<FileRef[]>([]);
+  const addFileRef = useCallback((ref: FileRef) => {
+    setFileRefs((prev) =>
+      prev.some((r) => r.path === ref.path) ? prev : [...prev, ref],
+    );
+  }, []);
+  const removeFileRef = useCallback((path: string) => {
+    setFileRefs((prev) => prev.filter((r) => r.path !== path));
+  }, []);
   const [recentUploads, setRecentUploads] = useState<RecentUpload[]>([]);
   const [workspaceVersion, setWorkspaceVersion] = useState(0);
   const [optimisticRows, setOptimisticRows] = useState<OptimisticRow[]>([]);
@@ -225,7 +268,11 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
   const dragDepthRef = useRef(0);
 
   const navigate = useNavigate();
-  const { data: sessions, isLoading: sessionsLoading, refresh: refreshSessions } = useLhaSessions();
+  const {
+    data: sessions,
+    isLoading: sessionsLoading,
+    refresh: refreshSessions,
+  } = useLhaSessions();
   const { data: sandboxStatus } = useSandboxStatus();
 
   const {
@@ -339,8 +386,16 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
   const confirmationSender = useCallback(
     (
       req:
-        | { callId: string | null; confirmed: boolean; payload: Record<string, unknown> | null }
-        | { callId: string | null; confirmed: boolean; payload: Record<string, unknown> | null }[],
+        | {
+            callId: string | null;
+            confirmed: boolean;
+            payload: Record<string, unknown> | null;
+          }
+        | {
+            callId: string | null;
+            confirmed: boolean;
+            payload: Record<string, unknown> | null;
+          }[],
     ) => {
       void confirm(req);
     },
@@ -475,7 +530,8 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
       // the Escape first — otherwise one keystroke would close the dialog and
       // clear find together.
       if (e.key === "Escape" && findOpenRef.current) {
-        if (document.querySelector('[role="dialog"][data-state="open"]')) return;
+        if (document.querySelector('[role="dialog"][data-state="open"]'))
+          return;
         e.preventDefault();
         setFindOpen(false);
         setFindHighlightId(null);
@@ -587,8 +643,38 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
 
   const handleSend = useCallback(
     (text: string) => {
+      // Built before the busy check so a message queued mid-turn keeps its
+      // selection and file references; flushing text alone would send the
+      // instruction without the span it refers to.
+      const queuedParts: Part[] = [];
+      if (fileRefs.length > 0) {
+        queuedParts.push(
+          makeDataPart({
+            lha_kind: FILEREF_DATA_KIND,
+            paths: fileRefs.map((r) => r.path),
+          } satisfies FileRefPayload),
+        );
+      }
+      if (pendingSelection) {
+        const a = pendingSelection.anchor;
+        queuedParts.push(
+          makeDataPart({
+            lha_kind: SELECTION_DATA_KIND,
+            path: pendingSelection.path,
+            start: a.start,
+            end: a.end,
+            start_line: a.startLine,
+            end_line: a.endLine,
+            snippet: a.snippet,
+          } satisfies SelectionPayload),
+        );
+      }
       if (turnActive) {
-        enqueue(text);
+        enqueue(text, queuedParts);
+        if (queuedParts.length > 0) {
+          setFileRefs([]);
+          setPendingSelection(null);
+        }
         return;
       }
       const sending = attachments;
@@ -600,6 +686,9 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
         outgoing = text.trim() ? `${prefix}\n\n${text}` : prefix;
         setPendingUploadNames([]);
       }
+      if (fileRefs.length > 0) setFileRefs([]);
+      if (pendingSelection) setPendingSelection(null);
+      const outgoingParts = queuedParts;
       // A project-chat seeds its workspace_window before the first turn so the
       // agent's file ops default into /workspace/<project>. Best-effort: a seed
       // failure must never swallow the user's message.
@@ -608,10 +697,16 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
         cid && messages.length === 0 ? takePendingWindow(cid) : undefined;
       if (cid && dirs && dirs.length > 0) {
         void setChatWindow(cid, dirs).finally(() =>
-          send(outgoing, { attachments: sending }),
+          send(outgoing, {
+            attachments: sending,
+            extraParts: outgoingParts.length > 0 ? outgoingParts : undefined,
+          }),
         );
       } else {
-        void send(outgoing, { attachments: sending });
+        void send(outgoing, {
+          attachments: sending,
+          extraParts: outgoingParts.length > 0 ? outgoingParts : undefined,
+        });
       }
     },
     [
@@ -619,6 +714,8 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
       enqueue,
       attachments,
       pendingUploadNames,
+      pendingSelection,
+      fileRefs,
       send,
       client,
       messages.length,
@@ -627,8 +724,42 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
 
   const handleStop = useCallback(() => {
     setDraft((d) =>
-      [d, ...queue].map((s) => s.trim()).filter(Boolean).join("\n\n"),
+      [d, ...queue.map((q) => q.text)]
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join("\n\n"),
     );
+    // The chips were cleared when these were queued, so without this the text
+    // comes back to the composer and its selection or file references are
+    // gone — the next send would carry the instruction and nothing to apply
+    // it to.
+    const queuedPayloads = queue
+      .flatMap((q) => q.parts)
+      .map((p): unknown => dataPartDict(p))
+      .filter((d) => d !== null);
+    const restoredRefs = queuedPayloads
+      .filter(isFileRefPayload)
+      .flatMap((d) => d.paths)
+      .map((path) => ({ path, name: path.split("/").pop() || path }));
+    if (restoredRefs.length > 0) {
+      setFileRefs((prev) => {
+        const seen = new Set(prev.map((r) => r.path));
+        return [...prev, ...restoredRefs.filter((r) => !seen.has(r.path))];
+      });
+    }
+    const restoredSelection = queuedPayloads.filter(isSelectionPayload).pop();
+    if (restoredSelection) {
+      setPendingSelection({
+        path: restoredSelection.path,
+        anchor: {
+          start: restoredSelection.start,
+          end: restoredSelection.end,
+          startLine: restoredSelection.start_line,
+          endLine: restoredSelection.end_line,
+          snippet: restoredSelection.snippet,
+        },
+      });
+    }
     clearQueue();
     // onStop cancels via the live send's own task id, which a reattached turn
     // doesn't have — cancel that one by id instead.
@@ -732,7 +863,10 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
     if (bootError || sessionLost)
       return { dot: "destructive" as const, label: "disconnected" };
     if (!client || historyLoading)
-      return { dot: "muted" as const, label: historyLoading ? "loading" : "connecting" };
+      return {
+        dot: "muted" as const,
+        label: historyLoading ? "loading" : "connecting",
+      };
     if (busy) return { dot: "primary" as const, label: "thinking" };
     // A turn reattached after a reopen is still running even though this tab
     // never sent it, so `busy` is false. Lags a completing turn by one poll.
@@ -754,8 +888,14 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
   const handleExport = useCallback(
     (format: "markdown" | "json") => {
       if (messages.length === 0) return;
-      downloadConversation(messages, activeSession?.title ?? "conversation", format);
-      notify.success(`Exported as ${format === "markdown" ? "Markdown" : "JSON"}`);
+      downloadConversation(
+        messages,
+        activeSession?.title ?? "conversation",
+        format,
+      );
+      notify.success(
+        `Exported as ${format === "markdown" ? "Markdown" : "JSON"}`,
+      );
     },
     [messages, activeSession],
   );
@@ -769,6 +909,12 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
       navigate({ to: "/" });
     },
   });
+
+  // The panel's Export action. A short text keeps the bubble readable; the
+  // DataPart carries the instruction, so none of it lands in the transcript.
+  const selectionChip = pendingSelection
+    ? { label: anchorLabel(pendingSelection.anchor.snippet) }
+    : null;
 
   const rightPaneHeader = (
     // Clears the Sheet's own absolute close button on mobile.
@@ -826,358 +972,419 @@ export function ChatShell({ contextId: contextIdProp }: ChatShellProps = {}) {
 
   return (
     <NowProvider>
-    <ImageLightboxProvider>
-    <ViewerProvider resetKey={contextId} onOpen={handleArtifactOpen}>
-    <div className="flex h-dvh flex-row overflow-hidden bg-background">
-      <ResizablePanelGroup
-        direction="horizontal"
-        autoSaveId="lha.layout"
-        className="flex-1"
-      >
-        {isDesktop && (
-          <>
-            <ResizablePanel
-              id="left"
-              order={1}
-              defaultSize={18}
-              minSize={14}
-              maxSize={30}
-              className="flex flex-col border-r bg-card/30"
-            >
-        <ChatListSidebar
-          activeContextId={activeContextId}
-          sessions={sessions}
-          sessionsLoading={sessionsLoading}
-          refreshSessions={refreshSessions}
-          onNewChat={onNewChat}
-          onPrefetch={handlePrefetchChat}
-          recentUploads={recentUploads}
-          optimisticRows={optimisticRows}
-          workspaceVersion={workspaceVersion}
-          onUploadComplete={handleUploadComplete}
-          onWorkspaceChanged={handleWorkspaceChanged}
-          onReconciled={handleReconciled}
-          onClearRecent={handleClearRecent}
-          onDeleteWorkspaceFile={handleDeleteWorkspaceFile}
-        />
-            </ResizablePanel>
-            <ResizableHandle withHandle />
-          </>
-        )}
-
-        <ResizablePanel
-          id="center"
-          order={2}
-          minSize={30}
-          className="flex min-h-0 min-w-0 flex-col"
+      <ImageLightboxProvider>
+        <ViewerProvider
+          resetKey={contextId}
+          onOpen={handleArtifactOpen}
+          onSelectionChange={setPendingSelection}
         >
-          {/* min-h-0 all the way down so the message list (not the column) is
+          {/* Hoisted above the layout so the artifact viewer can disable editing
+        mid-turn, not just the message list's resend/edit buttons. */}
+          <BusyProvider value={turnActive}>
+            <AutoOpenNewFile />
+            <div className="flex h-dvh flex-row overflow-hidden bg-background">
+              <ResizablePanelGroup
+                direction="horizontal"
+                autoSaveId="lha.layout"
+                className="flex-1"
+              >
+                {isDesktop && (
+                  <>
+                    <ResizablePanel
+                      id="left"
+                      order={1}
+                      defaultSize={18}
+                      minSize={14}
+                      maxSize={30}
+                      className="flex flex-col border-r bg-card/30"
+                    >
+                      <ChatListSidebar
+                        activeContextId={activeContextId}
+                        sessions={sessions}
+                        sessionsLoading={sessionsLoading}
+                        refreshSessions={refreshSessions}
+                        onNewChat={onNewChat}
+                        onPrefetch={handlePrefetchChat}
+                        recentUploads={recentUploads}
+                        optimisticRows={optimisticRows}
+                        workspaceVersion={workspaceVersion}
+                        onUploadComplete={handleUploadComplete}
+                        onWorkspaceChanged={handleWorkspaceChanged}
+                        onReconciled={handleReconciled}
+                        onClearRecent={handleClearRecent}
+                        onDeleteWorkspaceFile={handleDeleteWorkspaceFile}
+                      />
+                    </ResizablePanel>
+                    <ResizableHandle withHandle />
+                  </>
+                )}
+
+                <ResizablePanel
+                  id="center"
+                  order={2}
+                  minSize={30}
+                  className="flex min-h-0 min-w-0 flex-col"
+                >
+                  {/* min-h-0 all the way down so the message list (not the column) is
               the thing that scrolls, keeping the composer anchored. */}
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <header className="group/header flex h-12 shrink-0 items-center justify-between gap-2 border-b px-4">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-              <SheetTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 md:hidden"
-                >
-                  <PanelLeft className="h-4 w-4" />
-                  <span className="sr-only">Chat history</span>
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="left" className="w-72 p-0">
-                <SheetHeader className="sr-only">
-                  <SheetTitle>Chats</SheetTitle>
-                </SheetHeader>
-                {sidebarOpen && (
-                  <ChatListSidebar
-                    activeContextId={activeContextId}
-                    sessions={sessions}
-                    sessionsLoading={sessionsLoading}
-                    refreshSessions={refreshSessions}
-                    onNewChat={onNewChat}
-                    onNavigate={() => setSidebarOpen(false)}
-                    onPrefetch={handlePrefetchChat}
-                    reserveHeaderRight
-                    recentUploads={recentUploads}
-                    optimisticRows={optimisticRows}
-                    workspaceVersion={workspaceVersion}
-                    onUploadComplete={handleUploadComplete}
-                    onWorkspaceChanged={handleWorkspaceChanged}
-                    onReconciled={handleReconciled}
-                    onClearRecent={handleClearRecent}
-                    onDeleteWorkspaceFile={handleDeleteWorkspaceFile}
-                  />
-                )}
-              </SheetContent>
-            </Sheet>
-            <Wordmark label="Long Horizon Harness" className="min-w-0 truncate text-base font-semibold tracking-tight" />
-            {activeSession && (
-              <>
-                <span aria-hidden className="shrink-0 text-muted-foreground/40">
-                  ·
-                </span>
-                {headerControls.editing ? (
-                  <ChatTitleInput
-                    controls={headerControls}
-                    className="h-7 max-w-[40ch] px-1.5 py-0 text-sm"
-                  />
-                ) : (
-                  <span
-                    className="min-w-0 truncate text-sm text-foreground/90"
-                    title={activeSession.title}
-                  >
-                    {activeSession.title}
-                  </span>
-                )}
-                <div className="pointer-events-none flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/header:pointer-events-auto group-hover/header:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 max-md:pointer-events-auto max-md:opacity-100">
-                  <ChatActionButtons
-                    title={activeSession.title}
-                    controls={headerControls}
-                  />
-                </div>
-              </>
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {sandboxStatus?.user_id && (
-              <span
-                title={`signed in as ${sandboxStatus.user_id}`}
-                className="hidden max-w-[24ch] truncate rounded-full border border-border/40 bg-muted/40 px-2 py-0.5 font-mono text-[10px] text-muted-foreground sm:inline-block"
-              >
-                {sandboxStatus.user_id}
-              </span>
-            )}
-            <span
-              role="status"
-              aria-live="polite"
-              aria-label={`agent ${status.label}`}
-              className="flex items-center gap-1.5 text-[11px] text-muted-foreground"
-            >
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "h-1.5 w-1.5 rounded-full",
-                  status.dot === "destructive" && "bg-destructive",
-                  status.dot === "muted" &&
-                    "bg-muted-foreground/60 motion-safe:animate-pulse",
-                  status.dot === "primary" && "bg-primary motion-safe:animate-pulse",
-                  status.dot === "ready" && "bg-emerald-500",
-                )}
-              />
-              {status.label}
-            </span>
-            {isDesktop && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-10 w-10"
-                onClick={toggleRightPanel}
-                aria-label={rightCollapsed ? "Show panel" : "Hide panel"}
-                title={rightCollapsed ? "Show panel" : "Hide panel"}
-              >
-                {rightCollapsed ? (
-                  <PanelRightOpen className="h-4 w-4" />
-                ) : (
-                  <PanelRightClose className="h-4 w-4" />
-                )}
-              </Button>
-            )}
-            <Sheet
-              open={!isDesktop && panelsOpen}
-              onOpenChange={setPanelsOpen}
-            >
-              <SheetTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 md:hidden"
-                >
-                  <PanelRight className="h-4 w-4" />
-                  <span className="sr-only">Session panels</span>
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="right" className="flex max-w-sm flex-col p-0">
-                <SheetHeader className="sr-only">
-                  <SheetTitle>Session</SheetTitle>
-                </SheetHeader>
-                {panelsOpen && rightPane}
-              </SheetContent>
-            </Sheet>
-          </div>
-        </header>
+                  <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                    <header className="group/header flex h-12 shrink-0 items-center justify-between gap-2 border-b px-4">
+                      <div className="flex min-w-0 flex-1 items-center gap-2">
+                        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+                          <SheetTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-10 w-10 md:hidden"
+                            >
+                              <PanelLeft className="h-4 w-4" />
+                              <span className="sr-only">Chat history</span>
+                            </Button>
+                          </SheetTrigger>
+                          <SheetContent side="left" className="w-72 p-0">
+                            <SheetHeader className="sr-only">
+                              <SheetTitle>Chats</SheetTitle>
+                            </SheetHeader>
+                            {sidebarOpen && (
+                              <ChatListSidebar
+                                activeContextId={activeContextId}
+                                sessions={sessions}
+                                sessionsLoading={sessionsLoading}
+                                refreshSessions={refreshSessions}
+                                onNewChat={onNewChat}
+                                onNavigate={() => setSidebarOpen(false)}
+                                onPrefetch={handlePrefetchChat}
+                                reserveHeaderRight
+                                recentUploads={recentUploads}
+                                optimisticRows={optimisticRows}
+                                workspaceVersion={workspaceVersion}
+                                onUploadComplete={handleUploadComplete}
+                                onWorkspaceChanged={handleWorkspaceChanged}
+                                onReconciled={handleReconciled}
+                                onClearRecent={handleClearRecent}
+                                onDeleteWorkspaceFile={
+                                  handleDeleteWorkspaceFile
+                                }
+                              />
+                            )}
+                          </SheetContent>
+                        </Sheet>
+                        <Wordmark
+                          label="Long Horizon Harness"
+                          className="min-w-0 truncate text-base font-semibold tracking-tight"
+                        />
+                        {activeSession && (
+                          <>
+                            <span
+                              aria-hidden
+                              className="shrink-0 text-muted-foreground/40"
+                            >
+                              ·
+                            </span>
+                            {headerControls.editing ? (
+                              <ChatTitleInput
+                                controls={headerControls}
+                                className="h-7 max-w-[40ch] px-1.5 py-0 text-sm"
+                              />
+                            ) : (
+                              <span
+                                className="min-w-0 truncate text-sm text-foreground/90"
+                                title={activeSession.title}
+                              >
+                                {activeSession.title}
+                              </span>
+                            )}
+                            <div className="pointer-events-none flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/header:pointer-events-auto group-hover/header:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 max-md:pointer-events-auto max-md:opacity-100">
+                              <ChatActionButtons
+                                title={activeSession.title}
+                                controls={headerControls}
+                              />
+                            </div>
+                          </>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        {sandboxStatus?.user_id && (
+                          <span
+                            title={`signed in as ${sandboxStatus.user_id}`}
+                            className="hidden max-w-[24ch] truncate rounded-full border border-border/40 bg-muted/40 px-2 py-0.5 font-mono text-[10px] text-muted-foreground sm:inline-block"
+                          >
+                            {sandboxStatus.user_id}
+                          </span>
+                        )}
+                        <span
+                          role="status"
+                          aria-live="polite"
+                          aria-label={`agent ${status.label}`}
+                          className="flex items-center gap-1.5 text-[11px] text-muted-foreground"
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={cn(
+                              "h-1.5 w-1.5 rounded-full",
+                              status.dot === "destructive" && "bg-destructive",
+                              status.dot === "muted" &&
+                                "bg-muted-foreground/60 motion-safe:animate-pulse",
+                              status.dot === "primary" &&
+                                "bg-primary motion-safe:animate-pulse",
+                              status.dot === "ready" && "bg-emerald-500",
+                            )}
+                          />
+                          {status.label}
+                        </span>
+                        {isDesktop && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-10 w-10"
+                            onClick={toggleRightPanel}
+                            aria-label={
+                              rightCollapsed ? "Show panel" : "Hide panel"
+                            }
+                            title={rightCollapsed ? "Show panel" : "Hide panel"}
+                          >
+                            {rightCollapsed ? (
+                              <PanelRightOpen className="h-4 w-4" />
+                            ) : (
+                              <PanelRightClose className="h-4 w-4" />
+                            )}
+                          </Button>
+                        )}
+                        <Sheet
+                          open={!isDesktop && panelsOpen}
+                          onOpenChange={setPanelsOpen}
+                        >
+                          <SheetTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-10 w-10 md:hidden"
+                            >
+                              <PanelRight className="h-4 w-4" />
+                              <span className="sr-only">Session panels</span>
+                            </Button>
+                          </SheetTrigger>
+                          <SheetContent
+                            side="right"
+                            className="flex max-w-sm flex-col p-0"
+                          >
+                            <SheetHeader className="sr-only">
+                              <SheetTitle>Session</SheetTitle>
+                            </SheetHeader>
+                            {panelsOpen && rightPane}
+                          </SheetContent>
+                        </Sheet>
+                      </div>
+                    </header>
 
-        <ChatDeleteError error={headerControls.deleteError} className="mx-4 mt-1" />
-
-        {sessionLost && <SessionLostBanner />}
-        <GuardrailBanner contextId={contextId} bootError={bootError} />
-
-        <main
-          onDragEnter={onDragEnter}
-          onDragLeave={onDragLeave}
-          onDragOver={onDragOver}
-          onDrop={onDrop}
-          className="relative flex min-h-0 flex-1 flex-col"
-        >
-          {dragOver && (
-            <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-primary/10 text-sm font-medium text-primary ring-2 ring-inset ring-primary">
-              Drop files to attach
-            </div>
-          )}
-          {showWelcome ? (
-            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4">
-              <div className="flex flex-1 flex-col items-center justify-start pt-6 md:pt-24">
-                <div className="w-full max-w-2xl">
-                  <div className="text-center">
-                    {sandboxStatus?.user_id && (
-                      <p className="mb-3 text-lg text-muted-foreground md:text-xl">
-                        Hi, <span className="font-medium text-foreground">{sandboxStatus.user_id.split("@")[0]}</span>
-                      </p>
-                    )}
-                    <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">
-                      <Wordmark label="Long Horizon Harness" />
-                    </h1>
-                    <p className="mx-auto mt-4 max-w-xl text-base text-muted-foreground md:text-lg">
-                      A long-horizon agent that runs in a sandbox and gets better
-                      at its work over time.
-                    </p>
-                  </div>
-                  <div className="mt-6">
-                    <StatusStrip contextId={contextId} />
-                    <AuthCard contextId={contextId} className="mb-2" />
-                    <SandboxWarmupBanner
-                      status={sandboxStatus}
-                      className="mb-2"
+                    <ChatDeleteError
+                      error={headerControls.deleteError}
+                      className="mx-4 mt-1"
                     />
-                    <InputBox
-                      onSend={handleSend}
-                      onStop={handleStop}
-                      value={draft}
-                      onValueChange={onDraftChange}
-                      queued={queue}
-                      onRemoveQueued={removeQueued}
-                      disabled={!client}
-                      busy={turnActive}
-                      attachments={attachments}
-                      onAddFiles={addFiles}
-                      onRemoveAttachment={removeAttachment}
-                      attachmentError={attachmentError}
-                      hasPendingPrefix={pendingUploadNames.length > 0}
-                    />
-                  </div>
-                  <PromptChips
-                    onSend={handleSend}
-                    disabled={!client || busy}
-                  />
-                  <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
-                    <div className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-card/40 px-3 py-1 text-xs text-muted-foreground">
-                      <Sparkles className="h-3.5 w-3.5 text-primary/70" />
-                      Built with <span className="font-mono text-foreground/80">agents-cli</span>
-                    </div>
-                    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70">
-                      Press{" "}
-                      <kbd className="rounded border bg-muted/40 px-1 font-mono text-[10px] text-muted-foreground">
-                        ⌘K
-                      </kbd>{" "}
-                      for shortcuts
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <>
-              {findOpen && (
-                <FindBar
-                  messages={messages}
-                  onClose={handleFindClose}
-                  onActiveMatchChange={handleFindActiveMatch}
-                  focusSignal={findFocusSignal}
-                />
-              )}
-              <BusyProvider value={turnActive}>
-                <ConfirmationProvider sender={confirmationSender}>
-                  <MessageList
-                    messages={messages}
-                    contextId={contextId}
-                    onResend={resend}
-                    onEdit={editAndResend}
-                    highlightId={findHighlightId}
-                  />
-                </ConfirmationProvider>
-              </BusyProvider>
-              <StatusStrip contextId={contextId} />
-              <AuthCard contextId={contextId} className="mx-4 mb-2" />
-              <SandboxWarmupBanner
-                status={sandboxStatus}
-                warmError={warmError}
-                className="mx-4 mb-2"
-              />
-              <DormantActionsGate
-                lastUpdated={activeSession?.lastUpdated ?? null}
-                show={messages.length > 0 && !busy && !dormantActionsDismissed}
-                disabled={!client || busy}
-                onAction={(prompt) => {
-                  handleSend(prompt);
-                  setDormantActionsDismissed(true);
-                }}
-              />
-              <InputBox
-                onSend={handleSend}
-                onStop={handleStop}
-                value={draft}
-                onValueChange={onDraftChange}
-                queued={queue}
-                onRemoveQueued={removeQueued}
-                disabled={!client}
-                busy={turnActive}
-                attachments={attachments}
-                onAddFiles={addFiles}
-                onRemoveAttachment={removeAttachment}
-                attachmentError={attachmentError}
-                hasPendingPrefix={pendingUploadNames.length > 0}
-              />
-            </>
-          )}
-        </main>
-          </div>
-        </ResizablePanel>
 
-        {isDesktop && (
-          <>
-            <ResizableHandle withHandle />
-            <ResizablePanel
-              id="right"
-              order={3}
-              ref={rightPanelRef}
-              defaultSize={26}
-              minSize={18}
-              maxSize={50}
-              collapsible
-              collapsedSize={0}
-              onCollapse={() => setRightCollapsed(true)}
-              onExpand={() => setRightCollapsed(false)}
-              className="flex flex-col border-l bg-card/30"
-            >
-              {rightPane}
-            </ResizablePanel>
-          </>
-        )}
-      </ResizablePanelGroup>
-      <CommandPalette
-        open={paletteOpen}
-        onOpenChange={setPaletteOpen}
-        sessions={sessions}
-        activeContextId={contextId}
-        onNewChat={onNewChat}
-        canExport={messages.length > 0}
-        onExport={handleExport}
-      />
-    </div>
-    </ViewerProvider>
-    </ImageLightboxProvider>
+                    {sessionLost && <SessionLostBanner />}
+                    <GuardrailBanner
+                      contextId={contextId}
+                      bootError={bootError}
+                    />
+
+                    <main
+                      onDragEnter={onDragEnter}
+                      onDragLeave={onDragLeave}
+                      onDragOver={onDragOver}
+                      onDrop={onDrop}
+                      className="relative flex min-h-0 flex-1 flex-col"
+                    >
+                      {dragOver && (
+                        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-primary/10 text-sm font-medium text-primary ring-2 ring-inset ring-primary">
+                          Drop files to attach
+                        </div>
+                      )}
+                      {showWelcome ? (
+                        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4">
+                          <div className="flex flex-1 flex-col items-center justify-start pt-6 md:pt-24">
+                            <div className="w-full max-w-2xl">
+                              <div className="text-center">
+                                {sandboxStatus?.user_id && (
+                                  <p className="mb-3 text-lg text-muted-foreground md:text-xl">
+                                    Hi,{" "}
+                                    <span className="font-medium text-foreground">
+                                      {sandboxStatus.user_id.split("@")[0]}
+                                    </span>
+                                  </p>
+                                )}
+                                <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">
+                                  <Wordmark label="Long Horizon Harness" />
+                                </h1>
+                                <p className="mx-auto mt-4 max-w-xl text-base text-muted-foreground md:text-lg">
+                                  A long-horizon agent that runs in a sandbox
+                                  and gets better at its work over time.
+                                </p>
+                              </div>
+                              <div className="mt-6">
+                                <StatusStrip contextId={contextId} />
+                                <AuthCard
+                                  contextId={contextId}
+                                  className="mb-2"
+                                />
+                                <SandboxWarmupBanner
+                                  status={sandboxStatus}
+                                  className="mb-2"
+                                />
+                                <InputBox
+                                  onSend={handleSend}
+                                  onStop={handleStop}
+                                  value={draft}
+                                  onValueChange={onDraftChange}
+                                  queued={queue.map((q) => q.text)}
+                                  onRemoveQueued={removeQueued}
+                                  disabled={!client}
+                                  busy={turnActive}
+                                  attachments={attachments}
+                                  onAddFiles={addFiles}
+                                  onRemoveAttachment={removeAttachment}
+                                  attachmentError={attachmentError}
+                                  hasPendingPrefix={
+                                    pendingUploadNames.length > 0 ||
+                                    Boolean(pendingSelection)
+                                  }
+                                  selectionChip={selectionChip}
+                                  fileRefs={fileRefs}
+                                  onAddFileRef={addFileRef}
+                                  onRemoveFileRef={removeFileRef}
+                                  onClearSelection={() =>
+                                    setPendingSelection(null)
+                                  }
+                                />
+                              </div>
+                              <PromptChips
+                                onSend={handleSend}
+                                disabled={!client || busy}
+                              />
+                              <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+                                <div className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-card/40 px-3 py-1 text-xs text-muted-foreground">
+                                  <Sparkles className="h-3.5 w-3.5 text-primary/70" />
+                                  Built with{" "}
+                                  <span className="font-mono text-foreground/80">
+                                    agents-cli
+                                  </span>
+                                </div>
+                                <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70">
+                                  Press{" "}
+                                  <kbd className="rounded border bg-muted/40 px-1 font-mono text-[10px] text-muted-foreground">
+                                    ⌘K
+                                  </kbd>{" "}
+                                  for shortcuts
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
+                          {findOpen && (
+                            <FindBar
+                              messages={messages}
+                              onClose={handleFindClose}
+                              onActiveMatchChange={handleFindActiveMatch}
+                              focusSignal={findFocusSignal}
+                            />
+                          )}
+                          <ConfirmationProvider sender={confirmationSender}>
+                            <MessageList
+                              messages={messages}
+                              contextId={contextId}
+                              onResend={resend}
+                              onEdit={editAndResend}
+                              highlightId={findHighlightId}
+                            />
+                          </ConfirmationProvider>
+                          <StatusStrip contextId={contextId} />
+                          <AuthCard
+                            contextId={contextId}
+                            className="mx-4 mb-2"
+                          />
+                          <SandboxWarmupBanner
+                            status={sandboxStatus}
+                            warmError={warmError}
+                            className="mx-4 mb-2"
+                          />
+                          <DormantActionsGate
+                            lastUpdated={activeSession?.lastUpdated ?? null}
+                            show={
+                              messages.length > 0 &&
+                              !busy &&
+                              !dormantActionsDismissed
+                            }
+                            disabled={!client || busy}
+                            onAction={(prompt) => {
+                              handleSend(prompt);
+                              setDormantActionsDismissed(true);
+                            }}
+                          />
+                          <InputBox
+                            onSend={handleSend}
+                            onStop={handleStop}
+                            value={draft}
+                            onValueChange={onDraftChange}
+                            queued={queue.map((q) => q.text)}
+                            onRemoveQueued={removeQueued}
+                            disabled={!client}
+                            busy={turnActive}
+                            attachments={attachments}
+                            onAddFiles={addFiles}
+                            onRemoveAttachment={removeAttachment}
+                            attachmentError={attachmentError}
+                            hasPendingPrefix={
+                              pendingUploadNames.length > 0 ||
+                              Boolean(pendingSelection)
+                            }
+                            selectionChip={selectionChip}
+                            fileRefs={fileRefs}
+                            onAddFileRef={addFileRef}
+                            onRemoveFileRef={removeFileRef}
+                            onClearSelection={() => setPendingSelection(null)}
+                          />
+                        </>
+                      )}
+                    </main>
+                  </div>
+                </ResizablePanel>
+
+                {isDesktop && (
+                  <>
+                    <ResizableHandle withHandle />
+                    <ResizablePanel
+                      id="right"
+                      order={3}
+                      ref={rightPanelRef}
+                      defaultSize={26}
+                      minSize={18}
+                      maxSize={50}
+                      collapsible
+                      collapsedSize={0}
+                      onCollapse={() => setRightCollapsed(true)}
+                      onExpand={() => setRightCollapsed(false)}
+                      className="flex flex-col border-l bg-card/30"
+                    >
+                      {rightPane}
+                    </ResizablePanel>
+                  </>
+                )}
+              </ResizablePanelGroup>
+              <CommandPalette
+                open={paletteOpen}
+                onOpenChange={setPaletteOpen}
+                sessions={sessions}
+                activeContextId={contextId}
+                onNewChat={onNewChat}
+                canExport={messages.length > 0}
+                onExport={handleExport}
+              />
+            </div>
+          </BusyProvider>
+        </ViewerProvider>
+      </ImageLightboxProvider>
     </NowProvider>
   );
 }
@@ -1191,11 +1398,14 @@ function hasFileDrag(e: DragEvent<HTMLElement>): boolean {
   return false;
 }
 
-const selectIteration = (d: import("@/lib/horizon-state").HorizonStateResponse) =>
-  d.state.iteration;
+const selectIteration = (
+  d: import("@/lib/horizon-state").HorizonStateResponse,
+) => d.state.iteration;
 
 function StatusStrip({ contextId }: { contextId: string | null }) {
-  const { data: iteration } = useLhaState(contextId, { select: selectIteration });
+  const { data: iteration } = useLhaState(contextId, {
+    select: selectIteration,
+  });
   if (!contextId) return null;
   if (!iteration) return null;
   return (
@@ -1213,8 +1423,15 @@ interface PromptChip {
 const PROMPT_CHIPS: PromptChip[] = [
   { label: "Recap what you remember about me", Icon: Brain },
   { label: "Fetch a public dataset, plot it, save the PNG", Icon: LineChart },
-  { label: "Summarize today's top 3 AI research papers and create an HTML report", Icon: Newspaper },
-  { label: "Every day, analyze new activity in google/adk-python", Icon: CalendarClock },
+  {
+    label:
+      "Summarize today's top 3 AI research papers and create an HTML report",
+    Icon: Newspaper,
+  },
+  {
+    label: "Every day, analyze new activity in google/adk-python",
+    Icon: CalendarClock,
+  },
 ];
 
 function PromptChips({

--- a/core/python/long-horizon-harness/web/components/chat/hooks/__tests__/use-message-queue.parts.test.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/hooks/__tests__/use-message-queue.parts.test.tsx
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useMessageQueue } from "../use-message-queue";
+import { makeDataPart } from "@/lib/a2a-part";
+
+const part = () => makeDataPart({ lha_kind: "lha.selection" });
+
+describe("queueing a message typed during a turn", () => {
+  it("flushes its parts, not only its text", () => {
+    // A queued "shorten this" without its anchor reaches the model with no
+    // idea which span "this" is.
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ busy }) => useMessageQueue({ busy, send }),
+      { initialProps: { busy: true } },
+    );
+
+    act(() => result.current.enqueue("shorten this", [part()]));
+    rerender({ busy: false });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [text, opts] = send.mock.calls[0]!;
+    expect(text).toBe("shorten this");
+    expect(opts?.extraParts).toHaveLength(1);
+  });
+
+  it("accepts a message that is only parts", () => {
+    // Dragging a file in and pressing send, with nothing typed.
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ busy }) => useMessageQueue({ busy, send }),
+      { initialProps: { busy: true } },
+    );
+
+    act(() => result.current.enqueue("", [part()]));
+    expect(result.current.queue).toHaveLength(1);
+
+    rerender({ busy: false });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]![1]?.extraParts).toHaveLength(1);
+  });
+
+  it("still ignores a wholly empty message", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useMessageQueue({ busy: true, send }));
+    act(() => result.current.enqueue("   "));
+    expect(result.current.queue).toHaveLength(0);
+  });
+
+  it("carries parts from several queued messages", () => {
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ busy }) => useMessageQueue({ busy, send }),
+      { initialProps: { busy: true } },
+    );
+
+    act(() => result.current.enqueue("first", [part()]));
+    act(() => result.current.enqueue("second", [part()]));
+    rerender({ busy: false });
+
+    const [text, opts] = send.mock.calls[0]!;
+    expect(text).toBe("first\n\nsecond");
+    expect(opts?.extraParts).toHaveLength(2);
+  });
+
+  it("sends no extraParts when nothing was attached", () => {
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ busy }) => useMessageQueue({ busy, send }),
+      { initialProps: { busy: true } },
+    );
+    act(() => result.current.enqueue("plain"));
+    rerender({ busy: false });
+    expect(send).toHaveBeenCalledWith("plain", undefined);
+  });
+});

--- a/core/python/long-horizon-harness/web/components/chat/hooks/use-chat-stream.ts
+++ b/core/python/long-horizon-harness/web/components/chat/hooks/use-chat-stream.ts
@@ -13,11 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Part } from "@a2a-js/sdk";
 import type { HorizonClient } from "@/lib/a2a-client";
-import { makeFileBytesPart, makeFileUrlPart } from "@/lib/a2a-part";
+import {
+  dataPartDict,
+  makeFileBytesPart,
+  makeFileUrlPart,
+} from "@/lib/a2a-part";
 import { extractParts, extractTaskId, isFinal } from "@/lib/horizon-events";
 import {
   appendPartsToSegments,
@@ -138,7 +141,11 @@ export function useChatStream({
       // continuation lands its resumed tool result in a fresh bubble with no
       // matching function_call, so appendPartsToSegments drops it — confirm()
       // collects them here to re-attach to the original spinning row.
-      onToolResult?: (r: { callId: string | null; name: string; result: unknown }) => void,
+      onToolResult?: (r: {
+        callId: string | null;
+        name: string;
+        result: unknown;
+      }) => void,
     ) => {
       let turnTouchedFs = false;
       try {
@@ -165,7 +172,11 @@ export function useChatStream({
               turnTouchedFs = true;
             }
             if (p.kind === "tool_result") {
-              onToolResult?.({ callId: p.callId, name: p.name, result: p.result });
+              onToolResult?.({
+                callId: p.callId,
+                name: p.name,
+                result: p.result,
+              });
             }
           }
           if (parts.length > 0) {
@@ -208,7 +219,9 @@ export function useChatStream({
         }
       } finally {
         setMessages((prev) =>
-          prev.map((m) => (m.id === assistantMsgId ? { ...m, pending: false } : m)),
+          prev.map((m) =>
+            m.id === assistantMsgId ? { ...m, pending: false } : m,
+          ),
         );
         setBusy(false);
         abortRef.current = null;
@@ -226,7 +239,11 @@ export function useChatStream({
       // Defense-in-depth: if the busyRef guard ever races, kill the prior stream
       // before opening a new one.
       abortRef.current?.abort();
-      if (!text.trim() && attachments.length === 0) return;
+      // A UI action (e.g. Export) sends parts and no prose; only a wholly
+      // empty message is a no-op.
+      const extra = opts?.extraParts ?? [];
+      if (!text.trim() && attachments.length === 0 && extra.length === 0)
+        return;
 
       // First send on a brand-new chat: lock the generated contextId into the
       // URL for bookmarkability. The caller updates search params on the current
@@ -250,7 +267,10 @@ export function useChatStream({
             })),
           );
           attachmentParts = encoded.map((e) =>
-            makeFileBytesPart(e.bytes, { filename: e.name, mediaType: e.mimeType }),
+            makeFileBytesPart(e.bytes, {
+              filename: e.name,
+              mediaType: e.mimeType,
+            }),
           );
           userFileSegments = encoded.map((e) => ({
             kind: "file",
@@ -276,6 +296,13 @@ export function useChatStream({
       const userMsgId = crypto.randomUUID();
       const assistantMsgId = crypto.randomUUID();
       const userSegments: MessageSegment[] = [...userFileSegments];
+      // Mirror caller-supplied data parts into the optimistic bubble, so a UI
+      // payload (e.g. a highlighted selection) renders before history catches
+      // up rather than popping in on the refetch.
+      for (const p of opts?.extraParts ?? []) {
+        const data = dataPartDict(p);
+        if (data) userSegments.push({ kind: "data", mime: undefined, data });
+      }
       if (text.trim()) userSegments.push({ kind: "text", text });
       setMessages((prev) => [
         ...prev,
@@ -324,24 +351,43 @@ export function useChatStream({
         const items = req.filter((r) => r.callId);
         if (items.length === 0) return;
         abortRef.current?.abort();
-        setMessages((prev) => items.reduce((acc, r) => resolveHitlSegments(acc, r), prev));
+        setMessages((prev) =>
+          items.reduce((acc, r) => resolveHitlSegments(acc, r), prev),
+        );
 
         const assistantMsgId = crypto.randomUUID();
         setMessages((prev) => [
           ...prev,
-          { id: assistantMsgId, role: "assistant", createdAt: Date.now(), segments: [], pending: true },
+          {
+            id: assistantMsgId,
+            role: "assistant",
+            createdAt: Date.now(),
+            segments: [],
+            pending: true,
+          },
         ]);
         setBusy(true);
 
         const controller = new AbortController();
         abortRef.current = controller;
         const stream = client.sendConfirmations(
-          items.map((r) => ({ callId: r.callId as string, confirmed: r.confirmed, payload: r.payload })),
+          items.map((r) => ({
+            callId: r.callId as string,
+            confirmed: r.confirmed,
+            payload: r.payload,
+          })),
           { signal: controller.signal },
         );
-        const toolResults: { callId: string | null; name: string; result: unknown }[] = [];
-        await consumeStream(assistantMsgId, stream, controller, (r) => toolResults.push(r));
-        if (toolResults.length > 0) setMessages((prev) => resolveToolResults(prev, toolResults));
+        const toolResults: {
+          callId: string | null;
+          name: string;
+          result: unknown;
+        }[] = [];
+        await consumeStream(assistantMsgId, stream, controller, (r) =>
+          toolResults.push(r),
+        );
+        if (toolResults.length > 0)
+          setMessages((prev) => resolveToolResults(prev, toolResults));
         return;
       }
 
@@ -376,7 +422,11 @@ export function useChatStream({
       // The continuation streams the resumed gated tool's function_response into
       // a fresh bubble with no matching function_call, so it never attaches to
       // the original spinning row. Collect those results and re-attach by callId.
-      const toolResults: { callId: string | null; name: string; result: unknown }[] = [];
+      const toolResults: {
+        callId: string | null;
+        name: string;
+        result: unknown;
+      }[] = [];
       await consumeStream(assistantMsgId, stream, controller, (r) =>
         toolResults.push(r),
       );
@@ -455,9 +505,12 @@ export function useChatStream({
 
 // Build an A2A FilePart from a stored file segment. Returns null if the
 // segment has neither bytes nor uri — nothing to send.
-function fileSegmentToPart(
-  file: { bytes?: string; uri?: string; mimeType?: string; name?: string },
-): Part | null {
+function fileSegmentToPart(file: {
+  bytes?: string;
+  uri?: string;
+  mimeType?: string;
+  name?: string;
+}): Part | null {
   if (file.bytes) {
     return makeFileBytesPart(file.bytes, {
       filename: file.name,
@@ -478,7 +531,8 @@ function fileSegmentToPart(
 function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onerror = () => reject(reader.error ?? new Error("file read failed"));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("file read failed"));
     reader.onload = () => {
       const result = reader.result;
       if (typeof result !== "string") {

--- a/core/python/long-horizon-harness/web/components/chat/hooks/use-message-queue.ts
+++ b/core/python/long-horizon-harness/web/components/chat/hooks/use-message-queue.ts
@@ -13,20 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { Part } from "@a2a-js/sdk";
+
+/**
+ * A message typed during a turn, held until the turn ends. Carries its parts
+ * as well as its text: a highlighted span or a dragged file is part of the
+ * message, and flushing the text alone would send the instruction without the
+ * thing it refers to.
+ */
+export interface QueuedMessage {
+  text: string;
+  parts: Part[];
+}
 
 export interface UseMessageQueueArgs {
   busy: boolean;
   // Sends the combined queued text as a single new turn when the current
   // turn ends. Pass the raw `send` from useChatStream — NOT the enqueueing
   // wrapper — so flushing never re-enters the queue.
-  send: (text: string) => void;
+  send: (text: string, opts?: { extraParts?: Part[] }) => void;
 }
 
 export interface UseMessageQueueResult {
-  queue: string[];
-  enqueue: (text: string) => void;
+  queue: QueuedMessage[];
+  enqueue: (text: string, parts?: Part[]) => void;
   removeQueued: (index: number) => void;
   clearQueue: () => void;
 }
@@ -35,7 +46,7 @@ export function useMessageQueue({
   busy,
   send,
 }: UseMessageQueueArgs): UseMessageQueueResult {
-  const [queue, setQueue] = useState<string[]>([]);
+  const [queue, setQueue] = useState<QueuedMessage[]>([]);
   const prevBusyRef = useRef(busy);
   // The flush effect depends only on `busy`; read the live queue/send through
   // refs so an enqueue mid-turn doesn't re-run it and a stale closure doesn't
@@ -49,10 +60,12 @@ export function useMessageQueue({
     sendRef.current = send;
   }, [send]);
 
-  const enqueue = useCallback((text: string) => {
+  const enqueue = useCallback((text: string, parts?: Part[]) => {
     const trimmed = text.trim();
-    if (!trimmed) return;
-    setQueue((q) => [...q, trimmed]);
+    // Parts alone are still a message: a highlighted span or a dragged file
+    // carries the intent even when the user typed nothing alongside it.
+    if (!trimmed && !parts?.length) return;
+    setQueue((q) => [...q, { text: trimmed, parts: parts ?? [] }]);
   }, []);
 
   const removeQueued = useCallback((index: number) => {
@@ -68,9 +81,19 @@ export function useMessageQueue({
     const wasBusy = prevBusyRef.current;
     prevBusyRef.current = busy;
     if (wasBusy && !busy && queueRef.current.length > 0) {
-      const text = queueRef.current.join("\n\n");
+      const entries = queueRef.current;
+      const text = entries
+        .map((e) => e.text)
+        .filter(Boolean)
+        .join("\n\n");
+      // Carried through, or a queued "shorten this" would reach the model with
+      // no idea which span "this" is.
+      const parts = entries.flatMap((e) => e.parts);
       setQueue([]);
-      sendRef.current(text);
+      sendRef.current(
+        text,
+        parts.length > 0 ? { extraParts: parts } : undefined,
+      );
     }
   }, [busy]);
 

--- a/core/python/long-horizon-harness/web/components/chat/input-box.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/input-box.tsx
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import {
   type ChangeEvent,
   type ClipboardEvent,
@@ -27,9 +26,21 @@ import {
 } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { ArrowUp, FileIcon, Paperclip, Square, X } from "lucide-react";
+import {
+  ArrowUp,
+  FileIcon,
+  Paperclip,
+  Scissors,
+  Square,
+  X,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { onFocusComposer } from "@/lib/composer-focus";
+import {
+  FILEREF_DRAG_MIME,
+  parseFileRefDrag,
+  type FileRef,
+} from "./workspace-href";
 
 export interface InputAttachment {
   /** Stable per-attachment id used as React key + remove handle. */
@@ -59,6 +70,16 @@ export interface InputBoxProps {
   // — e.g. the sidebar dropzone has queued an upload that will be prepended
   // as `[Uploaded to /workspace: …]` on the next submit.
   hasPendingPrefix?: boolean;
+  // Text highlighted in the artifact panel's Source view. Rendered as a chip
+  // because the browser stops painting the native highlight once focus moves
+  // here, leaving no other cue that a span is held.
+  selectionChip?: { label: string } | null;
+  onClearSelection?: () => void;
+  // Files dragged in from the workspace tree. References, not uploads: the
+  // bytes are already on disk, so only the path travels.
+  fileRefs?: FileRef[];
+  onAddFileRef?: (ref: FileRef) => void;
+  onRemoveFileRef?: (path: string) => void;
   // Messages typed while the agent was busy, awaiting flush. Rendered as a
   // removable stack above the composer.
   queued: string[];
@@ -77,6 +98,11 @@ function InputBoxInner({
   onRemoveAttachment,
   attachmentError,
   hasPendingPrefix,
+  selectionChip,
+  onClearSelection,
+  fileRefs,
+  onAddFileRef,
+  onRemoveFileRef,
   queued,
   onRemoveQueued,
 }: InputBoxProps) {
@@ -121,7 +147,8 @@ function InputBoxInner({
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
-    if (autosizeRafRef.current != null) cancelAnimationFrame(autosizeRafRef.current);
+    if (autosizeRafRef.current != null)
+      cancelAnimationFrame(autosizeRafRef.current);
     autosizeRafRef.current = requestAnimationFrame(() => {
       autosizeRafRef.current = null;
       el.style.height = "auto";
@@ -133,7 +160,13 @@ function InputBoxInner({
     e?.preventDefault();
     if (disabled) return;
     const text = value.trim();
-    if (!text && attachments.length === 0 && !hasPendingPrefix) return;
+    if (
+      !text &&
+      attachments.length === 0 &&
+      (fileRefs?.length ?? 0) === 0 &&
+      !hasPendingPrefix
+    )
+      return;
     onSend(text);
     onValueChange("");
     if (textareaRef.current) {
@@ -150,11 +183,7 @@ function InputBoxInner({
     }
     // Backspace at an empty composer pops the most-recent attachment chip —
     // matches Slack / GitHub behavior so power users can clear by feel.
-    if (
-      e.key === "Backspace" &&
-      value.length === 0 &&
-      attachments.length > 0
-    ) {
+    if (e.key === "Backspace" && value.length === 0 && attachments.length > 0) {
       e.preventDefault();
       onRemoveAttachment(attachments[attachments.length - 1].id);
     }
@@ -186,12 +215,23 @@ function InputBoxInner({
 
   const canSend =
     !disabled &&
-    (value.trim().length > 0 || attachments.length > 0 || !!hasPendingPrefix);
+    (value.trim().length > 0 ||
+      attachments.length > 0 ||
+      (fileRefs?.length ?? 0) > 0 ||
+      !!hasPendingPrefix);
 
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const dragHasFiles = (e: DragEvent<HTMLFormElement>) =>
     Array.from(e.dataTransfer?.types ?? []).includes("Files");
+  const dragHasWorkspaceFile = (e: DragEvent<HTMLFormElement>) =>
+    Array.from(e.dataTransfer?.types ?? []).includes(FILEREF_DRAG_MIME);
   const onDragOver = (e: DragEvent<HTMLFormElement>) => {
+    if (dragHasWorkspaceFile(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDraggingFiles(true);
+      return;
+    }
     if (!dragHasFiles(e)) return;
     e.preventDefault();
     e.stopPropagation(); // don't let the shell-level workspace dropzone also fire
@@ -202,6 +242,14 @@ function InputBoxInner({
     setIsDraggingFiles(false);
   };
   const onDrop = (e: DragEvent<HTMLFormElement>) => {
+    if (dragHasWorkspaceFile(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDraggingFiles(false);
+      const ref = parseFileRefDrag(e.dataTransfer.getData(FILEREF_DRAG_MIME));
+      if (ref) onAddFileRef?.(ref);
+      return;
+    }
     if (!dragHasFiles(e)) return;
     e.preventDefault();
     e.stopPropagation();
@@ -232,7 +280,9 @@ function InputBoxInner({
                   key={`${i}:${q}`}
                   className="flex items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2 pr-1 text-xs text-muted-foreground"
                 >
-                  <span className="flex-1 truncate whitespace-pre-wrap">{q}</span>
+                  <span className="flex-1 truncate whitespace-pre-wrap">
+                    {q}
+                  </span>
                   <button
                     type="button"
                     onClick={() => onRemoveQueued(i)}
@@ -242,6 +292,35 @@ function InputBoxInner({
                     <X className="h-3 w-3" />
                   </button>
                 </div>
+              ))}
+            </div>
+          )}
+
+          {selectionChip && (
+            <div className="px-1.5 pt-1">
+              <span className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+                <Scissors className="h-3 w-3 shrink-0" />
+                <span className="truncate">{selectionChip.label}</span>
+                <button
+                  type="button"
+                  aria-label="Clear selection"
+                  onClick={onClearSelection}
+                  className="rounded p-0.5 hover:bg-muted"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            </div>
+          )}
+
+          {(fileRefs?.length ?? 0) > 0 && (
+            <div className="flex flex-wrap gap-1.5 px-1.5 pt-1">
+              {fileRefs?.map((r) => (
+                <FileRefChip
+                  key={r.path}
+                  fileRef={r}
+                  onRemove={() => onRemoveFileRef?.(r.path)}
+                />
               ))}
             </div>
           )}
@@ -300,10 +379,10 @@ function InputBoxInner({
                 disabled
                   ? "Connecting…"
                   : busy
-                  ? "Reply will be queued…"
-                  : attachments.length > 0
-                  ? "Add a message (optional)"
-                  : "Ask anything…"
+                    ? "Reply will be queued…"
+                    : attachments.length > 0
+                      ? "Add a message (optional)"
+                      : "Ask anything…"
               }
               disabled={disabled}
               rows={1}
@@ -342,6 +421,37 @@ function InputBoxInner({
 
 export const InputBox = memo(InputBoxInner);
 
+/** Same shape as an upload chip; it is a pointer, not a copy. */
+function FileRefChip({
+  fileRef,
+  onRemove,
+}: {
+  fileRef: FileRef;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="group/chip relative flex items-center gap-1.5 rounded-md border bg-muted/50 py-1 pl-1.5 pr-6 text-xs text-foreground">
+      <FileIcon className="h-3.5 w-3.5 text-muted-foreground" />
+      <div className="flex flex-col leading-tight">
+        <span className="max-w-[200px] truncate font-medium">
+          {fileRef.name}
+        </span>
+        <span className="text-[10px] text-muted-foreground">
+          {fileRef.size !== undefined ? formatBytes(fileRef.size) : "workspace"}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute right-0.5 top-0.5 inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/20 hover:text-destructive"
+        aria-label={`Remove ${fileRef.name}`}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
 function AttachmentChip({
   attachment,
   onRemove,
@@ -367,7 +477,9 @@ function AttachmentChip({
         <FileIcon className="h-3.5 w-3.5 text-muted-foreground" />
       )}
       <div className="flex flex-col leading-tight">
-        <span className="max-w-[200px] truncate font-medium">{attachment.name}</span>
+        <span className="max-w-[200px] truncate font-medium">
+          {attachment.name}
+        </span>
         <span className="text-[10px] text-muted-foreground">
           {formatBytes(attachment.file.size)}
         </span>

--- a/core/python/long-horizon-harness/web/components/chat/markdown.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/markdown.tsx
@@ -21,6 +21,13 @@ import { cn } from "@/lib/utils";
 import { useResolvedTheme } from "@/lib/use-appearance";
 import { CopyButton } from "./copy-button";
 import { useImageLightbox } from "./image-lightbox";
+import { useViewerOptional } from "./artifact-viewer/viewer-context";
+import { useBusy } from "./busy-context";
+import { useWorkspaceFiles } from "@/lib/workspace-files";
+import {
+  workspacePathFromHref,
+  workspacePathFromMention,
+} from "./workspace-href";
 import { CodeBlock, prismLanguageFromInfo } from "./tool-views";
 
 // Module-level so React doesn't see a new array reference every render and
@@ -36,7 +43,9 @@ function resolveHref(href?: string): string | undefined {
   if (!href) return href;
   const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(href)?.[1]?.toLowerCase();
   if (scheme) {
-    return ["http", "https", "mailto", "tel"].includes(scheme) ? href : undefined;
+    return ["http", "https", "mailto", "tel"].includes(scheme)
+      ? href
+      : undefined;
   }
   if (href.startsWith("/") || href.startsWith("#") || href.startsWith("?"))
     return href;
@@ -51,18 +60,35 @@ const ANCHOR_COMPONENT = ({
 }: {
   href?: string;
   children?: React.ReactNode;
-}) => (
-  // overflow-wrap:anywhere lets long bare URLs break mid-string instead of
-  // forcing the bubble wider than a phone viewport.
-  <a
-    href={resolveHref(href)}
-    target="_blank"
-    rel="noreferrer noopener"
-    className="[overflow-wrap:anywhere]"
-  >
-    {children}
-  </a>
-);
+}) => {
+  const viewer = useViewerOptional();
+  // A bare relative link is the model pointing at a workspace file it just
+  // wrote. Open those in the side panel rather than punting to a new tab —
+  // same destination, but it stays in the conversation.
+  const wsPath = workspacePathFromHref(href);
+  if (wsPath && viewer) {
+    return (
+      <OpenInPanelButton
+        path={wsPath}
+        className="underline [overflow-wrap:anywhere] hover:no-underline"
+      >
+        {children}
+      </OpenInPanelButton>
+    );
+  }
+  return (
+    // overflow-wrap:anywhere lets long bare URLs break mid-string instead of
+    // forcing the bubble wider than a phone viewport.
+    <a
+      href={resolveHref(href)}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="[overflow-wrap:anywhere]"
+    >
+      {children}
+    </a>
+  );
+};
 
 // Markdown images open full-screen in the lightbox instead of a new tab.
 function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
@@ -80,6 +106,72 @@ function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
     </button>
   );
 }
+
+/** Shared by the anchor and inline-code handlers. */
+function OpenInPanelButton({
+  path,
+  className,
+  children,
+}: {
+  path: string;
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  const viewer = useViewerOptional();
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        viewer?.openArtifact({
+          name: path.split("/").pop() || path,
+          // pickRenderer falls back to the extension, which is all a
+          // filename mention tells us.
+          mimeType: "",
+          path,
+          url: `/lha/workspace/download?path=${encodeURIComponent(path)}&inline=1`,
+        })
+      }
+      className={className}
+      title={`Open ${path} in the side panel`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// Models habitually write a filename as `cats.md` rather than a markdown
+// link, so inline code is where most workspace-file mentions actually land.
+// Only names that match a real file are linkified — a link opening an empty
+// panel is worse than plain text.
+const INLINE_CODE_COMPONENT = ({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLElement>) => {
+  const busy = useBusy();
+  const files = useWorkspaceFiles(busy);
+  const viewer = useViewerOptional();
+  const plain = (
+    <code className={className} {...props}>
+      {children}
+    </code>
+  );
+  // A fenced block arrives with `language-xxx`; those render through `pre`.
+  if (className?.includes("language-")) return plain;
+  if (!viewer || !files) return plain;
+  const text = typeof children === "string" ? children : null;
+  if (!text) return plain;
+  const path = workspacePathFromMention(text);
+  if (!path || !files.has(path)) return plain;
+  return (
+    <OpenInPanelButton
+      path={path}
+      className="underline decoration-dotted underline-offset-2 hover:decoration-solid"
+    >
+      {plain}
+    </OpenInPanelButton>
+  );
+};
 
 // Wide tables would otherwise burst the bubble and push the layout past a
 // phone viewport. Wrap in an overflow container so they scroll horizontally.
@@ -115,6 +207,7 @@ export const Markdown = memo(function Markdown({
   const components = useMemo(
     () => ({
       a: ANCHOR_COMPONENT,
+      code: INLINE_CODE_COMPONENT,
       img: MarkdownImage,
       table: TABLE_COMPONENT,
       pre: ({ children }: React.HTMLAttributes<HTMLPreElement>) => {

--- a/core/python/long-horizon-harness/web/components/chat/message-bubble.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/message-bubble.tsx
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import React, { useEffect, useId, useMemo, useState } from "react";
 import {
   BookOpen,
@@ -26,6 +25,7 @@ import {
   Music,
   Pencil,
   RotateCcw,
+  Scissors,
   Wrench,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -37,6 +37,12 @@ import { useConfirmationSender } from "./confirmation-context";
 import { CopyButton } from "./copy-button";
 import { Markdown } from "./markdown";
 import { useViewerOptional } from "./artifact-viewer/viewer-context";
+import { useWorkspaceFiles, workspacePathForName } from "@/lib/workspace-files";
+import {
+  isFileRefPayload,
+  isSelectionPayload,
+  type SelectionPayload,
+} from "./workspace-href";
 import {
   PatchView,
   ReadFileView,
@@ -86,13 +92,20 @@ function MessageBubbleInner({
   const grouped = groupSegments(message.segments);
 
   return (
-    <div className={cn("flex flex-col gap-1.5", isUser ? "items-end" : "items-start")}>
+    <div
+      className={cn(
+        "flex flex-col gap-1.5",
+        isUser ? "items-end" : "items-start",
+      )}
+    >
       {grouped.map((group, gi) => {
         if (group.kind === "toolGroup") {
           return <ToolGroup key={`tg-${gi}`} tools={group.tools} />;
         }
         if (group.kind === "confirmGroup") {
-          return <CombinedPermissionCard key={`cg-${gi}`} items={group.items} />;
+          return (
+            <CombinedPermissionCard key={`cg-${gi}`} items={group.items} />
+          );
         }
         const seg = group.segment;
         const i = group.index;
@@ -108,6 +121,18 @@ function MessageBubbleInner({
           );
         }
         if (seg.kind === "data") {
+          if (isFileRefPayload(seg.data)) {
+            return (
+              <div key={`refs-${i}`} className="flex flex-wrap gap-1.5">
+                {seg.data.paths.map((p) => (
+                  <WorkspaceFileChip key={p} path={p} />
+                ))}
+              </div>
+            );
+          }
+          if (isSelectionPayload(seg.data)) {
+            return <SelectionQuote key={`sel-${i}`} selection={seg.data} />;
+          }
           return (
             <pre
               key={`data-${i}`}
@@ -402,7 +427,9 @@ const selectPendingSlice = (d: HorizonStateResponse) => ({
 });
 
 function PendingIndicator({ contextId }: { contextId: string | null }) {
-  const { data: slice } = useLhaState(contextId, { select: selectPendingSlice });
+  const { data: slice } = useLhaState(contextId, {
+    select: selectPendingSlice,
+  });
   const provisioning = slice?.provisioning ?? false;
   const inFlight = slice?.inFlight ?? null;
   const [mountedAt] = useState(() => Date.now());
@@ -415,7 +442,9 @@ function PendingIndicator({ contextId }: { contextId: string | null }) {
   const startMs = inFlight?.started_ms ?? mountedAt;
   const elapsedS = Math.max(0, Math.floor((now - startMs) / 1000));
   const elapsedLabel =
-    elapsedS < 60 ? `${elapsedS}s` : `${Math.floor(elapsedS / 60)}m${elapsedS % 60}s`;
+    elapsedS < 60
+      ? `${elapsedS}s`
+      : `${Math.floor(elapsedS / 60)}m${elapsedS % 60}s`;
 
   let label: string;
   if (provisioning) {
@@ -459,6 +488,79 @@ function formatRelative(deltaMs: number): string {
   return `${days}d ago`;
 }
 
+/** A workspace file the user attached by dragging it in. */
+function WorkspaceFileChip({ path }: { path: string }) {
+  const name = path.split("/").pop() || path;
+  const viewer = useViewerOptional();
+  const full = path;
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        viewer?.openArtifact({
+          name,
+          mimeType: "",
+          path: full,
+          url: `/lha/workspace/download?path=${encodeURIComponent(full)}&inline=1`,
+        })
+      }
+      title={`Open ${full} in the side panel`}
+      className="inline-flex items-center gap-1.5 rounded-md border bg-muted/50 px-2 py-1 text-xs hover:bg-muted"
+    >
+      <FileIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="max-w-[220px] truncate font-medium">{name}</span>
+    </button>
+  );
+}
+
+/**
+ * A highlighted span, shown above the user's own words.
+ *
+ * The model-facing framing of the same selection is built server-side from
+ * the DataPart, so none of that markup reaches the transcript — the bubble
+ * shows what was pointed at, not how the agent was told about it.
+ */
+function SelectionQuote({ selection }: { selection: SelectionPayload }) {
+  const name = selection.path.split("/").pop() || selection.path;
+  const full = selection.path;
+  const lines =
+    selection.start_line === selection.end_line
+      ? `line ${selection.start_line}`
+      : `lines ${selection.start_line}–${selection.end_line}`;
+  const viewer = useViewerOptional();
+  return (
+    <div className="mb-1.5 max-w-full rounded-md border border-border/60 bg-background/40 text-[11px]">
+      <div className="flex items-center gap-1.5 border-b border-border/50 px-2 py-1 text-muted-foreground">
+        <Scissors className="h-3 w-3 shrink-0" />
+        {viewer ? (
+          <button
+            type="button"
+            onClick={() =>
+              viewer.openArtifact({
+                name,
+                mimeType: "",
+                path: full,
+                url: `/lha/workspace/download?path=${encodeURIComponent(full)}&inline=1`,
+              })
+            }
+            className="truncate font-mono underline-offset-2 hover:underline"
+            title={`Open ${full} in the side panel`}
+          >
+            {name}
+          </button>
+        ) : (
+          <span className="truncate font-mono">{name}</span>
+        )}
+        <span className="shrink-0">· {lines}</span>
+      </div>
+      {/* Whitespace preserved: this is a verbatim excerpt of the file. */}
+      <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-muted-foreground">
+        {selection.snippet}
+      </pre>
+    </div>
+  );
+}
+
 function FilePart({
   file,
 }: {
@@ -472,16 +574,27 @@ function FilePart({
   const mime = file.mimeType ?? "application/octet-stream";
   const name = file.name ?? defaultFileName(mime);
   const viewer = useViewerOptional();
+  const busy = useBusy();
+  const files = useWorkspaceFiles(busy);
   const hasContent = Boolean(file.bytes || file.uri);
+  // An attachment carries bytes and a name, never a location — the artifact
+  // service doesn't record one. Recover the path when the name identifies a
+  // workspace file, so opening the attachment lands on the same editable tab
+  // as opening it from the tree, rather than a read-only twin.
+  const path = workspacePathForName(files, name) ?? undefined;
   const onOpen =
     hasContent && viewer
       ? () =>
-          viewer.openArtifact({
-            name,
-            mimeType: mime,
-            bytes: file.bytes,
-            url: file.uri,
-          })
+          viewer.openArtifact(
+            path
+              ? // The attachment's bytes are frozen at the turn that produced
+                // them. Handing them over would show a stale copy of a file
+                // still being edited, and the first keystroke would autosave
+                // that copy back over the agent's work — so let the viewer
+                // read the file itself.
+                { name, mimeType: mime, path }
+              : { name, mimeType: mime, bytes: file.bytes, url: file.uri },
+          )
       : undefined;
   return (
     <AttachmentChip
@@ -723,7 +836,9 @@ function CommandPreview({ id, text }: { id?: string; text: string }) {
         className="flex cursor-pointer list-none items-center gap-1 text-muted-foreground hover:text-foreground [&::-webkit-details-marker]:hidden"
       >
         <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
-        <span className="truncate font-mono text-xs text-foreground/90">{text}</span>
+        <span className="truncate font-mono text-xs text-foreground/90">
+          {text}
+        </span>
       </summary>
       <pre className="mt-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/40 p-2 font-mono text-xs leading-snug text-foreground/90">
         {text}
@@ -791,7 +906,11 @@ function PermissionCard({
               key={label}
               type="button"
               onClick={() =>
-                send({ callId, confirmed: !isDecline, payload: { choice: label } })
+                send({
+                  callId,
+                  confirmed: !isDecline,
+                  payload: { choice: label },
+                })
               }
               className={cn(
                 "rounded-md border px-3 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
@@ -815,7 +934,13 @@ function CombinedPermissionCard({ items }: { items: ConfirmItem[] }) {
   // outcome KEY (not the single card's per-label `choice`) because labels differ
   // per command while the outcome order is identical for every permission card.
   const batch = (confirmed: boolean, outcome: string) =>
-    send(items.map((it) => ({ callId: it.callId, confirmed, payload: { outcome } })));
+    send(
+      items.map((it) => ({
+        callId: it.callId,
+        confirmed,
+        payload: { outcome },
+      })),
+    );
   return (
     <div
       role="group"
@@ -826,7 +951,10 @@ function CombinedPermissionCard({ items }: { items: ConfirmItem[] }) {
       </div>
       <ul className="flex flex-col gap-1">
         {items.map((it, k) => (
-          <li key={it.callId ?? k} className="font-mono text-xs text-muted-foreground">
+          <li
+            key={it.callId ?? k}
+            className="font-mono text-xs text-muted-foreground"
+          >
             {it.payload.summary}
           </li>
         ))}
@@ -911,7 +1039,10 @@ function groupSegments(segments: MessageSegment[]): SegmentGroup[] {
       while (j < segments.length) {
         const s = segments[j];
         if (!isPendingPermission(s)) break;
-        items.push({ callId: s.callId, payload: s.payload as unknown as PermissionPayload });
+        items.push({
+          callId: s.callId,
+          payload: s.payload as unknown as PermissionPayload,
+        });
         j++;
       }
       if (items.length >= 2) {
@@ -993,12 +1124,13 @@ function ToolRow({
 }) {
   const [open, setOpen] = useState(false);
   const isLoadSkill = name === "load_skill";
-  const skillName = isLoadSkill && typeof args?.name === "string" ? args.name : null;
+  const skillName =
+    isLoadSkill && typeof args?.name === "string" ? args.name : null;
   const richPreview = pickRichPreview(name, args);
   const preview = isLoadSkill
-    ? skillName ?? "skill"
-    : richPreview ?? formatArgsPreview(args);
-  const Icon = isLoadSkill ? BookOpen : TOOL_ICONS[name] ?? Wrench;
+    ? (skillName ?? "skill")
+    : (richPreview ?? formatArgsPreview(args));
+  const Icon = isLoadSkill ? BookOpen : (TOOL_ICONS[name] ?? Wrench);
   const displayName = isLoadSkill ? "load_skill" : name;
   return (
     <div className="flex w-full max-w-full flex-col gap-1">
@@ -1073,9 +1205,7 @@ function RichToolBody({
     return <WriteFileView args={args} result={result} />;
   }
   if (name === "read_file") {
-    return (
-      <ReadFileView args={args} result={result} hasResult={hasResult} />
-    );
+    return <ReadFileView args={args} result={result} hasResult={hasResult} />;
   }
   if (name === "terminal") {
     return <TerminalView args={args} result={result} hasResult={hasResult} />;

--- a/core/python/long-horizon-harness/web/components/chat/sidebar-workspace-tree.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/sidebar-workspace-tree.tsx
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import {
   useCallback,
   useEffect,
@@ -32,6 +31,8 @@ import {
   Trash2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useViewerOptional } from "./artifact-viewer/viewer-context";
+import { FILEREF_DRAG_MIME } from "./workspace-href";
 import { formatBytes } from "./input-box";
 import {
   AlertDialog,
@@ -150,7 +151,10 @@ function loadShowHidden(): boolean {
 
 function filterHidden(state: DirState): DirState {
   if (!state.entries) return state;
-  return { ...state, entries: state.entries.filter((e) => !isHiddenName(e.name)) };
+  return {
+    ...state,
+    entries: state.entries.filter((e) => !isHiddenName(e.name)),
+  };
 }
 
 export function SidebarWorkspaceTree({
@@ -496,6 +500,7 @@ function TreeRow({
   const path = `${parentPath}/${entry.name}`;
   const padding = { paddingLeft: `${0.5 + depth * 0.75}rem` };
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const viewer = useViewerOptional();
 
   if (entry.kind === "dir") {
     const isOpen = openDirs.has(path);
@@ -567,6 +572,8 @@ function TreeRow({
   }
 
   const Icon = entry.kind === "symlink" ? LinkIcon : FileIcon;
+  const openable =
+    entry.kind === "file" && !entry.optimistic && viewer !== null;
   return (
     <li
       className={cn(
@@ -583,7 +590,44 @@ function TreeRow({
       }
     >
       <Icon className="h-3 w-3 shrink-0" />
-      <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+      {openable ? (
+        <button
+          type="button"
+          // Dragged into the composer, a row becomes an attachment chip.
+          // Deliberately not text/plain: that would make the textarea insert
+          // the name as well as showing the chip.
+          draggable
+          onDragStart={(e) => {
+            e.dataTransfer.setData(
+              FILEREF_DRAG_MIME,
+              JSON.stringify({
+                path,
+                name: entry.name,
+                size: entry.size,
+              }),
+            );
+            e.dataTransfer.effectAllowed = "copy";
+          }}
+          onClick={() =>
+            viewer?.openArtifact({
+              name: entry.name,
+              // Left blank on purpose: pickRenderer falls back to the
+              // filename extension, which is all the tree knows.
+              mimeType: "",
+              path,
+              // Lets image/audio render straight from the endpoint; text
+              // kinds are fetched into `bytes` by the viewer.
+              url: buildOpenHref(path),
+            })
+          }
+          className="min-w-0 flex-1 truncate text-left hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          title={`Open ${entry.name}`}
+        >
+          {entry.name}
+        </button>
+      ) : (
+        <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+      )}
       <span className="shrink-0 text-[10px] text-muted-foreground/60">
         {formatBytes(entry.size)}
       </span>
@@ -783,7 +827,10 @@ function SkeletonRows({ compact = false }: { compact?: boolean }) {
       )}
     >
       {Array.from({ length: compact ? 2 : 3 }).map((_, i) => (
-        <div key={i} className="h-3.5 motion-safe:animate-pulse rounded bg-muted/40" />
+        <div
+          key={i}
+          className="h-3.5 motion-safe:animate-pulse rounded bg-muted/40"
+        />
       ))}
     </div>
   );

--- a/core/python/long-horizon-harness/web/components/chat/tool-views.tsx
+++ b/core/python/long-horizon-harness/web/components/chat/tool-views.tsx
@@ -13,12 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import { diffLines } from "diff";
-import { Highlight, themes, type Language, type PrismTheme } from "prism-react-renderer";
+import {
+  Highlight,
+  themes,
+  type Language,
+  type PrismTheme,
+} from "prism-react-renderer";
 import { FileText, Pencil, Terminal as TerminalIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "./copy-button";
+import { useViewerOptional } from "./artifact-viewer/viewer-context";
+import { normalizeWorkspacePath } from "./workspace-href";
 
 const EXT_TO_LANG: Record<string, Language> = {
   py: "python",
@@ -131,7 +137,9 @@ const LANG_ALIAS: Record<string, Language> = {
   ...EXT_TO_LANG,
 };
 
-export function prismLanguageFromInfo(info: string | null | undefined): Language {
+export function prismLanguageFromInfo(
+  info: string | null | undefined,
+): Language {
   if (!info) return "markup";
   return LANG_ALIAS[info.toLowerCase()] ?? "markup";
 }
@@ -204,8 +212,8 @@ export function DiffBlock({
         const cls = part.added
           ? "bg-emerald-500/10 text-emerald-300"
           : part.removed
-          ? "bg-rose-500/10 text-rose-300"
-          : "text-zinc-400";
+            ? "bg-rose-500/10 text-rose-300"
+            : "text-zinc-400";
         return lines.map((ln, li) => (
           <div key={`${pi}-${li}`} className={cn("px-1", cls)}>
             <span aria-hidden className="mr-2 select-none opacity-60">
@@ -259,7 +267,8 @@ export function PatchView({
   return (
     <div className="flex w-full max-w-full flex-col gap-1">
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-        patch · <span className="font-mono normal-case">{path || "(no path)"}</span>
+        patch ·{" "}
+        <span className="font-mono normal-case">{path || "(no path)"}</span>
         {replaceAll && (
           <span className="ml-1 rounded bg-amber-500/15 px-1 text-amber-300">
             replace_all
@@ -276,15 +285,39 @@ export function PatchView({
   );
 }
 
-export function writeFilePreview(
-  args: Record<string, unknown> | null,
-): string {
+export function writeFilePreview(args: Record<string, unknown> | null): string {
   if (!args) return "";
   const path = asString(args.path);
   if (!path) return "";
   const content = asString(args.content);
   const lines = content ? content.split("\n").length : 0;
   return `${basename(path)} · ${lines} lines`;
+}
+
+/** The written path, clickable when it resolves to a live workspace file. */
+function WorkspaceFileLink({ path }: { path: string }) {
+  const viewer = useViewerOptional();
+  const wsPath = path ? normalizeWorkspacePath(path) : null;
+  if (!wsPath || !viewer) {
+    return <span className="font-mono normal-case">{path || "(no path)"}</span>;
+  }
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        viewer.openArtifact({
+          name: wsPath.split("/").pop() || wsPath,
+          mimeType: "",
+          path: wsPath,
+          url: `/lha/workspace/download?path=${encodeURIComponent(wsPath)}&inline=1`,
+        })
+      }
+      className="font-mono normal-case underline hover:no-underline"
+      title={`Open ${wsPath} in the side panel`}
+    >
+      {path}
+    </button>
+  );
 }
 
 export function WriteFileView({
@@ -304,7 +337,12 @@ export function WriteFileView({
   return (
     <div className="flex w-full max-w-full flex-col gap-1">
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-        write_file · <span className="font-mono normal-case">{path || "(no path)"}</span>
+        write_file ·{" "}
+        {err ? (
+          <span className="font-mono normal-case">{path || "(no path)"}</span>
+        ) : (
+          <WorkspaceFileLink path={path} />
+        )}
       </div>
       <CodeBlock code={content} language={lang} />
       {err && (
@@ -316,9 +354,7 @@ export function WriteFileView({
   );
 }
 
-export function readFilePreview(
-  args: Record<string, unknown> | null,
-): string {
+export function readFilePreview(args: Record<string, unknown> | null): string {
   if (!args) return "";
   const path = asString(args.path);
   if (!path) return "";
@@ -350,7 +386,8 @@ export function ReadFileView({
   return (
     <div className="flex w-full max-w-full flex-col gap-1">
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-        read_file · <span className="font-mono normal-case">{path || "(no path)"}</span>
+        read_file ·{" "}
+        <span className="font-mono normal-case">{path || "(no path)"}</span>
       </div>
       {hasResult ? (
         err ? (
@@ -361,15 +398,15 @@ export function ReadFileView({
           <CodeBlock code={content} language={lang} />
         )
       ) : (
-        <div className="text-[11px] text-muted-foreground">awaiting content…</div>
+        <div className="text-[11px] text-muted-foreground">
+          awaiting content…
+        </div>
       )}
     </div>
   );
 }
 
-export function terminalPreview(
-  args: Record<string, unknown> | null,
-): string {
+export function terminalPreview(args: Record<string, unknown> | null): string {
   if (!args) return "";
   const cmd = asString(args.command);
   if (!cmd) return "";
@@ -398,8 +435,7 @@ export function TerminalView({
       : null;
   const stdout = asString(r?.stdout);
   const stderr = asString(r?.stderr);
-  const exitCode =
-    typeof r?.exit_code === "number" ? r.exit_code : null;
+  const exitCode = typeof r?.exit_code === "number" ? r.exit_code : null;
   const err = asString(r?.error);
   return (
     <div className="flex w-full max-w-full flex-col gap-1">

--- a/core/python/long-horizon-harness/web/components/chat/workspace-href.ts
+++ b/core/python/long-horizon-harness/web/components/chat/workspace-href.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const WORKSPACE_ROOT = "/workspace";
+
+/**
+ * Discriminator on the DataPart a highlighted selection travels in.
+ *
+ * The payload is sent untyped (no ADK metadata key), so the backend's
+ * `unwrap_a2a_datapart_text` sees it and renders the model-facing prose;
+ * the chat bubble keys off the same field to draw a quote card instead of
+ * the generic JSON dump. Both sides must agree on this string.
+ */
+export const SELECTION_DATA_KIND = "lha.selection";
+
+/**
+ * Discriminator on the DataPart a dragged workspace file travels in.
+ * Must match _FILEREF_KIND in horizon/a2a/datapart.py.
+ */
+export const FILEREF_DATA_KIND = "lha.fileref";
+
+/** Drag payload for a workspace file, and the mime it is carried under. */
+export const FILEREF_DRAG_MIME = "application/x-lha-workspace-file";
+
+export interface FileRef {
+  path: string;
+  name: string;
+  size?: number;
+}
+
+export interface FileRefPayload {
+  lha_kind: typeof FILEREF_DATA_KIND;
+  paths: string[];
+}
+
+export function isFileRefPayload(v: unknown): v is FileRefPayload {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    o.lha_kind === FILEREF_DATA_KIND &&
+    Array.isArray(o.paths) &&
+    o.paths.every((p) => typeof p === "string")
+  );
+}
+
+export function parseFileRefDrag(raw: string): FileRef | null {
+  try {
+    const v = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof v.path !== "string" || typeof v.name !== "string") return null;
+    return {
+      path: v.path,
+      name: v.name,
+      size: typeof v.size === "number" ? v.size : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface SelectionPayload {
+  lha_kind: typeof SELECTION_DATA_KIND;
+  path: string;
+  /** Character offsets into the raw file — what actually identifies the span. */
+  start: number;
+  end: number;
+  /** Display only; the backend never locates by line. */
+  start_line: number;
+  end_line: number;
+  snippet: string;
+}
+
+export function isSelectionPayload(v: unknown): v is SelectionPayload {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    o.lha_kind === SELECTION_DATA_KIND &&
+    typeof o.path === "string" &&
+    typeof o.snippet === "string" &&
+    typeof o.start === "number" &&
+    typeof o.end === "number" &&
+    typeof o.start_line === "number" &&
+    typeof o.end_line === "number"
+  );
+}
+
+/**
+ * Normalise a workspace path to its canonical ``/workspace/...`` form.
+ *
+ * Tabs are keyed by path, so the sidebar (`/workspace/report.md`) and a
+ * markdown link (`report.md`) have to agree or the same file opens twice.
+ */
+export function normalizeWorkspacePath(raw: string): string | null {
+  let rel = raw.trim();
+  if (!rel) return null;
+  if (rel.startsWith(WORKSPACE_ROOT)) {
+    rel = rel.slice(WORKSPACE_ROOT.length);
+  } else if (rel.startsWith("/")) {
+    // An absolute host path (what write_file echoes back on the local
+    // backend) isn't addressable through the workspace API.
+    return null;
+  }
+  rel = rel.replace(/^\.\//, "").replace(/^\/+/, "");
+  if (!rel) return null;
+  // Traversal is rejected server-side too; bail early so we never render a
+  // panel link that can only 400.
+  if (rel.split("/").some((seg) => seg === ".." || seg === ".")) return null;
+  return `${WORKSPACE_ROOT}/${rel}`;
+}
+
+/**
+ * Return the workspace path a markdown href points at, or ``null`` when the
+ * link belongs to the wider web.
+ *
+ * Only bare relative hrefs qualify — the model writing ``[plot.html](plot.html)``
+ * after generating it. Anything with a scheme, or rooted at ``/``/``#``/``?``,
+ * is a real link and is left alone.
+ */
+// A filename, not a shell line or a sentence: no whitespace, and a short
+// extension that starts with a letter (so version numbers like `3.14` and
+// `v1.2` don't qualify). Membership in the workspace listing is the real
+// gate — this just avoids normalising every backticked token.
+const FILENAME_MENTION = /^[^\s`]+\.[A-Za-z][A-Za-z0-9]{0,7}$/;
+
+/**
+ * Return the workspace path a backticked mention refers to, or ``null``.
+ *
+ * Models write ``I created `cats.md``` far more often than a markdown link,
+ * so inline code is where most workspace-file references land. Callers must
+ * still confirm the file exists before rendering a link.
+ */
+export function workspacePathFromMention(raw: string): string | null {
+  const text = raw.trim();
+  if (!FILENAME_MENTION.test(text)) return null;
+  // Command-ish and URL-ish tokens share the shape but aren't paths.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(text)) return null;
+  if (text.includes("..")) return null;
+  return normalizeWorkspacePath(text);
+}
+
+export function workspacePathFromHref(href?: string): string | null {
+  if (!href) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return null;
+  if (
+    href.startsWith("/") ||
+    href.startsWith("#") ||
+    href.startsWith("?") ||
+    href.startsWith("//")
+  ) {
+    return null;
+  }
+  return normalizeWorkspacePath(href);
+}

--- a/core/python/long-horizon-harness/web/e2e/auto-open-live.spec.ts
+++ b/core/python/long-horizon-harness/web/e2e/auto-open-live.spec.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "@playwright/test";
+
+// Opt-in: drives the real agent.
+// Enable: SMOKE_LIVE=1 npm run test:e2e -- auto-open-live
+test.describe("auto-open a written file", () => {
+  test.skip(!process.env.SMOKE_LIVE, "set SMOKE_LIVE=1 to enable");
+  test.setTimeout(300_000);
+
+  const FILE = "e2e-autoopen.md";
+
+  test("the panel opens the file the turn wrote, with no click", async ({
+    page,
+  }) => {
+    await page.request
+      .delete(`/lha/workspace/file?path=${encodeURIComponent(FILE)}`)
+      .catch(() => {});
+
+    await page.goto("/");
+    await page
+      .getByRole("textbox")
+      .first()
+      .fill(
+        `Use write_file to create ${FILE} with a one-line report about animals. Do not save it as an artifact.`,
+      );
+    await page.keyboard.press("Enter");
+
+    // No interaction with the panel at all — it must open itself.
+    await expect(page.getByRole("tab", { name: new RegExp(FILE) })).toBeVisible(
+      { timeout: 180_000 },
+    );
+  });
+});

--- a/core/python/long-horizon-harness/web/e2e/panel-refresh-live.spec.ts
+++ b/core/python/long-horizon-harness/web/e2e/panel-refresh-live.spec.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "@playwright/test";
+
+// Opt-in: drives the real agent, so it costs inference calls and minutes.
+// Enable: SMOKE_LIVE=1 npm run test:e2e -- panel-refresh-live
+//
+// Reproduces the reported bug: with a workspace file open in the side panel,
+// a turn that rewrites that file must refresh the panel without the user
+// clicking the file again.
+test.describe("side panel refresh after an agent write", () => {
+  test.skip(!process.env.SMOKE_LIVE, "set SMOKE_LIVE=1 to enable");
+  test.setTimeout(300_000);
+
+  const FILE = "e2e-panel.md";
+
+  test("panel updates when the agent rewrites the open file", async ({
+    page,
+  }) => {
+    // /lha/secrets and /lha/gcp/status 500 unless Secret Manager is enabled
+    // on the dev project — unrelated to the panel, so only watch the
+    // workspace endpoints this test actually exercises.
+    const failures: string[] = [];
+    page.on("response", (r) => {
+      const u = new URL(r.url()).pathname;
+      if (!u.startsWith("/lha/workspace")) return;
+      if (r.status() >= 400) failures.push(`${r.status()} ${u}`);
+    });
+
+    // Start from a clean slate so a previous run's file can't satisfy the
+    // assertions before the agent has written anything.
+    await page.request
+      .delete(`/lha/workspace/file?path=${encodeURIComponent(FILE)}`)
+      .catch(() => {});
+
+    await page.goto("/");
+    const composer = page.getByRole("textbox").first();
+
+    // 1. Create the file with a known first heading.
+    await composer.fill(
+      `Use write_file to create ${FILE} containing exactly this line and nothing else: "# Alpha". Do not save it as an artifact.`,
+    );
+    await page.keyboard.press("Enter");
+
+    // 2. Open it in the side panel via the sidebar tree. The row's filename
+    // button (the sibling anchor shares the title, so constrain to `button`).
+    const row = page.locator(`button[title="Open ${FILE}"]`).first();
+    await expect(async () => {
+      await page.getByRole("button", { name: "Refresh workspace" }).click();
+      await expect(row).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 150_000 });
+    await row.click();
+
+    const panel = page.getByRole("tab", { name: new RegExp(FILE) });
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: "Alpha" }).last(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 3. Ask the agent to rewrite it — and do NOT touch the panel after.
+    await composer.fill(
+      `Now use write_file to replace the entire contents of ${FILE} with exactly: "# Beta". Do not save it as an artifact.`,
+    );
+    await page.keyboard.press("Enter");
+
+    // 4. The panel must pick it up on its own.
+    await expect(
+      page.getByRole("heading", { name: "Beta" }).last(),
+    ).toBeVisible({ timeout: 180_000 });
+
+    expect(
+      failures,
+      `workspace request failures: ${failures.join(" | ")}`,
+    ).toEqual([]);
+  });
+});

--- a/core/python/long-horizon-harness/web/e2e/rename-live.spec.ts
+++ b/core/python/long-horizon-harness/web/e2e/rename-live.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "@playwright/test";
+
+// Opt-in: drives the real agent.
+// Enable: SMOKE_LIVE=1 npm run test:e2e -- rename-live
+test.describe("rename swaps the open tab", () => {
+  test.skip(!process.env.SMOKE_LIVE, "set SMOKE_LIVE=1 to enable");
+  test.setTimeout(300_000);
+
+  const OLD = "e2e-oldname.md";
+  const NEW = "e2e-newname.md";
+
+  test("the old tab closes and the new file takes its place", async ({
+    page,
+  }) => {
+    for (const f of [OLD, NEW]) {
+      await page.request
+        .delete(`/lha/workspace/file?path=${encodeURIComponent(f)}`)
+        .catch(() => {});
+    }
+
+    await page.goto("/");
+    const composer = page.getByRole("textbox").first();
+
+    // Auto-open puts it in the panel; no clicking required.
+    await composer.fill(
+      `Use write_file to create ${OLD} with one line about cats. Do not save it as an artifact.`,
+    );
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("tab", { name: new RegExp(OLD) })).toBeVisible({
+      timeout: 180_000,
+    });
+
+    await composer.fill(`Rename ${OLD} to ${NEW}.`);
+    await page.keyboard.press("Enter");
+
+    await expect(page.getByRole("tab", { name: new RegExp(NEW) })).toBeVisible({
+      timeout: 180_000,
+    });
+    await expect(page.getByRole("tab", { name: new RegExp(OLD) })).toBeHidden();
+  });
+});

--- a/core/python/long-horizon-harness/web/e2e/selection-edit-live.spec.ts
+++ b/core/python/long-horizon-harness/web/e2e/selection-edit-live.spec.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "@playwright/test";
+
+// Opt-in: drives the real agent, so it costs inference calls and minutes.
+// Enable: SMOKE_LIVE=1 npm run test:e2e -- selection-edit-live
+test.describe("selection-to-agent edit", () => {
+  test.skip(!process.env.SMOKE_LIVE, "set SMOKE_LIVE=1 to enable");
+  test.setTimeout(300_000);
+
+  const FILE = "e2e-selection.md";
+
+  test("agent rewrites only the highlighted span", async ({ page }) => {
+    await page.request
+      .delete(`/lha/workspace/file?path=${encodeURIComponent(FILE)}`)
+      .catch(() => {});
+
+    await page.goto("/");
+    const composer = page.getByRole("textbox").first();
+
+    await composer.fill(
+      `Use write_file to create ${FILE} with exactly these three lines and nothing else:\nKEEP ONE\nTARGET LINE\nKEEP TWO\nDo not save it as an artifact.`,
+    );
+    await page.keyboard.press("Enter");
+
+    const row = page.locator(`button[title="Open ${FILE}"]`).first();
+    await expect(async () => {
+      await page.getByRole("button", { name: "Refresh workspace" }).click();
+      await expect(row).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 150_000 });
+    await row.click();
+
+    await page.getByRole("button", { name: /^source$/i }).click();
+
+    // Highlight the middle line. React implements onSelect through its
+    // SelectEventPlugin, which watches focus/keyup/mouseup and diffs the
+    // selection — a raw `select` event does not reach it. Focus, set the
+    // range, then emit keyup, which is what a keyboard selection produces.
+    const editor = page.locator("textarea").last();
+    await editor.evaluate((el: HTMLTextAreaElement) => {
+      el.focus();
+      const i = el.value.indexOf("TARGET LINE");
+      el.setSelectionRange(i, i + "TARGET LINE".length);
+      el.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+    });
+
+    // The chip proves the anchor was captured before we type the instruction.
+    await expect(
+      page.getByRole("button", { name: /clear selection/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await composer.fill("Replace this with: REWRITTEN");
+    await page.keyboard.press("Enter");
+
+    await expect(async () => {
+      const body = await page.request
+        .get(`/lha/workspace/download?path=${encodeURIComponent(FILE)}`)
+        .then((r) => r.text());
+      expect(body).toContain("REWRITTEN");
+      expect(body).toContain("KEEP ONE");
+      expect(body).toContain("KEEP TWO");
+      expect(body).not.toContain("TARGET LINE");
+    }).toPass({ timeout: 180_000 });
+  });
+});

--- a/core/python/long-horizon-harness/web/e2e/selection-repeated-live.spec.ts
+++ b/core/python/long-horizon-harness/web/e2e/selection-repeated-live.spec.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "@playwright/test";
+
+// Opt-in: drives the real agent.
+// Enable: SMOKE_LIVE=1 npm run test:e2e -- selection-repeated-live
+//
+// The adversarial case: the highlighted text occurs several times, so no
+// content-based anchor can identify which one was meant. Offsets can.
+test.describe("selection in a repetitive file", () => {
+  test.skip(!process.env.SMOKE_LIVE, "set SMOKE_LIVE=1 to enable");
+  test.setTimeout(300_000);
+
+  const FILE = "e2e-repeat.md";
+  // "b" appears three times; the middle one is the target.
+  const BODY = "a\nb\nc\nb\nd\nb\n";
+
+  test("edits the highlighted occurrence and leaves its twins alone", async ({
+    page,
+  }) => {
+    await page.request
+      .delete(`/lha/workspace/file?path=${encodeURIComponent(FILE)}`)
+      .catch(() => {});
+
+    await page.goto("/");
+    const composer = page.getByRole("textbox").first();
+    await composer.fill(
+      `Use write_file to create ${FILE} with exactly these lines and nothing else:\n${BODY}Do not save it as an artifact.`,
+    );
+    await page.keyboard.press("Enter");
+
+    await expect(page.getByRole("tab", { name: new RegExp(FILE) })).toBeVisible(
+      {
+        timeout: 180_000,
+      },
+    );
+    await page.getByRole("button", { name: /^source$/i }).click();
+
+    // Highlight the SECOND "b" (offset 2), not the first or third.
+    const editor = page.locator("textarea").last();
+    await editor.evaluate((el: HTMLTextAreaElement) => {
+      el.focus();
+      const i = el.value.indexOf("b");
+      el.setSelectionRange(i, i + 1);
+      el.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+    });
+    await expect(
+      page.getByRole("button", { name: /clear selection/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await composer.fill("Replace this with: MIDDLE");
+    await page.keyboard.press("Enter");
+
+    await expect(async () => {
+      const body = await page.request
+        .get(`/lha/workspace/download?path=${encodeURIComponent(FILE)}`)
+        .then((r) => r.text());
+      // Only the highlighted occurrence changed; the other two survive.
+      expect(body.replace(/\s+$/, "")).toBe("a\nMIDDLE\nc\nb\nd\nb");
+    }).toPass({ timeout: 180_000 });
+  });
+});

--- a/core/python/long-horizon-harness/web/lib/__tests__/markdown-commands.test.ts
+++ b/core/python/long-horizon-harness/web/lib/__tests__/markdown-commands.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  applyMarkdownCommand,
+  type MarkdownCommand,
+} from "../markdown-commands";
+
+/**
+ * `|` marks a caret, `[...]` marks a selection. Keeps each case readable as
+ * the before/after a user would actually see.
+ */
+function parse(spec: string) {
+  const selMatch = /\[([\s\S]*?)\]/.exec(spec);
+  if (selMatch) {
+    const start = selMatch.index;
+    const inner = selMatch[1];
+    return {
+      text:
+        spec.slice(0, start) + inner + spec.slice(start + selMatch[0].length),
+      start,
+      end: start + inner.length,
+    };
+  }
+  const caret = spec.indexOf("|");
+  return {
+    text: spec.replace("|", ""),
+    start: caret,
+    end: caret,
+  };
+}
+
+function render(state: { text: string; start: number; end: number }) {
+  if (state.start === state.end) {
+    return (
+      state.text.slice(0, state.start) + "|" + state.text.slice(state.start)
+    );
+  }
+  return (
+    state.text.slice(0, state.start) +
+    "[" +
+    state.text.slice(state.start, state.end) +
+    "]" +
+    state.text.slice(state.end)
+  );
+}
+
+function run(spec: string, cmd: MarkdownCommand) {
+  return render(applyMarkdownCommand(parse(spec), cmd));
+}
+
+describe("inline wrapping", () => {
+  it("wraps a selection and keeps it selected", () => {
+    expect(run("say [hello] there", "bold")).toBe("say **[hello]** there");
+    expect(run("say [hello] there", "italic")).toBe("say *[hello]* there");
+    expect(run("say [hello] there", "strikethrough")).toBe(
+      "say ~~[hello]~~ there",
+    );
+    expect(run("say [hello] there", "code")).toBe("say `[hello]` there");
+  });
+
+  it("inserts a selected placeholder when nothing is selected", () => {
+    // Typing immediately replaces it, so the button is usable with no
+    // selection at all.
+    expect(run("say | there", "bold")).toBe("say **[bold text]** there");
+  });
+
+  it("unwraps when the markers are inside the selection", () => {
+    expect(run("say [**hello**] there", "bold")).toBe("say [hello] there");
+  });
+
+  it("unwraps when the markers sit just outside the selection", () => {
+    // Double-clicking a bold word selects the word, not the asterisks.
+    expect(run("say **[hello]** there", "bold")).toBe("say [hello] there");
+  });
+
+  it("does not mistake bold for italic when toggling", () => {
+    expect(run("say [**hello**] there", "italic")).toBe(
+      "say *[**hello**]* there",
+    );
+  });
+});
+
+describe("line prefixes", () => {
+  it("adds a heading to the caret's line", () => {
+    expect(run("hel|lo\nworld", "h1")).toBe("[# hello]\nworld");
+  });
+
+  it("replaces one heading level with another rather than stacking", () => {
+    expect(run("# hel|lo", "h2")).toBe("[## hello]");
+  });
+
+  it("toggles a heading off", () => {
+    expect(run("## hel|lo", "h2")).toBe("[hello]");
+  });
+
+  it("prefixes every line of a multi-line selection", () => {
+    expect(run("[one\ntwo]", "bullet")).toBe("[- one\n- two]");
+  });
+
+  it("toggles a list off only when every line has it", () => {
+    expect(run("[- one\n- two]", "bullet")).toBe("[one\ntwo]");
+    // Mixed: fill in the gap rather than strip what's there.
+    expect(run("[- one\ntwo]", "bullet")).toBe("[- one\n- two]");
+  });
+
+  it("numbers an ordered list from one", () => {
+    expect(run("[one\ntwo\nthree]", "ordered")).toBe(
+      "[1. one\n2. two\n3. three]",
+    );
+  });
+
+  it("converts a bullet list to an ordered list", () => {
+    expect(run("[- one\n- two]", "ordered")).toBe("[1. one\n2. two]");
+  });
+
+  it("supports task lists and quotes", () => {
+    expect(run("[one]", "task")).toBe("[- [ ] one]");
+    expect(run("[one]", "quote")).toBe("[> one]");
+  });
+});
+
+describe("blocks", () => {
+  it("puts the caret on the url of a new link", () => {
+    expect(run("see [here] now", "link")).toBe("see [here]([url]) now");
+  });
+
+  it("uses a placeholder label when nothing is selected", () => {
+    expect(run("see | now", "link")).toBe("see [text]([url]) now");
+  });
+
+  it("fences a selection as a code block", () => {
+    expect(run("[x = 1]", "codeblock")).toBe("```\n[x = 1]\n```\n");
+  });
+
+  it("inserts a table with example cells and the first header selected", () => {
+    // Filled cells give something to click into; an empty row is a blank
+    // strip with no visible target.
+    expect(run("|", "table")).toBe(
+      "| [Column] | Column |\n| --- | --- |\n| Cell | Cell |\n| Cell | Cell |\n",
+    );
+  });
+});
+
+describe("a selection that includes its trailing newline", () => {
+  it("does not prefix the line after it", () => {
+    // Triple-click and shift+Down both produce this shape.
+    expect(run("[one\n]two\nthree", "bullet")).toBe("[- one]\ntwo\nthree");
+  });
+
+  it("still covers every line of a multi-line selection", () => {
+    expect(run("[one\ntwo\n]three", "bullet")).toBe("[- one\n- two]\nthree");
+  });
+});

--- a/core/python/long-horizon-harness/web/lib/__tests__/selection-anchor.test.ts
+++ b/core/python/long-horizon-harness/web/lib/__tests__/selection-anchor.test.ts
@@ -1,0 +1,126 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { anchorLabel, resolveAnchor } from "../selection-anchor";
+
+describe("resolveAnchor", () => {
+  it("reports the offsets and text of the selection, unmodified", () => {
+    const text = "alpha\nbravo\ncharlie\n";
+    expect(resolveAnchor(text, 6, 11)).toEqual({
+      ok: true,
+      anchor: {
+        start: 6,
+        end: 11,
+        snippet: "bravo",
+        startLine: 2,
+        endLine: 2,
+      },
+    });
+  });
+
+  it("does not widen a selection whose text repeats", () => {
+    // The whole point of offsets: three identical lines stay distinguishable,
+    // and the user gets back exactly what they highlighted.
+    const text = "b\nb\nb\n";
+    const r = resolveAnchor(text, 2, 3);
+    expect(r).toEqual({
+      ok: true,
+      anchor: { start: 2, end: 3, snippet: "b", startLine: 2, endLine: 2 },
+    });
+  });
+
+  it("handles a selection inside a line", () => {
+    const r = resolveAnchor("# dogs\n", 2, 6);
+    expect(r.ok && r.anchor).toEqual({
+      start: 2,
+      end: 6,
+      snippet: "dogs",
+      startLine: 1,
+      endLine: 1,
+    });
+  });
+
+  it("reports 1-based inclusive line numbers for a multi-line selection", () => {
+    const text = "one\ntwo\nthree\nfour\n";
+    const r = resolveAnchor(text, 4, 13);
+    expect(r.ok && r.anchor.snippet).toBe("two\nthree");
+    expect(r.ok && r.anchor.startLine).toBe(2);
+    expect(r.ok && r.anchor.endLine).toBe(3);
+  });
+
+  it("does not claim the next line when the selection ends on a newline", () => {
+    const r = resolveAnchor("one\ntwo\n", 0, 4);
+    expect(r.ok && r.anchor.endLine).toBe(1);
+  });
+
+  it("rejects an empty, collapsed, inverted or blank selection", () => {
+    expect(resolveAnchor("abc", 1, 1)).toEqual({ ok: false });
+    expect(resolveAnchor("abc", 2, 1)).toEqual({ ok: false });
+    expect(resolveAnchor("   \n  ", 0, 5)).toEqual({ ok: false });
+  });
+
+  it("accepts a selection of the whole file, however large", () => {
+    // No cap: offsets stay exact regardless of span length.
+    const text = `${Array(500).fill("x").join("\n")}\n`;
+    const r = resolveAnchor(text, 0, text.length);
+    expect(r.ok).toBe(true);
+    // The trailing newline belongs to line 500, so that is the last line.
+    expect(r.ok && r.anchor.endLine).toBe(500);
+  });
+});
+
+describe("anchorLabel", () => {
+  it("returns short text unchanged, on one line", () => {
+    expect(anchorLabel("hello world")).toBe("hello world");
+    expect(anchorLabel("one\ntwo")).toBe("one two");
+  });
+
+  it("collapses runs of whitespace", () => {
+    expect(anchorLabel("a   \n\n  b")).toBe("a b");
+  });
+
+  it("truncates in the middle so both ends stay visible", () => {
+    const out = anchorLabel(`${"H".repeat(60)} ${"T".repeat(60)}`);
+    expect(out.startsWith("H".repeat(40))).toBe(true);
+    expect(out.endsWith("T".repeat(40))).toBe(true);
+    expect(out.length).toBe(83); // 40 + " … " + 40
+  });
+});
+
+describe("offsets on the wire", () => {
+  it("counts code points, not UTF-16 units", () => {
+    // The server slices code points; the DOM counts UTF-16 units, so an
+    // astral character earlier in the file shifts every later offset by one.
+    const text = "🐈 cat\nbravo\n";
+    const utf16Start = text.indexOf("bravo");
+    const r = resolveAnchor(text, utf16Start, utf16Start + 5);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.anchor.snippet).toBe("bravo");
+    // [..."🐈 cat\n"].length === 6, not 7.
+    expect(r.anchor.start).toBe(6);
+    expect(r.anchor.end).toBe(11);
+    // And the server's slice of those offsets is the selection.
+    expect([...text].slice(r.anchor.start, r.anchor.end).join("")).toBe(
+      "bravo",
+    );
+  });
+
+  it("is unchanged for plain ASCII", () => {
+    const r = resolveAnchor("alpha\nbravo\n", 6, 11);
+    expect(r.ok && r.anchor.start).toBe(6);
+    expect(r.ok && r.anchor.end).toBe(11);
+  });
+});

--- a/core/python/long-horizon-harness/web/lib/__tests__/workspace-files.test.ts
+++ b/core/python/long-horizon-harness/web/lib/__tests__/workspace-files.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { isAgentWorkingFile, workspacePathForName } from "../workspace-files";
+
+const files = new Map([
+  ["/workspace/report.md", 1],
+  ["/workspace/docs/plan.md", 2],
+  ["/workspace/notes/plan.md", 3],
+]);
+
+describe("workspacePathForName", () => {
+  it("resolves a unique basename to its path", () => {
+    expect(workspacePathForName(files, "report.md")).toBe(
+      "/workspace/report.md",
+    );
+  });
+
+  it("refuses an ambiguous basename", () => {
+    // Opening the wrong plan.md and letting it be edited is worse than
+    // leaving the attachment read-only.
+    expect(workspacePathForName(files, "plan.md")).toBeNull();
+  });
+
+  it("returns null for a file that isn't in the workspace", () => {
+    expect(workspacePathForName(files, "elsewhere.md")).toBeNull();
+  });
+
+  it("returns null before the listing has loaded", () => {
+    expect(workspacePathForName(undefined, "report.md")).toBeNull();
+  });
+
+  it("does not match on a path suffix", () => {
+    expect(workspacePathForName(files, "md")).toBeNull();
+    expect(workspacePathForName(files, "docs/plan.md")).toBeNull();
+  });
+});
+describe("isAgentWorkingFile", () => {
+  it("treats the agent's own bookkeeping as working material", () => {
+    expect(isAgentWorkingFile("/workspace/plan.md")).toBe(true);
+    expect(isAgentWorkingFile("/workspace/TODO.md")).toBe(true);
+    expect(isAgentWorkingFile("/workspace/scripts/md_to_pdf.py")).toBe(true);
+    expect(isAgentWorkingFile("/workspace/.agents/skills/x/SKILL.md")).toBe(
+      true,
+    );
+    expect(isAgentWorkingFile("/workspace/.ruff_cache/x")).toBe(true);
+  });
+
+  it("treats everything else as the user's", () => {
+    expect(isAgentWorkingFile("/workspace/report.md")).toBe(false);
+    expect(isAgentWorkingFile("/workspace/cats.pdf")).toBe(false);
+    // A plan inside a project folder is that project's document.
+    expect(isAgentWorkingFile("/workspace/acme/plan.md")).toBe(false);
+    // Not fooled by a name that merely contains one.
+    expect(isAgentWorkingFile("/workspace/my-plan.md")).toBe(false);
+    expect(isAgentWorkingFile("/workspace/scripts-notes.md")).toBe(false);
+  });
+});

--- a/core/python/long-horizon-harness/web/lib/markdown-commands.ts
+++ b/core/python/long-horizon-harness/web/lib/markdown-commands.ts
@@ -1,0 +1,247 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Text transforms behind the markdown toolbar.
+ *
+ * Pure: text plus a selection in, text plus a new selection out. The editor
+ * only applies the result and restores the caret, so every rule here — what
+ * toggles off, what a placeholder is, where the caret lands — is testable
+ * without a DOM.
+ */
+
+export interface EditState {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export type MarkdownCommand =
+  | "bold"
+  | "italic"
+  | "strikethrough"
+  | "code"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "bullet"
+  | "ordered"
+  | "task"
+  | "quote"
+  | "codeblock"
+  | "link"
+  | "table";
+
+const WRAPS: Record<string, { marker: string; placeholder: string }> = {
+  bold: { marker: "**", placeholder: "bold text" },
+  italic: { marker: "*", placeholder: "italic text" },
+  strikethrough: { marker: "~~", placeholder: "struck text" },
+  code: { marker: "`", placeholder: "code" },
+};
+
+const LINE_PREFIXES: Record<string, string> = {
+  h1: "# ",
+  h2: "## ",
+  h3: "### ",
+  bullet: "- ",
+  task: "- [ ] ",
+  quote: "> ",
+};
+
+// Any prefix this family owns, so applying one replaces another rather than
+// stacking (`## - # heading`).
+const HEADING_RE = /^#{1,6} /;
+const BULLET_RE = /^- (\[[ xX]\] )?/;
+const ORDERED_RE = /^\d+\. /;
+const QUOTE_RE = /^> /;
+
+function stripLinePrefix(line: string): string {
+  return line
+    .replace(HEADING_RE, "")
+    .replace(BULLET_RE, "")
+    .replace(ORDERED_RE, "")
+    .replace(QUOTE_RE, "");
+}
+
+/** Expand a selection to cover the whole lines it touches. */
+function lineSpan(text: string, start: number, end: number) {
+  const from = text.lastIndexOf("\n", start - 1) + 1;
+  // A selection that already swallowed its trailing newline (triple-click,
+  // shift+Down) must not also take the line after it.
+  if (end > start && text[end - 1] === "\n") return { from, to: end - 1 };
+  let to = text.indexOf("\n", end);
+  if (to === -1) to = text.length;
+  return { from, to };
+}
+
+function replace(
+  state: EditState,
+  from: number,
+  to: number,
+  body: string,
+  selStart: number,
+  selEnd: number,
+): EditState {
+  return {
+    text: state.text.slice(0, from) + body + state.text.slice(to),
+    start: selStart,
+    end: selEnd,
+  };
+}
+
+/**
+ * Length of the run of `ch` immediately before / at index `i`.
+ *
+ * `*` is both the italic and the bold marker, so a match only belongs to this
+ * style when the run is exactly this wide — otherwise italic would strip one
+ * asterisk off `**bold**` and quietly turn it into italic.
+ */
+function runBefore(text: string, i: number, ch: string): number {
+  let n = 0;
+  while (i - n - 1 >= 0 && text[i - n - 1] === ch) n++;
+  return n;
+}
+
+function runAfter(text: string, i: number, ch: string): number {
+  let n = 0;
+  while (i + n < text.length && text[i + n] === ch) n++;
+  return n;
+}
+
+function applyWrap(state: EditState, cmd: keyof typeof WRAPS): EditState {
+  const { marker, placeholder } = WRAPS[cmd];
+  const { text, start, end } = state;
+  const selected = text.slice(start, end);
+  const ch = marker[0];
+  const width = marker.length;
+
+  // Already wrapped, inside the selection — unwrap.
+  if (
+    selected.length >= width * 2 &&
+    runAfter(selected, 0, ch) === width &&
+    runBefore(selected, selected.length, ch) === width
+  ) {
+    const inner = selected.slice(width, selected.length - width);
+    return replace(state, start, end, inner, start, start + inner.length);
+  }
+
+  // Already wrapped, just outside the selection — unwrap those too, so
+  // double-clicking the word itself still toggles off.
+  if (
+    selected &&
+    runBefore(text, start, ch) === width &&
+    runAfter(text, end, ch) === width
+  ) {
+    const from = start - width;
+    return replace(
+      state,
+      from,
+      end + width,
+      selected,
+      from,
+      from + selected.length,
+    );
+  }
+
+  const body = selected || placeholder;
+  const inner = start + width;
+  return replace(
+    state,
+    start,
+    end,
+    `${marker}${body}${marker}`,
+    inner,
+    inner + body.length,
+  );
+}
+
+function applyLinePrefix(state: EditState, prefix: string): EditState {
+  const { text, start, end } = state;
+  const { from, to } = lineSpan(text, start, end);
+  const lines = text.slice(from, to).split("\n");
+  // Toggle off only when every line already carries exactly this prefix.
+  const allHave = lines.every((l) => l.startsWith(prefix));
+  const next = lines
+    .map((l) =>
+      allHave ? l.slice(prefix.length) : prefix + stripLinePrefix(l),
+    )
+    .join("\n");
+  return replace(state, from, to, next, from, from + next.length);
+}
+
+function applyOrdered(state: EditState): EditState {
+  const { text, start, end } = state;
+  const { from, to } = lineSpan(text, start, end);
+  const lines = text.slice(from, to).split("\n");
+  const allHave = lines.every((l) => ORDERED_RE.test(l));
+  const next = lines
+    .map((l, i) =>
+      allHave ? l.replace(ORDERED_RE, "") : `${i + 1}. ${stripLinePrefix(l)}`,
+    )
+    .join("\n");
+  return replace(state, from, to, next, from, from + next.length);
+}
+
+function applyLink(state: EditState): EditState {
+  const { text, start, end } = state;
+  const label = text.slice(start, end) || "text";
+  const body = `[${label}](url)`;
+  // Land on `url` — the label is either already right or easy to retype.
+  const urlAt = start + body.indexOf("(") + 1;
+  return replace(state, start, end, body, urlAt, urlAt + 3);
+}
+
+/**
+ * Replace the selection with a block, breaking onto a new line first when the
+ * caret is mid-line so the fence or table starts where markdown expects.
+ */
+function insertBlock(
+  state: EditState,
+  block: string,
+  selectFrom: number,
+  selectLength: number,
+): EditState {
+  const { text, start, end } = state;
+  const atLineStart = start === 0 || text[start - 1] === "\n";
+  const lead = atLineStart ? "" : "\n";
+  const at = start + lead.length + selectFrom;
+  return replace(state, start, end, lead + block, at, at + selectLength);
+}
+
+function applyCodeBlock(state: EditState): EditState {
+  const selected = state.text.slice(state.start, state.end);
+  const body = selected || "code";
+  const block = `\`\`\`\n${body}\n\`\`\`\n`;
+  return insertBlock(state, block, 4, body.length);
+}
+
+function applyTable(state: EditState): EditState {
+  // Filled cells rather than empty ones: an empty row renders as a blank
+  // strip, so there is nothing to aim at when replacing the contents.
+  const block =
+    "| Column | Column |\n| --- | --- |\n| Cell | Cell |\n| Cell | Cell |\n";
+  return insertBlock(state, block, 2, 6);
+}
+
+export function applyMarkdownCommand(
+  state: EditState,
+  cmd: MarkdownCommand,
+): EditState {
+  if (cmd in WRAPS) return applyWrap(state, cmd as keyof typeof WRAPS);
+  if (cmd in LINE_PREFIXES) return applyLinePrefix(state, LINE_PREFIXES[cmd]);
+  if (cmd === "ordered") return applyOrdered(state);
+  if (cmd === "link") return applyLink(state);
+  if (cmd === "codeblock") return applyCodeBlock(state);
+  return applyTable(state);
+}

--- a/core/python/long-horizon-harness/web/lib/selection-anchor.ts
+++ b/core/python/long-horizon-harness/web/lib/selection-anchor.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Describe a highlighted span as a range in the raw file.
+ *
+ * The span is identified by character offsets, not by its text. Content-based
+ * anchors cannot survive a file where the same words repeat, and they break
+ * outright in the rendered preview, where a selection reads `important` while
+ * the source says `**important**`. `patch` verifies the text at the offsets
+ * before writing, so position gives precision and content gives safety.
+ *
+ * This is the seam between a selection surface and the wire payload. The
+ * Source textarea resolves offsets directly; a future preview editor resolves
+ * them from mdast node positions, which carry offsets into the same raw
+ * source. Both produce a `SelectionAnchor`, and nothing downstream changes.
+ */
+
+export interface SelectionAnchor {
+  /**
+   * Offsets into the raw file, as **code points** — `start` inclusive, `end`
+   * exclusive. The DOM counts UTF-16 units, but the server slices code
+   * points, so one emoji earlier in the file would shift every offset by one.
+   */
+  start: number;
+  end: number;
+  /** The text at that range, used by the backend to verify before writing. */
+  snippet: string;
+  /** 1-based, inclusive. Display only. */
+  startLine: number;
+  /** 1-based, inclusive. Display only. */
+  endLine: number;
+}
+
+export type AnchorResult =
+  | { ok: true; anchor: SelectionAnchor }
+  | { ok: false };
+
+/**
+ * Convert a UTF-16 offset (what the DOM reports) to a code-point index (what
+ * Python's slicing uses). Equal for the ASCII case, off by one per astral
+ * character otherwise — an emoji anywhere earlier in the document.
+ */
+function codePointIndex(text: string, utf16Offset: number): number {
+  return [...text.slice(0, utf16Offset)].length;
+}
+
+/** Index of the line (0-based) containing character offset `pos`. */
+function lineAt(lineStarts: number[], pos: number): number {
+  let lo = 0;
+  let hi = lineStarts.length - 1;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (lineStarts[mid] <= pos) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+export function resolveAnchor(
+  text: string,
+  start: number,
+  end: number,
+): AnchorResult {
+  if (end <= start) return { ok: false };
+  const snippet = text.slice(start, end);
+  if (!snippet.trim()) return { ok: false };
+
+  const lineStarts: number[] = [];
+  let acc = 0;
+  for (const l of text.split("\n")) {
+    lineStarts.push(acc);
+    acc += l.length + 1;
+  }
+
+  return {
+    ok: true,
+    anchor: {
+      start: codePointIndex(text, start),
+      end: codePointIndex(text, end),
+      snippet,
+      startLine: lineAt(lineStarts, start) + 1,
+      // `end` is exclusive; step back one char so a selection ending exactly
+      // at a newline doesn't claim the following line.
+      endLine: lineAt(lineStarts, Math.max(start, end - 1)) + 1,
+    },
+  };
+}
+
+const LABEL_SIDE = 40;
+
+/**
+ * One-line chip text. Truncates in the *middle*: with a range, both ends need
+ * confirming — a tail-truncated label tells you nothing about where the
+ * selection stops.
+ */
+export function anchorLabel(snippet: string): string {
+  const flat = snippet.replace(/\s+/g, " ").trim();
+  if (flat.length <= LABEL_SIDE * 2 + 3) return flat;
+  return `${flat.slice(0, LABEL_SIDE)} … ${flat.slice(-LABEL_SIDE)}`;
+}

--- a/core/python/long-horizon-harness/web/lib/workspace-files.ts
+++ b/core/python/long-horizon-harness/web/lib/workspace-files.ts
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The set of workspace files, used to decide whether a filename the model
+ * mentioned is real. Chat linkifies backticked filenames, and a link that
+ * opens an empty panel is worse than plain text — so membership here is the
+ * gate.
+ *
+ * Deliberately not a React Query hook: `Markdown` renders in contexts with no
+ * QueryClientProvider (message-bubble tests, standalone previews), and
+ * `useQueryClient` throws there. A module-level store keeps the consumer a
+ * plain subscription that degrades to "no data, no links".
+ */
+
+import { useEffect, useSyncExternalStore } from "react";
+
+const ROOT = "/workspace";
+
+// One level below the root. Agent-written deliverables land at the root or in
+// a project folder; going deeper would cost a request per directory for
+// files nobody backticks.
+const MAX_DEPTH = 2;
+
+// Coalesce the burst of mounts when a long transcript renders.
+const MIN_REFETCH_INTERVAL_MS = 5_000;
+
+interface TreeEntry {
+  name: string;
+  kind: "file" | "dir" | "symlink";
+  mtime?: number;
+}
+
+/** Workspace path -> mtime, so "the newest file this turn made" is decidable. */
+export type WorkspaceFiles = ReadonlyMap<string, number>;
+
+let cache: WorkspaceFiles | undefined;
+let lastFetchedAt = 0;
+let inFlight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+async function fetchDir(path: string): Promise<TreeEntry[]> {
+  const r = await fetch(
+    `/lha/workspace/tree?path=${encodeURIComponent(path)}`,
+    {
+      cache: "no-store",
+    },
+  );
+  if (!r.ok) throw new Error(`workspace-tree ${r.status}`);
+  const body = (await r.json()) as { entries?: TreeEntry[] };
+  return body.entries ?? [];
+}
+
+/**
+ * The workspace path for a bare filename, or `null` when it isn't in the
+ * workspace or the name is ambiguous.
+ *
+ * A chat attachment carries only the file's name and bytes — the artifact
+ * service has no notion of where it came from. Recovering the path is what
+ * lets an attachment behave like the file it is, rather than a read-only
+ * snapshot of it. Ambiguity yields `null`: opening the wrong `report.md` and
+ * letting the user edit it is worse than leaving the attachment read-only.
+ */
+export function workspacePathForName(
+  files: WorkspaceFiles | undefined,
+  name: string,
+): string | null {
+  if (!files || !name) return null;
+  let found: string | null = null;
+  for (const path of files.keys()) {
+    if (path.slice(path.lastIndexOf("/") + 1) !== name) continue;
+    if (found) return null; // same basename in two directories
+    found = path;
+  }
+  return found;
+}
+
+// Files the agent keeps for itself. `plan.md` is prompted for by name, and
+// skills and scripts are how the harness is extended — none of them are the
+// answer to what the user asked, so the panel never surfaces them on its own.
+const WORKING_DIRS = ["scripts/", ".agents/"];
+const WORKING_NAMES = new Set(["plan.md", "todo.md"]);
+
+/** True when `path` is agent working material rather than a user-facing file. */
+export function isAgentWorkingFile(path: string): boolean {
+  const rel = path.startsWith(ROOT + "/") ? path.slice(ROOT.length + 1) : path;
+  if (!rel) return false;
+  if (rel.split("/").some((seg) => seg.startsWith("."))) return true;
+  if (WORKING_DIRS.some((d) => rel.startsWith(d))) return true;
+  return WORKING_NAMES.has(rel.toLowerCase());
+}
+
+/** Fetch a fresh listing, bypassing the cache. */
+export async function listWorkspaceFiles(): Promise<Map<string, number>> {
+  const files = new Map<string, number>();
+
+  const walk = async (dir: string, depth: number): Promise<void> => {
+    const entries = await fetchDir(dir);
+    const subDirs: string[] = [];
+    for (const e of entries) {
+      const full = `${dir}/${e.name}`;
+      if (e.kind === "dir") {
+        if (depth < MAX_DEPTH) subDirs.push(full);
+      } else {
+        files.set(full, e.mtime ?? 0);
+      }
+    }
+    // Siblings in parallel; the tree endpoint is a cheap directory listing.
+    await Promise.all(subDirs.map((d) => walk(d, depth + 1)));
+  };
+
+  await walk(ROOT, 1);
+  return files;
+}
+
+/**
+ * Refresh the listing. ``force`` bypasses the interval — used when a turn
+ * ends, since the agent has usually just written the file it's about to
+ * mention.
+ */
+export function refreshWorkspaceFiles(force = false): void {
+  if (typeof fetch !== "function") return;
+  if (inFlight) return;
+  if (!force && Date.now() - lastFetchedAt < MIN_REFETCH_INTERVAL_MS) return;
+  inFlight = listWorkspaceFiles()
+    .then((files) => {
+      cache = files;
+      emit();
+    })
+    .catch(() => {
+      // A failed listing just means nothing gets linkified — strictly better
+      // than rendering a link we can't honour.
+    })
+    .finally(() => {
+      lastFetchedAt = Date.now();
+      inFlight = null;
+    });
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+const getSnapshot = (): WorkspaceFiles | undefined => cache;
+
+/** Test seam. */
+export function __resetWorkspaceFiles(): void {
+  cache = undefined;
+  lastFetchedAt = 0;
+  inFlight = null;
+  listeners.clear();
+}
+
+/**
+ * Known workspace files, refreshed on mount and whenever a turn ends.
+ * Returns ``undefined`` until the first listing lands.
+ */
+export function useWorkspaceFiles(busy: boolean): WorkspaceFiles | undefined {
+  useEffect(() => {
+    // Turn end is the one moment we know the tree may have changed.
+    refreshWorkspaceFiles(!busy);
+  }, [busy]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
# Editable documents in the side panel

The side panel used to be read-only: you could look at a file the agent wrote, but not change it. Now it's a place you can work — open a document, edit it, and point the agent at a sentence.

46 files · no new dependencies

---

## What you can do now

**Open any file by clicking it** in the sidebar. Before, clicking only downloaded it.

**Edit documents in the panel.** Type directly into the file. It saves itself a moment after you stop typing — no save button. A file whose bytes aren't valid UTF-8 stays read-only rather than being saved back mangled.

**Format with a toolbar**, like a document editor: bold, italic, headings, bullet and numbered lists, quotes, links, tables, code.

**Highlight a sentence and tell the agent what to do with it.** Select some text, a small chip appears above the message box, then type *"make this shorter"*. The agent changes exactly that sentence and nothing else — even in a file where the same words appear several times. This works while the agent is busy too: the message waits its turn and keeps the highlight.

**The panel keeps itself up to date.** When the agent creates a file, it opens. When the agent edits the file you're looking at, it refreshes. When a file is renamed or deleted, the tab follows. No reloading the page.

**Click a filename in the chat to open it.** Whether the agent writes it as a link or just mentions it, the name is clickable.

**Drag a file from the sidebar into the message box** to attach it, instead of typing its name.

**The agent never fights you for the panel.** While it's working, the editor locks so your changes can't be overwritten. Its own scratch files (plans, helper scripts) stay out of your way.

---

## How it works, briefly

The file on disk stays plain Markdown, HTML or text — nothing proprietary, and the agent can still read and edit it normally.

When you highlight text, the panel records **where** it is in the file rather than **what** it says. That's what makes editing reliable in a document that repeats itself, and it's also what would let editing move into the rendered preview later.

UI actions — a highlight, a dragged file — are sent to the agent as structured events, not as text pasted into your message. So the chat shows what you did, not the machinery behind it.

---

## Technical summary

| Change | Purpose |
|---|---|
| `PUT /lha/workspace/file` | Save an edit from the browser. Same guards as the agent's own writes: protected paths, binary reject, traversal, size cap. |
| `patch` accepts character offsets | Edit an exact span. The expected text is verified before writing, so a stale edit fails rather than corrupting the file. |
| `datapart.py` renders UI events | Turns a highlight or an attached file into instructions server-side, so none of it appears in the transcript. |

## Testing

- Web **492 passing**, Python **2411 passing**
- 6 opt-in end-to-end tests (`SMOKE_LIVE=1`) that drive the real agent: editing a highlighted passage, doing it in a repetitive file, panel refresh, auto-open, rename, HTML editing

**Pre-existing failures, untouched:** 11 in `use-appearance.test.ts` (a happy-dom issue), 1 in `test_repo_overview.py`. Both fail on `main`.

---

## Limits

- **The rendered preview is read-only.** Agent-generated HTML runs in a locked sandbox, so the page can't read clicks or selections inside it. HTML is edited as source.
- **Fonts and colours aren't available.** Markdown has no syntax for them. Headings give you six text sizes.
