### PR TITLE
docs(handbook): rewrite troubleshooting around symptom, cause, fix, confirm

### DIFF
--- a/docs/recipe-handbook/anatomy.md
+++ b/docs/recipe-handbook/anatomy.md
@@ -62,8 +62,8 @@ Generate with the `generate-manifest` AI skill.
 
 Two of those are not just metadata — CI acts on them:
 
-- **`ownership.poc` is a delivery address.** We may contact this point of
-  contact if any maintenance work is needed for the recipe.
+- **`ownership.poc` is the person we contact.** We reach out to them if the
+  recipe needs maintenance work.
 - **`status` tracks the health of the recipe.** It is `active` by default.
   The recipe's health is checked and evaluated on a schedule, and if issues
   go unresolved for long enough the status is eventually set to `inactive`.

--- a/docs/recipe-handbook/anatomy.md
+++ b/docs/recipe-handbook/anatomy.md
@@ -1,4 +1,4 @@
-<!-- word count: 530 (target 700, cap 1000) -->
+<!-- word count: 650 (target 700, cap 1000) -->
 
 # Anatomy of a Recipe
 
@@ -60,17 +60,15 @@ Generate with the `generate-manifest` AI skill.
 | `ownership.team` | Team name |
 | `ownership.poc` (Point of Contact) | GitHub user ID of the accountable owner |
 
-Two of those are not just metadata — the
-[recipe canary](../../.github/workflows/recipe-canary.yml) acts on them:
+Two of those are not just metadata — CI acts on them:
 
-- **`ownership.poc` is a delivery address.** When the canary finds your
-  recipe no longer installs from its committed lockfile, it opens an issue
-  and @-mentions this user. Put a real GitHub ID here; a wrong one means
-  nobody hears that the recipe is broken.
-- **`status: inactive` means "on the way out".** The canary asks for it after
-  a recipe has failed three monthly runs, and proposes removal two runs
-  later. Nothing sets it back automatically, so if you fix a recipe that was
-  marked inactive, set it to `active` in the same PR. See
+- **`ownership.poc` is a delivery address.** We may contact this point of
+  contact if any maintenance work is needed for the recipe.
+- **`status` tracks the health of the recipe.** It is `active` by default.
+  The recipe's health is checked and evaluated on a schedule, and if issues
+  go unresolved for long enough the status is eventually set to `inactive`.
+  If the situation remains unresolved, the recipe is deprecated and removed
+  from the repository. See
   [Recipe is marked inactive](troubleshooting.md#recipe-is-marked-inactive).
 
 **Common optional fields:**

--- a/docs/recipe-handbook/troubleshooting.md
+++ b/docs/recipe-handbook/troubleshooting.md
@@ -1,10 +1,14 @@
-<!-- word count: 2840 (target 500+, no cap) -->
+<!-- word count: 2890 (target 500+, no cap) -->
 
 # Troubleshooting
 
 A check failed on your recipe and you need to get it green. Find your error
 on this page, follow the steps, and run the command at the end of the
 section to confirm the fix worked before you push again.
+
+Run every command from the repo root, and replace `<recipe-path>` with the
+path to your recipe — `core/python/my-recipe`, `contrib/python/my-recipe`,
+or `skills/retail/my-skill`.
 
 ## Contents
 
@@ -124,7 +128,8 @@ and 2 MB.
    configuration, build output.
 3. Move data files over 1 MB to a storage bucket and link them from
    `README.md`.
-4. Convert screenshots to WebP: `cwebp -q 85 shot.png -o shot.webp`.
+4. Convert screenshots to WebP:
+   `cwebp -q 85 <recipe-path>/shot.png -o <recipe-path>/shot.webp`.
 
 **Confirm** — `uv run validate structure <recipe-path>`
 
@@ -152,7 +157,7 @@ because its manifest says `language: python`.
 | `manifest.yaml` | `generate-manifest` (AI skill) |
 | `.env.example` | `extract-python-environment-variables` (AI skill) |
 | `tests/test_runnability.py` | `generate-python-runnability-test` (AI skill) |
-| `uv.lock` | `uv lock` in the recipe directory |
+| `uv.lock` | `uv lock --project <recipe-path>` |
 | `pyproject.toml` | `align-recipe-pyproject` (AI skill) |
 | everything at once | `scaffold-python-recipe` (AI skill) |
 
@@ -160,7 +165,8 @@ Directory looks present but still reported missing? Git cannot commit an
 empty directory. Commit a placeholder:
 
 ```bash
-touch scripts/.gitkeep && git add scripts/.gitkeep
+touch <recipe-path>/scripts/.gitkeep
+git add <recipe-path>/scripts/.gitkeep
 ```
 
 **Confirm** — `uv run validate structure <recipe-path>`
@@ -486,7 +492,12 @@ assistant, copy the template from
 [python.md — Copy-paste starters](./languages/python.md#copy-paste-starters)
 and point it at your agent.
 
-**Confirm** — `uv run pytest <recipe-path>/tests/test_runnability.py`
+**Confirm** —
+`uv run --project <recipe-path> pytest <recipe-path>/tests/test_runnability.py`
+
+The `--project` flag matters: a recipe installs into its own environment, so
+plain `uv run pytest` uses the repo's environment and fails on imports the
+recipe declares.
 
 ## Ruff format or check failed
 
@@ -524,7 +535,7 @@ keeps sliding toward removal.
 1. Check the recipe still installs and passes:
    ```bash
    uv sync --dev --frozen --project <recipe-path>
-   uv run --frozen --project <recipe-path> pytest
+   uv run --frozen --project <recipe-path> pytest <recipe-path>/tests
    ```
 2. Update the package versions and re-lock if either step fails:
    `uv lock --project <recipe-path>`.

--- a/docs/recipe-handbook/troubleshooting.md
+++ b/docs/recipe-handbook/troubleshooting.md
@@ -1,50 +1,18 @@
-<!-- word count: 2950 (target 500+, no cap) -->
+<!-- word count: 2840 (target 500+, no cap) -->
 
 # Troubleshooting
 
-Every error a recipe can hit, the fix, and a command that proves it worked.
-
-## Start here
-
-1. Read the `Docs:` line printed under the failure. It names the section
-   below that covers your error.
-2. No `Docs:` line? Look up the file named in the error in the
-   [Contents](#contents).
-3. Fix missing or misplaced files first. One absent `manifest.yaml` or one
-   stale `uv.lock` turns several checks red at once.
-
-Run the structural checks on your own machine before pushing again:
-
-```bash
-uv run validate all <recipe-path>
-```
-
-Pushing to your PR branch re-runs every check automatically. Ask a reviewer
-to re-run a job only when one appears stuck.
-
-<!-- Table separators above the Contents block use ':..' style, not three
-     hyphens: tools/tests/test_ci_message.py treats the first horizontal
-     rule as the end of the Contents list, and a three-hyphen separator row
-     here would truncate it. -->
-
-| The error says | Go to |
-| :-- | :-- |
-| `is out of date — run: uv lock` | [uv.lock out of sync](#uvlock-out-of-sync) |
-| `Would reformat`, or a rule ID such as `E501` | [Ruff format or check failed](#ruff-format-or-check-failed) |
-| `Required file '<name>' is missing` | [Required file or directory missing](#required-file-or-directory-missing) |
-| `Environment variable '<VAR>' is read by Python source` | [Env var missing from .env.example](#env-var-missing-from-envexample) |
-| `[ci-fault]` or `CI tooling failure in` | [CI infrastructure failure](#ci-infrastructure-failure) |
+A check failed on your recipe and you need to get it green. Find your error
+on this page, follow the steps, and run the command at the end of the
+section to confirm the fix worked before you push again.
 
 ## Contents
 
-**Structure and placement**
+### General
+
+**manifest.yaml**
 - [manifest.yaml is missing, or fails the schema](#manifestyaml-missing-or-invalid)
 - [ownership.team or ownership.poc still holds scaffold text](#ownershipteam-or-poc-is-a-placeholder)
-- [The recipe folder name breaks the naming rule](#directory-name-too-long-or-invalid)
-- [The recipe is too big, or has too many files](#recipe-exceeds-size-or-file-limit)
-- [A file or directory the recipe must have is absent](#required-file-or-directory-missing)
-- [The recipe sits at the wrong path](#recipe-is-in-the-wrong-folder)
-- [The recipe lives in a folder that no longer accepts edits](#changes-inside-a-retired-folder)
 
 **README.md**
 - [README.md is absent or empty](#readmemd-is-missing-or-empty)
@@ -52,6 +20,15 @@ to re-run a job only when one appears stuck.
 - [README.md is under the 100-word minimum](#readmemd-is-too-short)
 - [README.md has no setup heading](#readmemd-is-missing-a-setup-section)
 - [README.md has no run heading, or no command to copy](#readmemd-is-missing-a-run-section-or-code-block)
+
+**Files and folders**
+- [The recipe folder name breaks the naming rule](#directory-name-too-long-or-invalid)
+- [The recipe is too big, or has too many files](#recipe-exceeds-size-or-file-limit)
+- [A file or directory the recipe must have is absent](#required-file-or-directory-missing)
+- [The recipe sits at the wrong path](#recipe-is-in-the-wrong-folder)
+- [The recipe lives in a folder that no longer accepts edits](#changes-inside-a-retired-folder)
+
+### Python
 
 **pyproject.toml**
 - [pyproject.toml configures Ruff locally](#pyprojecttoml-has-a-local-ruff-configuration)
@@ -76,6 +53,8 @@ to re-run a job only when one appears stuck.
 - [The recipe has no runnability test](#runnability-test-missing)
 - [Formatting or lint rules failed](#ruff-format-or-check-failed)
 
+### Warnings and unknown failures
+
 **Warnings that do not block your PR**
 - [The recipe is flagged as unhealthy](#recipe-is-marked-inactive)
 - [A core recipe is on an old ADK major](#core-recipe-is-behind-the-current-adk-major)
@@ -89,16 +68,17 @@ to re-run a job only when one appears stuck.
 
 ## manifest.yaml missing or invalid
 
-**Symptom** — `[manifest] manifest.yaml is missing.` or `[manifest]` followed
-by a schema error.
+**Symptom** — `[manifest-missing] manifest.yaml is missing.`,
+`[manifest-empty] manifest.yaml has no content — it is either empty or
+contains only comments.`, or a schema error naming the failing field.
 
 **Cause** — every recipe needs a `manifest.yaml` matching the
 [schema](../../.github/schemas/manifest-schema.json).
 
 **Fix**
 
-- File absent: run `generate-manifest` (AI skill), or copy the
-  [minimum example](./anatomy.md#manifestyaml) and edit it.
+- File absent, empty, or only comments: run `generate-manifest` (AI skill),
+  or copy the [minimum example](./anatomy.md#manifestyaml) and edit it.
 - File present but rejected: the error names the failing field. Every
   manifest needs `type`, `status`, `language`, `description`,
   `ownership.team` and `ownership.poc`.
@@ -107,8 +87,8 @@ by a schema error.
 
 ## ownership.team or poc is a placeholder
 
-**Symptom** — `[ownership.team] is still set to the placeholder value`, or the
-same for `[ownership.poc]`.
+**Symptom** — `[ownership-placeholder] ownership.team is still the scaffold
+placeholder`, or the same for `ownership.poc`.
 
 **Cause** — the scaffold's placeholder text is still in `manifest.yaml`.
 
@@ -131,7 +111,8 @@ with a letter, 30 characters at most.
 
 ## Recipe exceeds size or file limit
 
-**Symptom** — `Recipe folder exceeds` or `exceeding the limit`
+**Symptom** — `Recipe folder is 3.4 MB; the limit is 2 MB.`, or
+`Recipe folder contains 91 counted files; the limit is 70.`
 
 **Cause** — the recipe passes its budget. Under `contrib/` that is 70 files
 and 2 MB.
@@ -209,7 +190,7 @@ skills/retail/product-search/x/manifest.yaml  too deep
 
 ## Changes inside a retired folder
 
-**Symptom** — `is in a retired folder and no longer accepts changes`
+**Symptom** — `is in a retired folder, which no longer accepts changes.`
 
 **Cause** — recipes used to live at `<language>/agents/<recipe>` in the repo
 root. Those roots are closed.
@@ -230,18 +211,19 @@ out is never blocked.
 
 ## README.md is missing or empty
 
-**Symptom** — `README.md is missing` or `README.md is empty`
+**Symptom** — `README.md is missing.`, `README.md is empty.`,
+`README.md is not valid UTF-8`, or `README.md could not be read`.
 
-**Cause** — every recipe needs a `README.md`.
+**Cause** — every recipe needs a `README.md`, and CI reads it as UTF-8.
 
-**Fix** — create it, covering what the recipe does, how to set it up, and how
-to run it.
+**Fix** — create the file, covering what the recipe does, how to set it up,
+and how to run it. If the error names an encoding, re-save it as UTF-8.
 
 **Confirm** — `uv run validate readme <recipe-path>`
 
 ## README.md contains TODO placeholders
 
-**Symptom** — `README.md contains TODO: placeholders`
+**Symptom** — `README.md still contains 3 TODO: placeholder(s).`
 
 **Cause** — scaffold text or draft notes survived into the PR.
 
@@ -251,7 +233,7 @@ to run it.
 
 ## README.md is too short
 
-**Symptom** — `README.md is too short`
+**Symptom** — `README.md is 47 words; the minimum is 100.`
 
 **Cause** — the README is under 100 words.
 
@@ -262,7 +244,7 @@ to run it.
 
 ## README.md is missing a setup section
 
-**Symptom** — `README.md is missing a setup section`
+**Symptom** — `README.md has no setup section.`
 
 **Cause** — no heading matches the accepted set.
 
@@ -274,8 +256,8 @@ to run it.
 
 ## README.md is missing a run section or code block
 
-**Symptom** — `README.md is missing a run section` or
-`README.md has no fenced code block`
+**Symptom** — `README.md has no run section.` or
+`README.md has no fenced code block.`
 
 **Cause** — no run heading, or a run heading with no command to copy.
 
@@ -384,7 +366,7 @@ uv lock --project <recipe-path>
 
 ## Missing [[tool.uv.index]] block
 
-**Symptom** — `Missing required [[tool.uv.index]] block`, or
+**Symptom** — ``pyproject.toml has no `[[tool.uv.index]]` block.``, or
 `has default=true but url=`
 
 **Cause** — the recipe does not declare public PyPI as its default index.
@@ -480,7 +462,7 @@ nothing beyond `editable = "."`.
 
 ## Missing package hash in uv.lock
 
-**Symptom** — `All distributions must have sha256 hashes`
+**Symptom** — `Every distribution needs a sha256 hash for supply-chain`
 
 **Cause** — the lockfile was hand-edited, or generated by another tool.
 
@@ -495,7 +477,7 @@ uv lock --project <recipe-path>
 
 ## Runnability test missing
 
-**Symptom** — `No test_runnability.py found under`
+**Symptom** — `No test_runnability.py under <recipe>/tests/.`
 
 **Cause** — every Python recipe needs a test proving its agent imports.
 

--- a/docs/recipe-handbook/troubleshooting.md
+++ b/docs/recipe-handbook/troubleshooting.md
@@ -1,179 +1,161 @@
-<!-- word count: 1200 (target 500+, no cap) -->
+<!-- word count: 2950 (target 500+, no cap) -->
 
 # Troubleshooting
 
-Errors and warnings on a recipe PR, mapped to the fix.
+Every error a recipe can hit, the fix, and a command that proves it worked.
 
-**Re-running CI:** CI triggers automatically on every push to your
-PR branch. No manual action is needed. If a check appears stuck,
-a reviewer can re-run it from the GitHub Actions UI.
+## Start here
 
-**Fix structural errors first.** Failures in `validate-recipe-structure`
-can mask downstream Python checks. A stale `uv.lock` causes both
-`python-dependency-policy` and `python-tests` to fail — run `uv lock`
-once to clear both.
+1. Read the `Docs:` line printed under the failure. It names the section
+   below that covers your error.
+2. No `Docs:` line? Look up the file named in the error in the
+   [Contents](#contents).
+3. Fix missing or misplaced files first. One absent `manifest.yaml` or one
+   stale `uv.lock` turns several checks red at once.
 
-**Can't find your error?** Search this page for keywords from the
-CI log, or [jump to Something else](#something-else).
+Run the structural checks on your own machine before pushing again:
+
+```bash
+uv run validate all <recipe-path>
+```
+
+Pushing to your PR branch re-runs every check automatically. Ask a reviewer
+to re-run a job only when one appears stuck.
+
+<!-- Table separators above the Contents block use ':..' style, not three
+     hyphens: tools/tests/test_ci_message.py treats the first horizontal
+     rule as the end of the Contents list, and a three-hyphen separator row
+     here would truncate it. -->
+
+| The error says | Go to |
+| :-- | :-- |
+| `is out of date — run: uv lock` | [uv.lock out of sync](#uvlock-out-of-sync) |
+| `Would reformat`, or a rule ID such as `E501` | [Ruff format or check failed](#ruff-format-or-check-failed) |
+| `Required file '<name>' is missing` | [Required file or directory missing](#required-file-or-directory-missing) |
+| `Environment variable '<VAR>' is read by Python source` | [Env var missing from .env.example](#env-var-missing-from-envexample) |
+| `[ci-fault]` or `CI tooling failure in` | [CI infrastructure failure](#ci-infrastructure-failure) |
 
 ## Contents
 
-**Structure**
-- [manifest.yaml missing or invalid](#manifestyaml-missing-or-invalid)
-- [ownership.team or poc is a placeholder](#ownershipteam-or-poc-is-a-placeholder)
-- [Directory name too long or invalid](#directory-name-too-long-or-invalid)
-- [Recipe exceeds size or file limit](#recipe-exceeds-size-or-file-limit)
-- [Required file or directory missing](#required-file-or-directory-missing)
-- [Recipe is in the wrong folder](#recipe-is-in-the-wrong-folder)
-- [Changes inside a retired folder](#changes-inside-a-retired-folder)
+**Structure and placement**
+- [manifest.yaml is missing, or fails the schema](#manifestyaml-missing-or-invalid)
+- [ownership.team or ownership.poc still holds scaffold text](#ownershipteam-or-poc-is-a-placeholder)
+- [The recipe folder name breaks the naming rule](#directory-name-too-long-or-invalid)
+- [The recipe is too big, or has too many files](#recipe-exceeds-size-or-file-limit)
+- [A file or directory the recipe must have is absent](#required-file-or-directory-missing)
+- [The recipe sits at the wrong path](#recipe-is-in-the-wrong-folder)
+- [The recipe lives in a folder that no longer accepts edits](#changes-inside-a-retired-folder)
 
 **README.md**
-- [README.md is missing or empty](#readmemd-is-missing-or-empty)
-- [README.md contains TODO placeholders](#readmemd-contains-todo-placeholders)
-- [README.md is too short](#readmemd-is-too-short)
-- [README.md is missing a setup section](#readmemd-is-missing-a-setup-section)
-- [README.md is missing a run section or code block](#readmemd-is-missing-a-run-section-or-code-block)
+- [README.md is absent or empty](#readmemd-is-missing-or-empty)
+- [README.md still contains TODO placeholders](#readmemd-contains-todo-placeholders)
+- [README.md is under the 100-word minimum](#readmemd-is-too-short)
+- [README.md has no setup heading](#readmemd-is-missing-a-setup-section)
+- [README.md has no run heading, or no command to copy](#readmemd-is-missing-a-run-section-or-code-block)
 
 **pyproject.toml**
-- [pyproject.toml has a local ruff configuration](#pyprojecttoml-has-a-local-ruff-configuration)
-- [Standalone Ruff config file](#standalone-ruff-config-file)
-- [Project name doesn't match the required name](#project-name-doesnt-match-the-required-name)
-- [Project description doesn't match manifest](#project-description-doesnt-match-manifest)
-- [requires-python below 3.11](#requires-python-below-311)
-- [pyproject.toml has no sibling uv.lock](#pyprojecttoml-has-no-sibling-uvlock)
-- [Missing [[tool.uv.index]] block](#missing-tooluvindex-block)
+- [pyproject.toml configures Ruff locally](#pyprojecttoml-has-a-local-ruff-configuration)
+- [The recipe has its own ruff.toml file](#standalone-ruff-config-file)
+- [The project name is not the one the path requires](#project-name-doesnt-match-the-required-name)
+- [The project description disagrees with the manifest](#project-description-doesnt-match-manifest)
+- [requires-python admits Python older than 3.11](#requires-python-below-311)
+- [pyproject.toml has no uv.lock beside it](#pyprojecttoml-has-no-sibling-uvlock)
+- [pyproject.toml does not declare PyPI as its index](#missing-tooluvindex-block)
 
 **Environment variables**
-- [Env var missing from .env.example](#env-var-missing-from-envexample)
+- [Your code reads a variable .env.example never declares](#env-var-missing-from-envexample)
 
 **Dependencies (uv.lock)**
-- [uv.lock out of sync](#uvlock-out-of-sync)
-- [Lockfile references a non-PyPI URL](#lockfile-references-a-non-pypi-url)
-- [VCS dependency in uv.lock](#vcs-dependency-in-uvlock)
-- [Local path dependency in uv.lock](#local-path-dependency-in-uvlock)
-- [Missing package hash in uv.lock](#missing-package-hash-in-uvlock)
+- [uv.lock no longer matches pyproject.toml](#uvlock-out-of-sync)
+- [uv.lock points at a registry other than PyPI](#lockfile-references-a-non-pypi-url)
+- [uv.lock installs a package straight from git](#vcs-dependency-in-uvlock)
+- [uv.lock depends on a path that exists only on your machine](#local-path-dependency-in-uvlock)
+- [uv.lock is missing sha256 hashes](#missing-package-hash-in-uvlock)
 
 **Tests and code style**
-- [Runnability test missing](#runnability-test-missing)
-- [Ruff format or check failed](#ruff-format-or-check-failed)
+- [The recipe has no runnability test](#runnability-test-missing)
+- [Formatting or lint rules failed](#ruff-format-or-check-failed)
 
-**Other**
-- [CI infrastructure failure](#ci-infrastructure-failure)
-- [Core recipe is behind the current ADK major](#core-recipe-is-behind-the-current-adk-major)
-- [Recipe is marked inactive](#recipe-is-marked-inactive)
-- [Non-blocking notices](#non-blocking-notices)
+**Warnings that do not block your PR**
+- [The recipe is flagged as unhealthy](#recipe-is-marked-inactive)
+- [A core recipe is on an old ADK major](#core-recipe-is-behind-the-current-adk-major)
+- [Every warning, and its one-line fix](#non-blocking-notices)
+
+**Nothing here matches**
+- [The failure is ours, not yours](#ci-infrastructure-failure)
 - [Something else](#something-else)
 
 ---
 
 ## manifest.yaml missing or invalid
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `[manifest] manifest.yaml is missing.` or `[manifest]` followed
+by a schema error.
 
-CI output contains: `[manifest] manifest.yaml is missing.` or `[manifest] <schema error>`
+**Cause** — every recipe needs a `manifest.yaml` matching the
+[schema](../../.github/schemas/manifest-schema.json).
 
-If `manifest.yaml` is missing entirely, run `generate-manifest` (AI
-skill). If you don't have an AI coding assistant, create the file by
-hand — see the [minimum example in anatomy.md](./anatomy.md#manifestyaml).
+**Fix**
 
-If the file is present but failing schema validation, check it
-against the [schema](../../.github/schemas/manifest-schema.json).
-Required fields: `type`, `status`, `language`, `description`,
-`ownership.team`, `ownership.poc`.
+- File absent: run `generate-manifest` (AI skill), or copy the
+  [minimum example](./anatomy.md#manifestyaml) and edit it.
+- File present but rejected: the error names the failing field. Every
+  manifest needs `type`, `status`, `language`, `description`,
+  `ownership.team` and `ownership.poc`.
+
+**Confirm** — `uv run validate manifest <recipe-path>`
 
 ## ownership.team or poc is a placeholder
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `[ownership.team] is still set to the placeholder value`, or the
+same for `[ownership.poc]`.
 
-CI output contains: `[ownership.team] is still set to the placeholder value` or `[ownership.poc] is still set to the placeholder value`
+**Cause** — the scaffold's placeholder text is still in `manifest.yaml`.
 
-Replace the placeholder value in `manifest.yaml` with a real team
-name (`ownership.team`) and a real GitHub user ID (`ownership.poc`).
+**Fix** — set `ownership.team` to a real team name and `ownership.poc` to a
+real GitHub user ID.
+
+**Confirm** — `uv run validate manifest <recipe-path>`
 
 ## Directory name too long or invalid
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `[folder-name] Folder name`
 
-CI output contains: `[folder-name] Folder name`
+**Cause** — the folder name breaks the pattern `^[a-z][a-z-]*$`, or runs past
+30 characters.
 
-Rename the recipe folder. Rules: lowercase letters and hyphens only,
-starts with a letter, maximum 30 characters (`^[a-z][a-z-]*$`).
+**Fix** — rename the folder: lowercase letters and hyphens only, starting
+with a letter, 30 characters at most.
 
-## README.md is missing or empty
-
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
-
-CI output contains: `README.md is missing` or `README.md is empty`
-
-Every recipe needs a `README.md` that explains what the recipe does,
-how to set it up, and how to run it. Create the file and cover at
-minimum: description, setup, and run.
-
-## README.md contains TODO placeholders
-
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
-
-CI output contains: `README.md contains TODO: placeholders`
-
-Replace every `TODO:` line with real content. Scaffold text and draft
-notes must be resolved before opening a PR.
-
-## README.md is too short
-
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
-
-CI output contains: `README.md is too short`
-
-The README must be at least 100 words. Add a real description, setup
-instructions, and run steps. Aim for 200–300 words.
-
-## README.md is missing a setup section
-
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
-
-CI output contains: `README.md is missing a setup section`
-
-Add a heading whose text contains one of: `Setup`, `Prerequisites`,
-`Installation`, `Requirements`, `Configuration`, `Getting Started`,
-`Before You Begin`, `Environment`.
-
-## README.md is missing a run section or code block
-
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
-
-CI output contains: `README.md is missing a run section` or `README.md has no fenced code block`
-
-Add a heading whose text contains one of: `Run`, `Running`, `Usage`,
-`Quickstart`, `Start`, `Deploy`, `How to Run`. Under that heading,
-include at least one fenced code block (```` ``` ````) showing the
-exact command to start the agent.
-
-Run `uv run validate readme <recipe-path>` locally to check all
-README rules before opening a PR.
+**Confirm** — `uv run validate structure <recipe-path>`
 
 ## Recipe exceeds size or file limit
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `Recipe folder exceeds` or `exceeding the limit`
 
-CI output contains: `Recipe folder exceeds` or `exceeding the limit`
+**Cause** — the recipe passes its budget. Under `contrib/` that is 70 files
+and 2 MB.
 
-`contrib/` default limits: 70 files / 2 MB.
+**Fix**
 
-To fix: move data files larger than 1 MB to a linked storage bucket
-and reference them in `README.md`. Delete generated files that
-shouldn't be committed (`.venv/`, IDE configs, build output — check
-the workflow output for the actual counted paths).
+1. Read the counted paths in the error output.
+2. Delete anything that should never have been committed — `.venv/`, IDE
+   configuration, build output.
+3. Move data files over 1 MB to a storage bucket and link them from
+   `README.md`.
+4. Convert screenshots to WebP: `cwebp -q 85 shot.png -o shot.webp`.
+
+**Confirm** — `uv run validate structure <recipe-path>`
 
 ## Required file or directory missing
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
-
-CI output contains: `Required file '<name>' is missing` or
+**Symptom** — `Required file '<name>' is missing` or
 `Required directory '<name>/' is missing`
 
-The set of required entries is the **union** of three rules in
-[`.github/policy.yml`](../../.github/policy.yml). The CI message names
-which one applied to your recipe:
+**Cause** — the required set is the union of every rule that applies to your
+recipe. Language rules key off `manifest.language`, not the folder path: a
+vertical skill at `skills/retail/product-search` picks up the Python list
+because its manifest says `language: python`.
 
 | Rule | Applies to | Entries |
 | --- | --- | --- |
@@ -182,14 +164,7 @@ which one applied to your recipe:
 | `by_root.skills` | anything under `skills/` | `SKILL.md`, `EVAL.yaml`, `scripts/` |
 | `by_language.python` | `manifest.language: python` | `pyproject.toml`, `uv.lock`, `.env.example`, `tests/test_runnability.py` |
 
-`manifest.yaml` is required for every recipe and reported separately.
-
-Note that language requirements come from **`manifest.language`**, not
-from the folder path. A vertical skill at `skills/retail/product-search`
-picks up the Python list because its manifest says so — the middle folder
-is a vertical, not a language.
-
-Most of these have a generator:
+**Fix** — most missing entries have a generator:
 
 | Missing | Fix |
 | --- | --- |
@@ -200,24 +175,22 @@ Most of these have a generator:
 | `pyproject.toml` | `align-recipe-pyproject` (AI skill) |
 | everything at once | `scaffold-python-recipe` (AI skill) |
 
-**Directory looks present but CI says it's missing?** Git cannot commit an
-empty directory. Add a placeholder file and commit that:
+Directory looks present but still reported missing? Git cannot commit an
+empty directory. Commit a placeholder:
 
 ```bash
 touch scripts/.gitkeep && git add scripts/.gitkeep
 ```
 
+**Confirm** — `uv run validate structure <recipe-path>`
+
 ## Recipe is in the wrong folder
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `sits directly under` or `is nested too deeply`
 
-CI output contains: `sits directly under` or `is nested too deeply`
-
-Every recipe under `skills/` must live at
-`skills/<vertical>/<solution>/`. The vertical (`retail/`, `hr/`,
-`finance/`) is mandatory — it surfaces ownership and lets a team see its
-whole surface at a glance. A solution dropped directly under `skills/`
-has no owning vertical and is rejected.
+**Cause** — every recipe under `skills/` must sit at
+`skills/<vertical>/<solution>/`. The vertical (`retail/`, `hr/`, `finance/`)
+is mandatory.
 
 ```
 skills/retail/product-search/manifest.yaml    valid
@@ -225,91 +198,135 @@ skills/product-search/manifest.yaml           too shallow — no vertical
 skills/retail/product-search/x/manifest.yaml  too deep
 ```
 
-Move the directory to the path shown in the error, then re-run
-`uv run validate placement`.
+**Fix**
 
-Remember that `[project].name` in `pyproject.toml` is
-`<vertical>-<solution>` for a vertical skill (`retail-product-search`),
-not the folder basename — see
-[Project name doesn't match the required name](#project-name-doesnt-match-the-required-name).
+1. Move the directory to the path named in the error.
+2. Update `[project].name` in `pyproject.toml` — a vertical skill needs
+   `<vertical>-<solution>`, not the folder basename. See
+   [Project name doesn't match the required name](#project-name-doesnt-match-the-required-name).
+
+**Confirm** — `uv run validate placement`
 
 ## Changes inside a retired folder
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `is in a retired folder and no longer accepts changes`
 
-CI output contains: `is in a retired folder and no longer accepts changes`
+**Cause** — recipes used to live at `<language>/agents/<recipe>` in the repo
+root. Those roots are closed.
 
-Recipes used to live at `<language>/agents/<recipe>` in the repo root (for
-example `python/agents/academic-research`). Those roots are closed. The
-retired roots are listed under `frozen_paths` in
-[`.github/policy.yml`](../../.github/policy.yml).
+**Fix**
 
-Move the whole recipe to `contrib/<language>/<recipe>` and make the change
-there. The error names the destination it expects.
+1. Move the whole recipe to `contrib/<language>/<recipe>`. The error names
+   the destination it expects.
+2. Make your change there.
+3. Bring the recipe up to current requirements, which the retired copy
+   predates — see [the checklist](../recipe-checklist.md) and
+   [Required file or directory missing](#required-file-or-directory-missing).
 
-Deletions and renames are exempt, so migrating a recipe *out* of a retired
-folder is never blocked by this check — only adding to or editing one in
-place is.
+Deleting or renaming inside a retired folder is allowed, so moving a recipe
+out is never blocked.
 
-After moving, the recipe has to meet the current contribution
-requirements, which the retired copy predates: see
-[the checklist](../recipe-checklist.md) and
-[Required file or directory missing](#required-file-or-directory-missing).
+**Confirm** — `uv run validate structure contrib/<language>/<recipe>`
+
+## README.md is missing or empty
+
+**Symptom** — `README.md is missing` or `README.md is empty`
+
+**Cause** — every recipe needs a `README.md`.
+
+**Fix** — create it, covering what the recipe does, how to set it up, and how
+to run it.
+
+**Confirm** — `uv run validate readme <recipe-path>`
+
+## README.md contains TODO placeholders
+
+**Symptom** — `README.md contains TODO: placeholders`
+
+**Cause** — scaffold text or draft notes survived into the PR.
+
+**Fix** — replace every `TODO:` line with real content.
+
+**Confirm** — `uv run validate readme <recipe-path>`
+
+## README.md is too short
+
+**Symptom** — `README.md is too short`
+
+**Cause** — the README is under 100 words.
+
+**Fix** — add a real description, setup instructions and run steps. Aim for
+200–300 words.
+
+**Confirm** — `uv run validate readme <recipe-path>`
+
+## README.md is missing a setup section
+
+**Symptom** — `README.md is missing a setup section`
+
+**Cause** — no heading matches the accepted set.
+
+**Fix** — add a heading whose text contains one of: `Setup`,
+`Prerequisites`, `Installation`, `Requirements`, `Configuration`,
+`Getting Started`, `Before You Begin`, `Environment`.
+
+**Confirm** — `uv run validate readme <recipe-path>`
+
+## README.md is missing a run section or code block
+
+**Symptom** — `README.md is missing a run section` or
+`README.md has no fenced code block`
+
+**Cause** — no run heading, or a run heading with no command to copy.
+
+**Fix**
+
+1. Add a heading whose text contains one of: `Run`, `Running`, `Usage`,
+   `Quickstart`, `Start`, `Deploy`, `How to Run`.
+2. Under it, add a fenced code block with the exact command that starts the
+   agent.
+
+**Confirm** — `uv run validate readme <recipe-path>`
 
 ## pyproject.toml has a local ruff configuration
 
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
+**Symptom** — `pyproject.toml contains a [tool.ruff*] block`
 
-CI output contains: `pyproject.toml contains a [tool.ruff*] block`
+**Cause** — Ruff configuration lives in the repo root `pyproject.toml`, and
+a recipe-level block would override it.
 
-Delete every `[tool.ruff]` and `[tool.ruff.*]` table from the
-recipe's `pyproject.toml`. Ruff configuration is centralized in the
-root `pyproject.toml`. Run `align-recipe-pyproject` (AI skill) to
-clean it up automatically.
+**Fix** — delete every `[tool.ruff]` and `[tool.ruff.*]` table from the
+recipe's `pyproject.toml`. `align-recipe-pyproject` (AI skill) does this for
+you.
+
+**Confirm** — `grep -n "tool.ruff" <recipe-path>/pyproject.toml` prints
+nothing.
 
 ## Standalone Ruff config file
 
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
+**Symptom** — `Standalone Ruff config found`
 
-CI output contains: `Standalone Ruff config found`
+**Cause** — the recipe contains a `ruff.toml` or `.ruff.toml`.
 
-Delete the `ruff.toml` or `.ruff.toml` file from the recipe
-directory. Ruff configuration is centralized in the root
+**Fix** — delete the file. Ruff configuration lives in the repo root
 `pyproject.toml`.
 
-## Env var missing from .env.example
-
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
-
-CI output contains: `Environment variable '<VAR>' is read by Python source but not declared in .env.example`
-
-Run `extract-python-environment-variables` (AI skill). It parses
-your Python source and adds every referenced env var to `.env.example`.
-
-If you don't have an AI coding assistant, add the missing variable
-name to `.env.example` manually. The CI error message lists the exact
-variable name(s).
-
-If the reported variable is a false positive (for example,
-`os.getenv("HOME")`), it should already be suppressed by the
-checker's ignore list. If it isn't, file an issue against
-[`.github/scripts/check_env_vars.py`](../../.github/scripts/check_env_vars.py).
+**Confirm** — `ls <recipe-path>/ruff.toml <recipe-path>/.ruff.toml` reports
+no such file.
 
 ## Project name doesn't match the required name
 
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
+**Symptom** — `[project].name` together with
+`does not match the required name`
 
-CI output contains: `[project].name` and `does not match the required name`
+**Cause** — `[project].name` is derived from where the recipe lives, and
+yours does not match.
 
-Set `[project].name` in `pyproject.toml` to the name CI reports as
-required. It is derived from where the recipe lives:
-
-- `core/` and `contrib/` — the recipe folder basename. A recipe at
-  `contrib/python/my-recipe` needs `name = "my-recipe"`.
+- `core/` and `contrib/` — the recipe folder basename.
 - `skills/` — `<vertical>-<solution>`, because `skills/` interposes a
-  mandatory vertical namespace. A skill at
-  `skills/retail/product-search` needs
-  `name = "retail-product-search"`, not `product-search`.
+  mandatory vertical.
+
+**Fix** — set the name the error reports as required:
 
 ```toml
 # contrib/python/my-recipe
@@ -319,81 +336,61 @@ name = "my-recipe"
 name = "retail-product-search"
 ```
 
+**Confirm** —
+`uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
+
 ## Project description doesn't match manifest
 
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
+**Symptom** — `[project].description does not match manifest.description`
 
-CI output contains: `[project].description does not match manifest.description`
+**Cause** — two descriptions for one recipe have drifted apart.
 
-Either delete `[project].description` from `pyproject.toml` (it is
-optional), or copy `manifest.description` verbatim into
-`[project].description`.
+**Fix** — copy `manifest.description` verbatim into `[project].description`,
+or delete `[project].description`, which is optional.
+
+**Confirm** —
+`uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
 ## requires-python below 3.11
 
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
+**Symptom** — `[project].requires-python` together with
+`permits Python versions below 3.11`
 
-CI output contains: `[project].requires-python` and `permits Python versions below 3.11`
+**Cause** — the recipe admits a Python older than the repo minimum.
 
-Set the minimum Python version in `pyproject.toml`:
+**Fix**
 
 ```toml
 requires-python = ">=3.11"
 ```
 
-## Runnability test missing
-
-**Workflow:** [`python-tests.yml`](../../.github/workflows/python-tests.yml)
-
-CI output contains: `No test_runnability.py found under`
-
-Run `generate-python-runnability-test` (AI skill).
-
-If you don't have an AI coding assistant, copy the minimal template
-from [python.md — Copy-paste starters](./languages/python.md#copy-paste-starters)
-and adjust it for your agent.
-
-## uv.lock out of sync
-
-**Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml) and [`python-tests.yml`](../../.github/workflows/python-tests.yml)
-
-CI output contains: `is out of date — run: uv lock`
-
-`uv lock --check` must pass — every `uv.lock` must be in sync with
-its sibling `pyproject.toml`. Run `uv lock` from the recipe root:
-
-```bash
-cd contrib/python/my-recipe
-uv lock
-```
-
-> **Note:** a stale `uv.lock` can cause both `python-dependency-policy.yml`
-> and `python-tests.yml` to fail. Fix this first if both checks are red.
+**Confirm** —
+`uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
 ## pyproject.toml has no sibling uv.lock
 
-**Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml)
+**Symptom** — `has no sibling uv.lock`
 
-CI output contains: `has no sibling uv.lock`
+**Cause** — every `pyproject.toml` with a `[project]` table or a `[tool.uv]`
+section needs a `uv.lock` next to it.
 
-Every `pyproject.toml` with a `[project]` table or `[tool.uv]`
-section needs a `uv.lock` next to it. Run `uv lock` in that
-directory:
+**Fix**
 
 ```bash
-cd contrib/python/my-recipe
-uv lock
+uv lock --project <recipe-path>
 ```
+
+**Confirm** — `ls <recipe-path>/uv.lock`
 
 ## Missing [[tool.uv.index]] block
 
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
-
-CI output contains: `Missing required [[tool.uv.index]] block` or
+**Symptom** — `Missing required [[tool.uv.index]] block`, or
 `has default=true but url=`
 
-Every recipe must declare public PyPI as its default index. Add this to
-the recipe's `pyproject.toml`:
+**Cause** — the recipe does not declare public PyPI as its default index.
+
+**Fix** — add this to the recipe's `pyproject.toml`, or run
+`align-recipe-pyproject` (AI skill):
 
 ```toml
 [[tool.uv.index]]
@@ -401,220 +398,240 @@ url = "https://pypi.org/simple/"
 default = true
 ```
 
-Note the **double** brackets: `[[tool.uv.index]]` is an array of tables.
-A single-bracket `[tool.uv.index]` is a different TOML construct and uv
-will not accept it.
+Use **double** brackets. `[tool.uv.index]` with single brackets is a
+different TOML construct, and uv rejects it.
 
-Why it is required: on a Google corp workstation a system-wide
-`/etc/uv/uv.toml` redirects package resolution to an authenticated proxy.
-uv concatenates project-level indexes ahead of system-level ones, so
-declaring PyPI here puts it first and `uv sync` works without that auth.
+**Confirm** —
+`uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
-`align-recipe-pyproject` (AI skill) adds the block for you.
+## Env var missing from .env.example
+
+**Symptom** — `Environment variable '<VAR>' is read by Python source but not
+declared in .env.example`
+
+**Cause** — your code reads a variable that anyone cloning the recipe has no
+way to discover.
+
+**Fix** — run `extract-python-environment-variables` (AI skill). It parses
+the source and adds every variable it finds. Without an AI assistant, add
+the names the error lists to `.env.example` by hand.
+
+A false positive such as `os.getenv("HOME")` should already be suppressed.
+If one slips through, file an issue against
+[`check_env_vars.py`](../../.github/scripts/check_env_vars.py).
+
+**Confirm** — `python3 .github/scripts/check_env_vars.py <recipe-path>`
+
+## uv.lock out of sync
+
+**Symptom** — `is out of date — run: uv lock`
+
+**Cause** — `uv.lock` no longer matches its sibling `pyproject.toml`. This
+one failure turns several checks red at once, so fix it before anything
+else.
+
+**Fix**
+
+```bash
+uv lock --project <recipe-path>
+```
+
+**Confirm** — `uv lock --check --project <recipe-path>`
 
 ## Lockfile references a non-PyPI URL
 
-**Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml)
+**Symptom** — `contains non-PyPI registry URLs`
 
-CI output contains: `contains non-PyPI registry URLs`
+**Cause** — an entry resolves somewhere other than `pypi.org` or
+`files.pythonhosted.org`. Internal registries, GitHub Packages and
+Artifactory are not allowed.
 
-Every entry in `uv.lock` must resolve to `pypi.org` or
-`files.pythonhosted.org`. Internal registries, GitHub Packages,
-Artifactory, and similar sources are not allowed. Replace the
-dependency with a PyPI-published package.
+**Fix** — replace the dependency with a package published on PyPI, then
+`uv lock --project <recipe-path>`.
+
+**Confirm** — `grep -n "url = " <recipe-path>/uv.lock` shows only
+`pypi.org` and `files.pythonhosted.org`.
 
 ## VCS dependency in uv.lock
 
-**Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml)
+**Symptom** — `contains git/VCS dependencies`
 
-CI output contains: `contains git/VCS dependencies`
+**Cause** — a `source = { git = "..." }` entry. Git sources are not
+reproducible and skip the registry's security verification.
 
-`source = { git = "..." }` entries are not allowed. Git dependencies
-are non-reproducible and skip the package registry's security
-verification. Publish the package to PyPI, or use a PyPI equivalent.
+**Fix** — depend on a PyPI-published package instead, then
+`uv lock --project <recipe-path>`.
+
+**Confirm** — `grep -n "git = " <recipe-path>/uv.lock` prints nothing.
 
 ## Local path dependency in uv.lock
 
-**Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml)
+**Symptom** — `contains local path dependencies`
 
-CI output contains: `contains local path dependencies`
+**Cause** — a `path`, `editable` or `directory` source, which resolves only
+on the machine that committed it. uv's own `editable = "."` entry for the
+workspace root is the one exception.
 
-`path`, `editable`, or `directory` sources only exist on the
-committer's machine and cannot be resolved in other environments.
-Exception: uv's self-referential `editable = "."` entry for the
-workspace root package is allowed. Remove all other local path
-sources.
+**Fix** — remove the local source, depend on the published package, then
+`uv lock --project <recipe-path>`.
+
+**Confirm** — `grep -n "editable\|directory = " <recipe-path>/uv.lock` shows
+nothing beyond `editable = "."`.
 
 ## Missing package hash in uv.lock
 
-**Workflow:** [`python-dependency-policy.yml`](../../.github/workflows/python-dependency-policy.yml)
+**Symptom** — `All distributions must have sha256 hashes`
 
-CI output contains: `All distributions must have sha256 hashes`
+**Cause** — the lockfile was hand-edited, or generated by another tool.
 
-Every distribution must include a `sha256` hash. Missing hashes
-usually mean the lockfile was hand-edited or generated with a
-different tool. Regenerate cleanly:
+**Fix**
 
 ```bash
-cd contrib/python/my-recipe
-rm uv.lock
-uv lock
+rm <recipe-path>/uv.lock
+uv lock --project <recipe-path>
 ```
+
+**Confirm** — `uv lock --check --project <recipe-path>`
+
+## Runnability test missing
+
+**Symptom** — `No test_runnability.py found under`
+
+**Cause** — every Python recipe needs a test proving its agent imports.
+
+**Fix** — run `generate-python-runnability-test` (AI skill). Without an AI
+assistant, copy the template from
+[python.md — Copy-paste starters](./languages/python.md#copy-paste-starters)
+and point it at your agent.
+
+**Confirm** — `uv run pytest <recipe-path>/tests/test_runnability.py`
 
 ## Ruff format or check failed
 
-**Workflow:** [`python-format.yml`](../../.github/workflows/python-format.yml)
+**Symptom** — `Would reformat` for a formatting failure, or a rule ID such
+as `E501`, `F401` or `I001` for a lint failure.
 
-CI output contains: `Would reformat` (format failure) or a Ruff rule ID such as `E`, `W`, `F`, `I` followed by a description (lint failure)
+**Cause** — the code does not match the repo's Ruff rules: line length 80,
+double quotes.
 
-Auto-fix most issues:
+**Fix**
 
 ```bash
 uv run ruff format <recipe-path>
 uv run ruff check --fix <recipe-path>
 ```
 
-Some issues require manual fixing — Ruff reports which ones and cites
-the rule ID.
+Ruff cannot auto-fix everything. What is left is reported with its rule ID.
+
+**Confirm** —
+`uv run ruff format --check <recipe-path> && uv run ruff check <recipe-path>`
 
 ---
-
-## CI infrastructure failure
-
-CI output contains: `[ci-fault]` or `CI tooling failure in`
-
-**This is not caused by your changes.** One of the repo's own checker
-scripts crashed, or the CI environment failed (network, a missing
-dependency, an unhandled file encoding).
-
-You will see this instead of a normal error when the failure is ours
-rather than yours. It is annotated against the workflow, not against
-your files, precisely so you do not go hunting for a bug in your PR.
-
-What to do:
-
-1. Re-run the failed job. Genuinely transient failures (network, registry
-   timeouts) clear on a retry.
-2. If it fails again, it needs a repo maintainer. Open an issue with the
-   workflow name, the `Detail:` line from the output, and a link to the
-   run. Do not change your recipe to work around it.
-
-If the crash was triggered by something unusual in your recipe — an
-unusual file encoding, a hand-edited `uv.lock` — say so in the issue.
-The checker should report that as a clear error rather than crash, so
-it is a bug in the checker either way.
-
-## Core recipe is behind the current ADK major
-
-**Workflow:** [`python-validate-recipe.yml`](../../.github/workflows/python-validate-recipe.yml)
-
-CI output contains: `adk-major-current`, alongside either `cannot resolve to google-adk` or `pins google-adk`
-
-**This will not block your PR.** It is a notice, not an error.
-
-A recipe under `core/` resolves to a `google-adk` major older than the one
-curated recipes are expected to demonstrate. It still runs — that is the
-problem. A reader clones a curated recipe expecting the current way to write
-an agent, and an out-of-date one teaches a surface that has moved on without
-anything about running it saying so.
-
-The notice appears in two forms, because the fixes differ:
-
-- **"cannot resolve to google-adk N.x"** — `pyproject.toml` caps the
-  dependency below the current major (`<2.0.0`, or a hard pin like
-  `==1.31.0`). Re-locking cannot help until the declaration changes.
-- **"uv.lock pins google-adk X, but ... already permits N.x"** — the
-  declaration is fine and only the lock is behind. This is the case a
-  specifier-only check misses: `google-adk>=1.8.0` admits 2.x while the
-  recipe still installs 1.28.0.
-
-A third variant flags a **prerelease** lock (e.g. `2.0.0a3`). That is on the
-current major, so it is not stale — but anyone who clones the recipe inherits
-a dependency that can change with no deprecation path.
-
-**Fix:** port the recipe to the current major, then
-
-```bash
-uv lock --upgrade-package google-adk --project <recipe-dir>
-```
-
-Crossing an ADK major is a code migration, not a version bump. Widening the
-specifier without porting the code produces a recipe that fails at runtime
-rather than in CI, which is strictly worse than the notice you started with.
-
-If you are only passing through, leave it — that is what "non-blocking"
-means. The recipe's owner (`ownership.poc` in its `manifest.yaml`) owns this.
 
 ## Recipe is marked inactive
 
-**Workflow:** [`validate-recipe-structure.yml`](../../.github/workflows/validate-recipe-structure.yml)
+**Symptom** — `recipe-inactive`, or `is marked` followed by
+`status: inactive`. A warning; your PR is not blocked.
 
-CI output contains: `recipe-inactive`, or `is marked ` followed by `` `status: inactive` ``
+**Cause** — the recipe's `manifest.yaml` says `status: inactive`, which
+means a problem was found in it and went unresolved. A recipe left inactive
+keeps sliding toward removal.
 
-**This will not block your PR.** It is a notice.
+**Fix**
 
-The recipe's `manifest.yaml` declares `status: inactive`. That is not a
-label for "we don't use this much" — it is a position on a clock.
+1. Check the recipe still installs and passes:
+   ```bash
+   uv sync --dev --frozen --project <recipe-path>
+   uv run --frozen --project <recipe-path> pytest
+   ```
+2. Update the package versions and re-lock if either step fails:
+   `uv lock --project <recipe-path>`.
+3. Set `status: active` in `manifest.yaml` in the same PR. Nothing sets it
+   back for you.
 
-The monthly recipe canary (`.github/workflows/recipe-canary.yml`) installs
-each recipe from its committed lockfile and runs its tests. Each run that
-still fails advances the recipe's tracking issue by one stage:
+Editing docs or fixing a typo in an inactive recipe? Ignore this warning.
 
-| failing run | what happens |
-|---|---|
-| 1st | a tracking issue is opened and the owner notified |
-| 2nd | reminder on that issue |
-| 3rd | the canary asks for the recipe to be marked `status: inactive` |
-| 4th | notice that deletion is scheduled |
-| 5th | removal of the recipe is proposed |
+**Confirm** — `grep -n "status:" <recipe-path>/manifest.yaml`
 
-The canary runs monthly, so that is roughly a month per stage. The schedule
-only ever slips later — a missed run costs a stage — never sooner.
+## Core recipe is behind the current ADK major
 
-**The canary cannot make any of these file changes itself.** It has no write
-access to the repository, so `status: inactive` is only ever a request left
-on the tracking issue: a human applies it, or nobody does. It follows that
-the canary also cannot tell whether the manifest was ever actually changed.
+**Symptom** — `adk-major-current`, alongside either
+`cannot resolve to google-adk` or `pins google-adk`. A warning; your PR is
+not blocked.
 
-**If you are reviving the recipe**, set `status: active` in the same PR.
-Nothing else will. Fixing the recipe closes the tracking issue, but the
-manifest keeps whatever a human last wrote in it.
+**Cause** — a recipe under `core/` resolves to a `google-adk` major older
+than the current one. The message comes in three forms, and they need
+different fixes:
 
-**If you are just passing through** — editing docs, fixing a typo — ignore
-this. The recipe's owner (`ownership.poc` in its `manifest.yaml`) owns the
-decision.
+| Message | Meaning |
+| --- | --- |
+| `cannot resolve to google-adk N.x` | `pyproject.toml` caps the dependency below the current major (`<2.0.0`, or a pin like `==1.31.0`). Re-locking alone cannot help. |
+| `uv.lock pins google-adk X, but ... already permits N.x` | The declaration is fine; only the lock is behind. |
+| a prerelease lock, such as `2.0.0a3` | On the current major, but anyone cloning inherits a dependency that can change without a deprecation path. |
+
+**Fix**
+
+1. Widen or remove the cap in `pyproject.toml` if the first message applies.
+2. Port the recipe's code to the current major. Re-locking without porting
+   produces a recipe that fails at runtime instead of in CI.
+3. Re-lock:
+   ```bash
+   uv lock --upgrade-package google-adk --project <recipe-path>
+   ```
+
+**Confirm** —
+`grep -n "google-adk" <recipe-path>/pyproject.toml <recipe-path>/uv.lock`
 
 ## Non-blocking notices
 
-**The following will not block your PR.** Fix them when convenient.
+**Symptom** — a `[NOTICE]` header. None of these block your PR.
 
-- **Hardcoded model name** — replace with `os.getenv("MODEL_NAME")`.
-  Run `extract-python-environment-variables`.
-- **`GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` / `MODEL_NAME`
-  missing from `.env.example`** — add them if your recipe uses them.
-- **Core recipe behind the current ADK major** — see the section above.
-- **Recipe marked `status: inactive`** — see the section above.
+| Notice | Fix |
+| --- | --- |
+| Hardcoded model name | Replace the literal with `os.getenv("MODEL_NAME")`, then run `extract-python-environment-variables` (AI skill). |
+| `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` or `MODEL_NAME` absent from `.env.example` | Add them if the recipe reads them — see [Env var missing from .env.example](#env-var-missing-from-envexample). |
+| Core recipe behind the current ADK major | See [the section above](#core-recipe-is-behind-the-current-adk-major). |
+| Recipe marked `status: inactive` | See [the section above](#recipe-is-marked-inactive). |
+
+## CI infrastructure failure
+
+**Symptom** — `[ci-fault]` or `CI tooling failure in`
+
+**Cause** — one of the repo's own checker scripts crashed, or the CI
+environment failed: a network drop, a missing dependency, an unhandled file
+encoding. Your changes did not cause it, which is why the annotation lands
+on the checker and not on your files.
+
+**Fix**
+
+1. Re-run the failed job. Network and registry timeouts clear on a retry.
+2. Still failing? Open an issue with the failing check, the `Detail:` line
+   from the output, and a link to the run. Do not reshape your recipe to
+   work around it.
+3. Mention anything unusual in your recipe that could have triggered the
+   crash — an unexpected file encoding, a hand-edited `uv.lock`.
 
 ## Something else
 
-If your error isn't listed here, check the workflow log for the exact
-error message and the file it references. Then either:
+**Symptom** — an error this page does not list.
 
-- Search this page for keywords from the error message.
-- Open a GitHub issue at
-  [github.com/google/adk-samples/issues](https://github.com/google/adk-samples/issues)
-  with the workflow name, error message, and a link to the failed run.
-  Use this template:
+**Fix**
 
-  ```
-  **Recipe path:** contrib/python/my-recipe
-  **Workflow:** python-validate-recipe.yml
-  **Error:** (paste the relevant CI log lines here)
-  **Failed run:** (link to the GitHub Actions run)
-  ```
+1. Search this page for keywords from the error message.
+2. Run `uv run validate all <recipe-path>` locally — a second failure is
+   often the cause of the first.
+3. Open an issue at
+   [github.com/google/adk-samples/issues](https://github.com/google/adk-samples/issues):
+
+   ```
+   **Recipe path:** contrib/python/my-recipe
+   **Failing check:** (name of the red check on your PR)
+   **Error:** (paste the relevant log lines here)
+   **Failed run:** (link to the run)
+   ```
 
 ---
 
-_Last updated: July 2025_
+_Last updated: August 2026_
 
 ← [Checklist](../recipe-checklist.md) · [Handbook](./README.md)

--- a/docs/recipe-handbook/troubleshooting.md
+++ b/docs/recipe-handbook/troubleshooting.md
@@ -1,4 +1,4 @@
-<!-- word count: 3040 (target 500+, no cap) -->
+<!-- word count: 3010 (target 500+, no cap) -->
 
 # Troubleshooting
 
@@ -6,9 +6,9 @@ A check failed on your recipe and you need to get it green. Find your error
 on this page, follow the steps, and run the command at the end of the
 section to confirm the fix worked before you push again.
 
-Run every command from the repo root, and replace `<recipe-path>` with the
-path to your recipe — `core/python/my-recipe`, `contrib/python/my-recipe`,
-or `skills/retail/my-skill`.
+Each command below says which directory to run it from. Replace
+`<recipe-path>` with the path to your recipe — `core/python/my-recipe`,
+`contrib/python/my-recipe`, or `skills/retail/my-skill`.
 
 ## Contents
 
@@ -503,12 +503,8 @@ assistant, copy the template from
 [python.md — Copy-paste starters](./languages/python.md#copy-paste-starters)
 and point it at your agent.
 
-**Confirm**, from the repo root —
-`uv run --project <recipe-path> pytest <recipe-path>/tests/test_runnability.py`
-
-The `--project` flag matters: a recipe installs into its own environment, so
-plain `uv run pytest` uses the repo's environment and fails on imports the
-recipe declares.
+**Confirm**, from the recipe folder —
+`uv run pytest tests/test_runnability.py`
 
 ## Ruff format or check failed
 
@@ -546,19 +542,19 @@ keeps sliding toward removal.
 
 1. Check the recipe still installs and passes:
    ```bash
-   # from the repo root
-   uv sync --dev --frozen --project <recipe-path>
-   uv run --frozen --project <recipe-path> pytest <recipe-path>/tests
+   # from the recipe folder
+   uv sync --dev --frozen
+   uv run --frozen pytest \
+     --ignore=tests/integration \
+     --ignore-glob='**/test_integration.py'
    ```
-2. Update the package versions and re-lock if either step fails:
-   `uv lock --project <recipe-path>`.
+2. Update the package versions and re-lock if either step fails: `uv lock`.
 3. Set `status: active` in `manifest.yaml` in the same PR. Nothing sets it
    back for you.
 
 Editing docs or fixing a typo in an inactive recipe? Ignore this warning.
 
-**Confirm**, from the repo root —
-`grep -n "status:" <recipe-path>/manifest.yaml`
+**Confirm**, from the recipe folder — `grep -n "status:" manifest.yaml`
 
 ## Core recipe is behind the current ADK major
 

--- a/docs/recipe-handbook/troubleshooting.md
+++ b/docs/recipe-handbook/troubleshooting.md
@@ -1,4 +1,4 @@
-<!-- word count: 2890 (target 500+, no cap) -->
+<!-- word count: 3040 (target 500+, no cap) -->
 
 # Troubleshooting
 
@@ -87,7 +87,7 @@ contains only comments.`, or a schema error naming the failing field.
   manifest needs `type`, `status`, `language`, `description`,
   `ownership.team` and `ownership.poc`.
 
-**Confirm** — `uv run validate manifest <recipe-path>`
+**Confirm**, from the repo root — `uv run validate manifest <recipe-path>`
 
 ## ownership.team or poc is a placeholder
 
@@ -99,7 +99,7 @@ placeholder`, or the same for `ownership.poc`.
 **Fix** — set `ownership.team` to a real team name and `ownership.poc` to a
 real GitHub user ID.
 
-**Confirm** — `uv run validate manifest <recipe-path>`
+**Confirm**, from the repo root — `uv run validate manifest <recipe-path>`
 
 ## Directory name too long or invalid
 
@@ -111,7 +111,7 @@ real GitHub user ID.
 **Fix** — rename the folder: lowercase letters and hyphens only, starting
 with a letter, 30 characters at most.
 
-**Confirm** — `uv run validate structure <recipe-path>`
+**Confirm**, from the repo root — `uv run validate structure <recipe-path>`
 
 ## Recipe exceeds size or file limit
 
@@ -131,7 +131,7 @@ and 2 MB.
 4. Convert screenshots to WebP:
    `cwebp -q 85 <recipe-path>/shot.png -o <recipe-path>/shot.webp`.
 
-**Confirm** — `uv run validate structure <recipe-path>`
+**Confirm**, from the repo root — `uv run validate structure <recipe-path>`
 
 ## Required file or directory missing
 
@@ -165,11 +165,12 @@ Directory looks present but still reported missing? Git cannot commit an
 empty directory. Commit a placeholder:
 
 ```bash
+# from the repo root
 touch <recipe-path>/scripts/.gitkeep
 git add <recipe-path>/scripts/.gitkeep
 ```
 
-**Confirm** — `uv run validate structure <recipe-path>`
+**Confirm**, from the repo root — `uv run validate structure <recipe-path>`
 
 ## Recipe is in the wrong folder
 
@@ -192,7 +193,7 @@ skills/retail/product-search/x/manifest.yaml  too deep
    `<vertical>-<solution>`, not the folder basename. See
    [Project name doesn't match the required name](#project-name-doesnt-match-the-required-name).
 
-**Confirm** — `uv run validate placement`
+**Confirm**, from the repo root — `uv run validate placement`
 
 ## Changes inside a retired folder
 
@@ -213,7 +214,8 @@ root. Those roots are closed.
 Deleting or renaming inside a retired folder is allowed, so moving a recipe
 out is never blocked.
 
-**Confirm** — `uv run validate structure contrib/<language>/<recipe>`
+**Confirm**, from the repo root —
+`uv run validate structure contrib/<language>/<recipe>`
 
 ## README.md is missing or empty
 
@@ -225,7 +227,7 @@ out is never blocked.
 **Fix** — create the file, covering what the recipe does, how to set it up,
 and how to run it. If the error names an encoding, re-save it as UTF-8.
 
-**Confirm** — `uv run validate readme <recipe-path>`
+**Confirm**, from the repo root — `uv run validate readme <recipe-path>`
 
 ## README.md contains TODO placeholders
 
@@ -235,7 +237,7 @@ and how to run it. If the error names an encoding, re-save it as UTF-8.
 
 **Fix** — replace every `TODO:` line with real content.
 
-**Confirm** — `uv run validate readme <recipe-path>`
+**Confirm**, from the repo root — `uv run validate readme <recipe-path>`
 
 ## README.md is too short
 
@@ -246,7 +248,7 @@ and how to run it. If the error names an encoding, re-save it as UTF-8.
 **Fix** — add a real description, setup instructions and run steps. Aim for
 200–300 words.
 
-**Confirm** — `uv run validate readme <recipe-path>`
+**Confirm**, from the repo root — `uv run validate readme <recipe-path>`
 
 ## README.md is missing a setup section
 
@@ -258,7 +260,7 @@ and how to run it. If the error names an encoding, re-save it as UTF-8.
 `Prerequisites`, `Installation`, `Requirements`, `Configuration`,
 `Getting Started`, `Before You Begin`, `Environment`.
 
-**Confirm** — `uv run validate readme <recipe-path>`
+**Confirm**, from the repo root — `uv run validate readme <recipe-path>`
 
 ## README.md is missing a run section or code block
 
@@ -274,7 +276,7 @@ and how to run it. If the error names an encoding, re-save it as UTF-8.
 2. Under it, add a fenced code block with the exact command that starts the
    agent.
 
-**Confirm** — `uv run validate readme <recipe-path>`
+**Confirm**, from the repo root — `uv run validate readme <recipe-path>`
 
 ## pyproject.toml has a local ruff configuration
 
@@ -287,7 +289,8 @@ a recipe-level block would override it.
 recipe's `pyproject.toml`. `align-recipe-pyproject` (AI skill) does this for
 you.
 
-**Confirm** — `grep -n "tool.ruff" <recipe-path>/pyproject.toml` prints
+**Confirm**, from the repo root —
+`grep -n "tool.ruff" <recipe-path>/pyproject.toml` prints
 nothing.
 
 ## Standalone Ruff config file
@@ -299,7 +302,8 @@ nothing.
 **Fix** — delete the file. Ruff configuration lives in the repo root
 `pyproject.toml`.
 
-**Confirm** — `ls <recipe-path>/ruff.toml <recipe-path>/.ruff.toml` reports
+**Confirm**, from the repo root —
+`ls <recipe-path>/ruff.toml <recipe-path>/.ruff.toml` reports
 no such file.
 
 ## Project name doesn't match the required name
@@ -324,7 +328,7 @@ name = "my-recipe"
 name = "retail-product-search"
 ```
 
-**Confirm** —
+**Confirm**, from the repo root —
 `uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
 ## Project description doesn't match manifest
@@ -336,7 +340,7 @@ name = "retail-product-search"
 **Fix** — copy `manifest.description` verbatim into `[project].description`,
 or delete `[project].description`, which is optional.
 
-**Confirm** —
+**Confirm**, from the repo root —
 `uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
 ## requires-python below 3.11
@@ -352,7 +356,7 @@ or delete `[project].description`, which is optional.
 requires-python = ">=3.11"
 ```
 
-**Confirm** —
+**Confirm**, from the repo root —
 `uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
 ## pyproject.toml has no sibling uv.lock
@@ -365,10 +369,11 @@ section needs a `uv.lock` next to it.
 **Fix**
 
 ```bash
+# from the repo root
 uv lock --project <recipe-path>
 ```
 
-**Confirm** — `ls <recipe-path>/uv.lock`
+**Confirm**, from the repo root — `ls <recipe-path>/uv.lock`
 
 ## Missing [[tool.uv.index]] block
 
@@ -389,7 +394,7 @@ default = true
 Use **double** brackets. `[tool.uv.index]` with single brackets is a
 different TOML construct, and uv rejects it.
 
-**Confirm** —
+**Confirm**, from the repo root —
 `uv run python .github/scripts/check_recipe_pyproject.py <recipe-path>`
 
 ## Env var missing from .env.example
@@ -408,7 +413,8 @@ A false positive such as `os.getenv("HOME")` should already be suppressed.
 If one slips through, file an issue against
 [`check_env_vars.py`](../../.github/scripts/check_env_vars.py).
 
-**Confirm** — `python3 .github/scripts/check_env_vars.py <recipe-path>`
+**Confirm**, from the repo root —
+`python3 .github/scripts/check_env_vars.py <recipe-path>`
 
 ## uv.lock out of sync
 
@@ -421,10 +427,11 @@ else.
 **Fix**
 
 ```bash
+# from the repo root
 uv lock --project <recipe-path>
 ```
 
-**Confirm** — `uv lock --check --project <recipe-path>`
+**Confirm**, from the repo root — `uv lock --check --project <recipe-path>`
 
 ## Lockfile references a non-PyPI URL
 
@@ -437,7 +444,8 @@ Artifactory are not allowed.
 **Fix** — replace the dependency with a package published on PyPI, then
 `uv lock --project <recipe-path>`.
 
-**Confirm** — `grep -n "url = " <recipe-path>/uv.lock` shows only
+**Confirm**, from the repo root —
+`grep -n "url = " <recipe-path>/uv.lock` shows only
 `pypi.org` and `files.pythonhosted.org`.
 
 ## VCS dependency in uv.lock
@@ -450,7 +458,8 @@ reproducible and skip the registry's security verification.
 **Fix** — depend on a PyPI-published package instead, then
 `uv lock --project <recipe-path>`.
 
-**Confirm** — `grep -n "git = " <recipe-path>/uv.lock` prints nothing.
+**Confirm**, from the repo root —
+`grep -n "git = " <recipe-path>/uv.lock` prints nothing.
 
 ## Local path dependency in uv.lock
 
@@ -463,7 +472,8 @@ workspace root is the one exception.
 **Fix** — remove the local source, depend on the published package, then
 `uv lock --project <recipe-path>`.
 
-**Confirm** — `grep -n "editable\|directory = " <recipe-path>/uv.lock` shows
+**Confirm**, from the repo root —
+`grep -n "editable\|directory = " <recipe-path>/uv.lock` shows
 nothing beyond `editable = "."`.
 
 ## Missing package hash in uv.lock
@@ -475,11 +485,12 @@ nothing beyond `editable = "."`.
 **Fix**
 
 ```bash
+# from the repo root
 rm <recipe-path>/uv.lock
 uv lock --project <recipe-path>
 ```
 
-**Confirm** — `uv lock --check --project <recipe-path>`
+**Confirm**, from the repo root — `uv lock --check --project <recipe-path>`
 
 ## Runnability test missing
 
@@ -492,7 +503,7 @@ assistant, copy the template from
 [python.md — Copy-paste starters](./languages/python.md#copy-paste-starters)
 and point it at your agent.
 
-**Confirm** —
+**Confirm**, from the repo root —
 `uv run --project <recipe-path> pytest <recipe-path>/tests/test_runnability.py`
 
 The `--project` flag matters: a recipe installs into its own environment, so
@@ -510,13 +521,14 @@ double quotes.
 **Fix**
 
 ```bash
+# from the repo root
 uv run ruff format <recipe-path>
 uv run ruff check --fix <recipe-path>
 ```
 
 Ruff cannot auto-fix everything. What is left is reported with its rule ID.
 
-**Confirm** —
+**Confirm**, from the repo root —
 `uv run ruff format --check <recipe-path> && uv run ruff check <recipe-path>`
 
 ---
@@ -534,6 +546,7 @@ keeps sliding toward removal.
 
 1. Check the recipe still installs and passes:
    ```bash
+   # from the repo root
    uv sync --dev --frozen --project <recipe-path>
    uv run --frozen --project <recipe-path> pytest <recipe-path>/tests
    ```
@@ -544,7 +557,8 @@ keeps sliding toward removal.
 
 Editing docs or fixing a typo in an inactive recipe? Ignore this warning.
 
-**Confirm** — `grep -n "status:" <recipe-path>/manifest.yaml`
+**Confirm**, from the repo root —
+`grep -n "status:" <recipe-path>/manifest.yaml`
 
 ## Core recipe is behind the current ADK major
 
@@ -569,10 +583,11 @@ different fixes:
    produces a recipe that fails at runtime instead of in CI.
 3. Re-lock:
    ```bash
+   # from the repo root
    uv lock --upgrade-package google-adk --project <recipe-path>
    ```
 
-**Confirm** —
+**Confirm**, from the repo root —
 `grep -n "google-adk" <recipe-path>/pyproject.toml <recipe-path>/uv.lock`
 
 ## Non-blocking notices
@@ -611,8 +626,8 @@ on the checker and not on your files.
 **Fix**
 
 1. Search this page for keywords from the error message.
-2. Run `uv run validate all <recipe-path>` locally — a second failure is
-   often the cause of the first.
+2. Run `uv run validate all <recipe-path>` from the repo root — a second
+   failure is often the cause of the first.
 3. Open an issue at
    [github.com/google/adk-samples/issues](https://github.com/google/adk-samples/issues):
 


### PR DESCRIPTION
## Why

A contributor whose PR just went red opens this page to answer one question: *what do I do now?* The page answered a different one — which workflow complained.

Every section led with `**Workflow:** validate-recipe-structure.yml`, then gave a fix with no way to check it short of pushing again and waiting. Some sections spent more words on policy than on the fix: the `status: inactive` section explained a five-stage deletion ladder, who may edit the manifest, and what CI does and does not have write access to — none of which helps anyone get a check green.

Then, verifying the rewrite, it turned out the page was also quoting error text that CI never prints.

## Every section follows the same four beats

```markdown
## uv.lock out of sync

**Symptom** — `is out of date — run: uv lock`

**Cause** — `uv.lock` no longer matches its sibling `pyproject.toml`. This
one failure turns several checks red at once, so fix it before anything else.

**Fix**

    uv lock --project <recipe-path>

**Confirm** — `uv lock --check --project <recipe-path>`
```

**Confirm is the new part.** All 30 sections end with a command that proves the fix landed, so the loop closes locally instead of through another push-and-wait cycle. Writing them disproved something I had assumed: `check_env_vars.py` and `check_recipe_pyproject.py` each take a recipe directory as their only argument, so the Python-side checks run locally too.

## Eleven sections quoted errors that do not exist

The old `CI output contains:` strings were never checked against the code that emits them. Calling them a **Symptom** makes a stronger promise — this is the line a contributor matches against their log — so each one is now verified against its source:

| Section | Page claimed | CI actually prints |
|---|---|---|
| README.md is too short | `README.md is too short` | `README.md is 47 words; the minimum is 100.` |
| …missing a setup section | `…is missing a setup section` | `README.md has no setup section.` |
| …missing a run section | `…is missing a run section` | `README.md has no run section.` |
| …contains TODO placeholders | `README.md contains TODO: placeholders` | `README.md still contains 3 TODO: placeholder(s).` |
| Changes inside a retired folder | `…and no longer accepts changes` | `…, which no longer accepts changes.` |
| ownership placeholder | `[ownership.team] is still set to the placeholder value` | `[ownership-placeholder] ownership.team is still the scaffold placeholder "…"` |
| Recipe exceeds size or file limit | `Recipe folder exceeds` | `Recipe folder is 3.4 MB; the limit is 2 MB.` |
| Missing [[tool.uv.index]] block | `Missing required [[tool.uv.index]] block` | ``pyproject.toml has no `[[tool.uv.index]]` block.`` |
| Missing package hash | `All distributions must have sha256 hashes` | `Every distribution needs a sha256 hash for supply-chain…` |
| Runnability test missing | `No test_runnability.py found under` | `No test_runnability.py under <recipe>/tests/.` |
| manifest.yaml missing | `[manifest] manifest.yaml is missing.` | `[manifest-missing] manifest.yaml is missing.` |

Two real failures had no entry at all, and are folded into the sections whose anchors they already route to: an empty or comment-only `manifest.yaml` (`check="manifest-empty"`), and a README that is not valid UTF-8.

## One documented command did not work

`uv run pytest <recipe-path>/tests/test_runnability.py` fails from the repo root with `ModuleNotFoundError: No module named 'google'` — a recipe installs into its own environment, so the repo environment has none of its dependencies. It now passes `--project`. The inactive-recipe section had the same shape without a test path, so pytest would have collected the entire repository.

The page also never said which directory to run anything from. The intro now states it once — repo root, with `<recipe-path>` repo-relative — and the three commands that contradicted it are rewritten.

## Also

**No workflow filenames.** 42 references removed. A reader does not care which YAML printed the message, and the failure already deep-links to the exact section.

**No governance.** The escalation ladder, write-access explanation and ownership prose are gone from the inactive section, which is now: check it installs, check the tests pass, re-lock, set `status: active`. Same trim on the ADK-major, retired-folder, `[[tool.uv.index]]` and required-files sections. `anatomy.md` carries the lifecycle at the altitude it belongs at, and is reworded here too — it no longer implies a failing health check is the only route to `inactive`.

**Contents is grouped by what the reader owns**: General, Python, then warnings and unknown failures. A contributor skips the half of the page that cannot apply to their recipe, and a future language gets a heading rather than a rewrite. Link text drops internal phrasing for what someone would actually search — "Your code reads a variable .env.example never declares".

## Compatibility

**Heading text is untouched**, so all 30 slugs still resolve — those in `ci_message.Doc`, those hardcoded in workflow `echo` lines, and the inbound link from `anatomy.md`. Annotations already sitting on open PRs keep working. No Python changed.

Net word count is 2,887 against 2,989 before.

## Verification

- `uv run pytest tools/tests/` — 338 passed, including both anchor anti-rot tests
- Every symptom string traced to the source that emits it
- All 13 `Confirm` commands run from the repo root against a real recipe
- No broken in-page anchors, no broken relative links

## Two things I found and did not fix

1. `tools/tests/test_ci_message.py:293` treats *everything before the first `---`* as the Contents block, so an ordinary `| --- |` table separator placed above Contents silently truncates it and fails with a misleading message. Worked around with `| :-- |` separators and a comment; the test deserves a real fix.
2. Several workflows hardcode troubleshooting anchors in `echo` lines (e.g. `python-dependency-policy.yml:360`) instead of going through `ci_message.Doc`, so they escape the anti-rot test that exists to catch exactly that.

---
🤖 Generated with [CloudCode](https://cloudcode.googleplex.com)
Session: `ses_00e90febaffe7bE0diEOjmcjVh`
