### PR TITLE
fix(ci): review pull requests from forks

### DIFF
--- a/.github/workflows/_ai-pr-review-core.yml
+++ b/.github/workflows/_ai-pr-review-core.yml
@@ -29,11 +29,6 @@ on:
         required: false
         type: 'string'
         default: ''
-      pr_number_review:
-        description: 'PR number from pull_request_review/review_comment event'
-        required: false
-        type: 'string'
-        default: ''
       pr_number_dispatch:
         description: 'PR number from workflow_dispatch event'
         required: false
@@ -41,16 +36,6 @@ on:
         default: ''
       comment_body:
         description: 'Comment body (for issue_comment events)'
-        required: false
-        type: 'string'
-        default: ''
-      review_body:
-        description: 'Review body (for pull_request_review events)'
-        required: false
-        type: 'string'
-        default: ''
-      review_comment_body:
-        description: 'Review comment body (for pull_request_review_comment events)'
         required: false
         type: 'string'
         default: ''
@@ -77,33 +62,20 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - name: 'Checkout PR code (pull_request)'
-        if: |-
-          ${{ inputs.event_name == 'pull_request' }}
+      # SECURITY: checks out the BASE repo, never `refs/pull/N/head`, and does
+      # so unconditionally. Under `pull_request_target` this job holds full
+      # secrets and a write-scoped token, so checking out the pull request's
+      # code would hand its author both. Nothing here needs that code — the
+      # diff and metadata arrive through `gh`, and the only thing read off
+      # disk is `.github/scripts/post_review_comments.py`.
+      #
+      # Unconditional because the four per-event variants this replaced all
+      # keyed on event names that `pull_request_target` is not one of, so none
+      # would have matched: no checkout, no repo for `gh` to infer, no script.
+      - name: 'Checkout the base repo (never the PR head)'
         uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v4
         with:
           fetch-depth: 1 # PR diff and metadata come from the gh API; git history is not needed.
-
-      - name: 'Checkout PR code (workflow_dispatch)'
-        if: |-
-          ${{ inputs.event_name == 'workflow_dispatch' }}
-        uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: 'Checkout PR code (issue_comment)'
-        if: |-
-          ${{ inputs.event_name == 'issue_comment' }}
-        uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: 'Checkout PR code (pull_request_review & pull_request_review_comment)'
-        if: |-
-          ${{ inputs.event_name == 'pull_request_review' || inputs.event_name == 'pull_request_review_comment' }}
-        uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       # SECURITY: strip the workspace config agy reads, so the only
       # configuration it sees is the global config written to $HOME below —
@@ -134,10 +106,10 @@ jobs:
           permission-issues: 'write'
           permission-pull-requests: 'write'
 
-      - name: 'Get PR details (pull_request & workflow_dispatch)'
+      - name: 'Get PR details (pull_request_target & workflow_dispatch)'
         id: 'get_pr'
         if: |-
-          ${{ inputs.event_name == 'pull_request' || inputs.event_name == 'workflow_dispatch' }}
+          ${{ inputs.event_name == 'pull_request_target' || inputs.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'
           EVENT_NAME: '${{ inputs.event_name }}'
@@ -193,7 +165,7 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
           ADDITIONAL_INSTRUCTIONS="$(
-            echo "${COMMENT_BODY}" | sed 's/.*@gemini-cli \/review//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+            echo "${COMMENT_BODY}" | sed 's/.*@ai-review//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
           )"
           # Use a UUID-derived delimiter so a multi-line comment body, PR title,
           # or file path containing a bare "EOF" on its own line cannot escape
@@ -215,58 +187,13 @@ jobs:
           done
           { echo "changed_files<<${DELIM}"; echo "${CHANGED_FILES}"; echo "${DELIM}"; } >> "${GITHUB_OUTPUT}"
 
-      - name: 'Get PR details (pull_request_review & pull_request_review_comment)'
-        id: 'get_pr_review'
-        if: |-
-          ${{ inputs.event_name == 'pull_request_review' || inputs.event_name == 'pull_request_review_comment' }}
+      # One reason a PR can be unreviewable, and it is a hard API limit rather
+      # than a policy. Seven later steps hang off this step's `skip` output.
+      - name: 'Check whether the PR diff is fetchable'
+        id: 'diff_size_guard'
         env:
           GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'
-          EVENT_NAME: '${{ inputs.event_name }}'
-          REVIEW_BODY: '${{ inputs.review_body }}'
-          COMMENT_BODY: '${{ inputs.review_comment_body }}'
-          PR_NUMBER: '${{ inputs.pr_number_review }}'
-        run: |-
-          set -euo pipefail
-
-          echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
-
-          if [[ "${EVENT_NAME}" == "pull_request_review" ]]; then
-            TRIGGER_BODY="${REVIEW_BODY}"
-          else
-            TRIGGER_BODY="${COMMENT_BODY}"
-          fi
-
-          ADDITIONAL_INSTRUCTIONS="$(
-            echo "${TRIGGER_BODY}" | sed 's/.*@gemini-cli \/review//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
-          )"
-          # Same UUID-delimited heredoc as the issue_comment path above —
-          # applies to all multi-line outputs, not just additional_instructions.
-          DELIM="EOF_$(uuidgen)"
-          { echo "additional_instructions<<${DELIM}"; echo "${ADDITIONAL_INSTRUCTIONS}"; echo "${DELIM}"; } >> "${GITHUB_OUTPUT}"
-
-          for attempt in 1 2 3; do
-            PR_DATA="$(gh pr view "${PR_NUMBER}" --json title,additions,deletions,changedFiles,baseRefName,headRefName)" && break
-            echo "::warning::gh pr view failed (attempt ${attempt}/3); retrying in 5s..."
-            sleep 5
-          done
-          { echo "pr_data<<${DELIM}"; echo "${PR_DATA}"; echo "${DELIM}"; } >> "${GITHUB_OUTPUT}"
-
-          for attempt in 1 2 3; do
-            CHANGED_FILES="$(gh pr diff "${PR_NUMBER}" --name-only)" && break
-            echo "::warning::gh pr diff failed (attempt ${attempt}/3); retrying in 5s..."
-            sleep 5
-          done
-          { echo "changed_files<<${DELIM}"; echo "${CHANGED_FILES}"; echo "${DELIM}"; } >> "${GITHUB_OUTPUT}"
-
-      # Both reasons a PR can be unreviewable are decided here, because seven
-      # later steps hang off this one step's `skip` output. The id stays
-      # `new_files_only_guard` so none of them have to move.
-      - name: 'Check whether this PR can be reviewed'
-        id: 'new_files_only_guard'
-        env:
-          GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'
-          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number || steps.get_pr_review.outputs.pr_number }}'
-          EVENT_NAME: '${{ inputs.event_name }}'
+          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
         run: |-
           set -euo pipefail
 
@@ -276,29 +203,17 @@ jobs:
           fi
 
           # IMPORTANT: `gh api --paginate --jq EXPR` applies EXPR to EACH page's
-          # response separately and concatenates the results. The `/pulls/N/files`
-          # endpoint paginates at 30 files per page, so a previous form
-          #     --jq '[.[] | select(.status != "added")] | length'
-          # emitted one integer per page for any PR with more than 30 changed
-          # files, and the multi-line capture broke the `-eq` comparison below
-          # under `set -euo pipefail` — the guard would crash on every large PR.
-          # Emit one line per file and count the lines instead.
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-            --paginate --jq '.[] | .status' > pr_file_statuses.txt
+          # response separately and concatenates the results, so an aggregating
+          # filter like `| length` emits one integer PER PAGE and breaks any
+          # numeric comparison on the result. Emit one line per file and count
+          # the lines instead.
+          #
           # `tr -d` because `wc -l < file` right-pads the count on BSD wc, and
           # TOTAL_COUNT is interpolated into the PR comment below. Arithmetic
           # would tolerate the padding; the reader would not.
-          TOTAL_COUNT="$(wc -l < pr_file_statuses.txt | tr -d '[:space:]')"
-          # awk, not `grep -cv ... || true`. grep exits 1 on no match, which
-          # `set -e` reads as failure and an all-added PR triggers, so it needs
-          # `|| true` — but that also swallows grep's exit >1 on a REAL error,
-          # leaving the count empty, and `[[ "" -eq 0 ]]` is true in bash. The
-          # guard would then skip the review as "only adds new files" for a PR
-          # it never managed to read. awk exits 0 with no matches and non-zero
-          # only on a real error, which pipefail turns into a loud failure.
-          NON_ADDED_COUNT="$(awk '$0 != "added"' pr_file_statuses.txt | wc -l | tr -d '[:space:]')"
+          TOTAL_COUNT="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | .filename' | wc -l | tr -d '[:space:]')"
 
-          # A HARD API LIMIT, not a policy, so it applies on every event.
           # `gh pr diff` reads GET /repos/{owner}/{repo}/pulls/{n} with the diff
           # media type, which answers HTTP 406 "PullRequest.diff too_large" above
           # 300 files. 406 is deterministic, so the fetch step's three retries
@@ -311,17 +226,6 @@ jobs:
             echo "skip=true" >> "${GITHUB_OUTPUT}"
             gh pr comment "${PR_NUMBER}" \
               --body "This PR changes ${TOTAL_COUNT} files, above the ${MAX_DIFF_FILES} GitHub's diff API will serve, so automated AI review was skipped. Splitting it up would get each part reviewed."
-            exit 0
-          fi
-
-          # A POLICY skip, so only on the automatic trigger — a maintainer
-          # invoking a review by hand has already decided it is worth one.
-          # Every file 'added' means a new recipe drop, and human admin
-          # approval is the real quality gate for those.
-          if [[ "${EVENT_NAME}" == 'pull_request' && "${NON_ADDED_COUNT}" -eq 0 ]]; then
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-            gh pr comment "${PR_NUMBER}" \
-              --body "This PR only adds new files — automated AI review was skipped. New recipe submissions are reviewed by a maintainer during the approval process."
             exit 0
           fi
 
@@ -342,10 +246,10 @@ jobs:
       # step output round-trips through the environment, where Linux caps a
       # single variable at the same 131072 bytes that caps an argv string.
       - name: 'Fetch the PR diff for the reviewer'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         env:
           GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'
-          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number || steps.get_pr_review.outputs.pr_number }}'
+          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
         run: |-
           set -euo pipefail
 
@@ -382,7 +286,7 @@ jobs:
       # this step provides by exporting GOOGLE_APPLICATION_CREDENTIALS.
       - name: 'Authenticate to Google Cloud (Workload Identity Federation)'
         id: 'auth'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # ratchet:google-github-actions/auth@v3.0.0
         with:
           project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
@@ -398,7 +302,7 @@ jobs:
       # validated against that catalog the run dies with the badly misleading
       # "model <name> is not recognized as a known model".
       - name: 'Add the quota project to the ADC credential'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         env:
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
         run: |-
@@ -411,7 +315,7 @@ jobs:
       # The installer always fetches the latest build — it has no version flag,
       # so the old `gemini_cli_version` pin has no equivalent here.
       - name: 'Install Antigravity CLI (agy)'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         run: |-
           set -euo pipefail
           curl -fsSL https://antigravity.google/cli/install.sh | bash
@@ -434,7 +338,7 @@ jobs:
       # a review that produced nothing still looks like a pass. Leaving room
       # for routine improvisation is cheaper than a silently voided review.
       - name: 'Configure agy (tool permissions)'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         run: |-
           set -euo pipefail
 
@@ -459,14 +363,14 @@ jobs:
           SETTINGS_EOF
 
       - name: 'Run AI PR Review'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         id: 'agy_pr_review'
         env:
           AGY_ADC_AUTH: 'true'
-          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number || steps.get_pr_review.outputs.pr_number }}'
-          PR_DATA: '${{ steps.get_pr.outputs.pr_data || steps.get_pr_comment.outputs.pr_data || steps.get_pr_review.outputs.pr_data }}'
-          CHANGED_FILES: '${{ steps.get_pr.outputs.changed_files || steps.get_pr_comment.outputs.changed_files || steps.get_pr_review.outputs.changed_files }}'
-          ADDITIONAL_INSTRUCTIONS: '${{ steps.get_pr.outputs.additional_instructions || steps.get_pr_comment.outputs.additional_instructions || steps.get_pr_review.outputs.additional_instructions }}'
+          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
+          PR_DATA: '${{ steps.get_pr.outputs.pr_data || steps.get_pr_comment.outputs.pr_data }}'
+          CHANGED_FILES: '${{ steps.get_pr.outputs.changed_files || steps.get_pr_comment.outputs.changed_files }}'
+          ADDITIONAL_INSTRUCTIONS: '${{ steps.get_pr.outputs.additional_instructions || steps.get_pr_comment.outputs.additional_instructions }}'
           GOOGLE_CLOUD_PROJECT: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
           GOOGLE_CLOUD_LOCATION: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
           REPOSITORY: '${{ github.repository }}'
@@ -629,11 +533,11 @@ jobs:
       # right here, so a bad position can be dropped deterministically instead
       # of taking every other comment down with it.
       - name: 'Post the review'
-        if: steps.new_files_only_guard.outputs.skip != 'true'
+        if: steps.diff_size_guard.outputs.skip != 'true'
         id: 'post_review'
         env:
           GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'
-          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number || steps.get_pr_review.outputs.pr_number }}'
+          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
           REVIEW_LABEL: '${{ inputs.review_label }}'
         run: |-
           set -euo pipefail
@@ -692,7 +596,7 @@ jobs:
         # sees it, so any quote in the expanded value can break out of the
         # string literal and become executable code.
         env:
-          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number || steps.get_pr_review.outputs.pr_number }}'
+          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number || steps.get_pr_comment.outputs.pr_number }}'
           REVIEW_LABEL: '${{ inputs.review_label }}'
         with:
           github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'

--- a/.github/workflows/ai-pr-review-correctness.yml
+++ b/.github/workflows/ai-pr-review-correctness.yml
@@ -4,8 +4,22 @@ name: '🔍 AI PR Review — Correctness'
 # on every PR — logic bugs, wrong return values, missing edge cases —
 # and posts findings as inline review comments.
 
-on:
-  pull_request:
+# SECURITY: `pull_request_target` runs in the BASE repo context, with the
+# base branch's workflow file, full secrets and a write-scoped token. It is
+# only safe because nothing in this workflow or its callee ever executes the
+# pull request's code: the checkout is the base repo, the diff is fetched
+# through `gh` as data, and the agent runs in an empty scratch directory.
+# Reassess if a step is ever added that runs anything out of the checkout.
+#
+# It is what lets fork PRs be reviewed at all. A fork `pull_request` gets no
+# secrets, a read-only token and no OIDC token, so Workload Identity auth and
+# comment posting cannot work there — and ~90% of contributions are forks.
+#
+# The directive has to sit ON this line, not above it: zizmor only honours an
+# ignore comment that falls inside the span the finding covers, and this
+# finding spans the whole `on:` block.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types:
       - 'opened'
       - 'reopened'
@@ -13,12 +27,6 @@ on:
   issue_comment:
     types:
       - 'created'
-  pull_request_review_comment:
-    types:
-      - 'created'
-  pull_request_review:
-    types:
-      - 'submitted'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -38,38 +46,21 @@ permissions:
 
 jobs:
   trigger:
-    # CONTRIBUTOR association is intentionally allowed on the
-    # `pull_request` trigger below so PRs from prior contributors still
-    # receive an automated review on open/reopen/synchronize. It is
-    # deliberately NOT allowed on the comment/review re-invoke paths
-    # (`issue_comment`, `pull_request_review`,
-    # `pull_request_review_comment`) so re-runs require an
-    # OWNER/MEMBER/COLLABORATOR -- bounds the model-call quota against
-    # any past contributor being able to re-trigger reviews at will.
+    # No fork check and no author allowlist on the automatic path: the whole
+    # point is that an outside contributor's PR gets reviewed. A PR opening
+    # is not a privileged act, and the reviewer only ever reads the diff and
+    # writes comments.
+    #
+    # The comment re-invoke path DOES keep an OWNER/MEMBER/COLLABORATOR
+    # check, so an unlimited number of re-runs stays a maintainer's call.
     if: |-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
-      ) ||
+      github.event_name == 'pull_request_target' ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@gemini-cli /review') &&
+        contains(github.event.comment.body, '@ai-review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(github.event.comment.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(github.event.review.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
     uses: './.github/workflows/_ai-pr-review-core.yml'
     with:
@@ -77,11 +68,8 @@ jobs:
       event_name: '${{ github.event_name }}'
       pr_number_pull_request: '${{ github.event.pull_request.number }}'
       pr_number_issue: '${{ github.event.issue.number }}'
-      pr_number_review: '${{ github.event.pull_request.number }}'
       pr_number_dispatch: '${{ github.event.inputs.pr_number }}'
       comment_body: '${{ github.event.comment.body }}'
-      review_body: '${{ github.event.review.body }}'
-      review_comment_body: '${{ github.event.comment.body }}'
       app_id: '${{ vars.APP_ID }}'
       prompt: |-
         ## Role

--- a/.github/workflows/ai-pr-review-maintainability.yml
+++ b/.github/workflows/ai-pr-review-maintainability.yml
@@ -4,8 +4,22 @@ name: '🧹 AI PR Review — Maintainability'
 # review on every PR — naming, structure, readability, dead code —
 # and posts findings as inline review comments.
 
-on:
-  pull_request:
+# SECURITY: `pull_request_target` runs in the BASE repo context, with the
+# base branch's workflow file, full secrets and a write-scoped token. It is
+# only safe because nothing in this workflow or its callee ever executes the
+# pull request's code: the checkout is the base repo, the diff is fetched
+# through `gh` as data, and the agent runs in an empty scratch directory.
+# Reassess if a step is ever added that runs anything out of the checkout.
+#
+# It is what lets fork PRs be reviewed at all. A fork `pull_request` gets no
+# secrets, a read-only token and no OIDC token, so Workload Identity auth and
+# comment posting cannot work there — and ~90% of contributions are forks.
+#
+# The directive has to sit ON this line, not above it: zizmor only honours an
+# ignore comment that falls inside the span the finding covers, and this
+# finding spans the whole `on:` block.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types:
       - 'opened'
       - 'reopened'
@@ -13,12 +27,6 @@ on:
   issue_comment:
     types:
       - 'created'
-  pull_request_review_comment:
-    types:
-      - 'created'
-  pull_request_review:
-    types:
-      - 'submitted'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -38,38 +46,21 @@ permissions:
 
 jobs:
   trigger:
-    # CONTRIBUTOR association is intentionally allowed on the
-    # `pull_request` trigger below so PRs from prior contributors still
-    # receive an automated review on open/reopen/synchronize. It is
-    # deliberately NOT allowed on the comment/review re-invoke paths
-    # (`issue_comment`, `pull_request_review`,
-    # `pull_request_review_comment`) so re-runs require an
-    # OWNER/MEMBER/COLLABORATOR -- bounds the model-call quota against
-    # any past contributor being able to re-trigger reviews at will.
+    # No fork check and no author allowlist on the automatic path: the whole
+    # point is that an outside contributor's PR gets reviewed. A PR opening
+    # is not a privileged act, and the reviewer only ever reads the diff and
+    # writes comments.
+    #
+    # The comment re-invoke path DOES keep an OWNER/MEMBER/COLLABORATOR
+    # check, so an unlimited number of re-runs stays a maintainer's call.
     if: |-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
-      ) ||
+      github.event_name == 'pull_request_target' ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@gemini-cli /review') &&
+        contains(github.event.comment.body, '@ai-review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(github.event.comment.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(github.event.review.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
     uses: './.github/workflows/_ai-pr-review-core.yml'
     with:
@@ -77,11 +68,8 @@ jobs:
       event_name: '${{ github.event_name }}'
       pr_number_pull_request: '${{ github.event.pull_request.number }}'
       pr_number_issue: '${{ github.event.issue.number }}'
-      pr_number_review: '${{ github.event.pull_request.number }}'
       pr_number_dispatch: '${{ github.event.inputs.pr_number }}'
       comment_body: '${{ github.event.comment.body }}'
-      review_body: '${{ github.event.review.body }}'
-      review_comment_body: '${{ github.event.comment.body }}'
       app_id: '${{ vars.APP_ID }}'
       prompt: |-
         ## Role

--- a/.github/workflows/ai-pr-review-security.yml
+++ b/.github/workflows/ai-pr-review-security.yml
@@ -4,8 +4,22 @@ name: '🔒 AI PR Review — Security'
 # every PR — injection risks, secret leaks, unsafe deserialisation —
 # and posts findings as inline review comments.
 
-on:
-  pull_request:
+# SECURITY: `pull_request_target` runs in the BASE repo context, with the
+# base branch's workflow file, full secrets and a write-scoped token. It is
+# only safe because nothing in this workflow or its callee ever executes the
+# pull request's code: the checkout is the base repo, the diff is fetched
+# through `gh` as data, and the agent runs in an empty scratch directory.
+# Reassess if a step is ever added that runs anything out of the checkout.
+#
+# It is what lets fork PRs be reviewed at all. A fork `pull_request` gets no
+# secrets, a read-only token and no OIDC token, so Workload Identity auth and
+# comment posting cannot work there — and ~90% of contributions are forks.
+#
+# The directive has to sit ON this line, not above it: zizmor only honours an
+# ignore comment that falls inside the span the finding covers, and this
+# finding spans the whole `on:` block.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types:
       - 'opened'
       - 'reopened'
@@ -13,12 +27,6 @@ on:
   issue_comment:
     types:
       - 'created'
-  pull_request_review_comment:
-    types:
-      - 'created'
-  pull_request_review:
-    types:
-      - 'submitted'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -38,38 +46,21 @@ permissions:
 
 jobs:
   trigger:
-    # CONTRIBUTOR association is intentionally allowed on the
-    # `pull_request` trigger below so PRs from prior contributors still
-    # receive an automated review on open/reopen/synchronize. It is
-    # deliberately NOT allowed on the comment/review re-invoke paths
-    # (`issue_comment`, `pull_request_review`,
-    # `pull_request_review_comment`) so re-runs require an
-    # OWNER/MEMBER/COLLABORATOR -- bounds the model-call quota against
-    # any past contributor being able to re-trigger reviews at will.
+    # No fork check and no author allowlist on the automatic path: the whole
+    # point is that an outside contributor's PR gets reviewed. A PR opening
+    # is not a privileged act, and the reviewer only ever reads the diff and
+    # writes comments.
+    #
+    # The comment re-invoke path DOES keep an OWNER/MEMBER/COLLABORATOR
+    # check, so an unlimited number of re-runs stays a maintainer's call.
     if: |-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
-      ) ||
+      github.event_name == 'pull_request_target' ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@gemini-cli /review') &&
+        contains(github.event.comment.body, '@ai-review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(github.event.comment.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(github.event.review.body, '@gemini-cli /review') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
     uses: './.github/workflows/_ai-pr-review-core.yml'
     with:
@@ -77,11 +68,8 @@ jobs:
       event_name: '${{ github.event_name }}'
       pr_number_pull_request: '${{ github.event.pull_request.number }}'
       pr_number_issue: '${{ github.event.issue.number }}'
-      pr_number_review: '${{ github.event.pull_request.number }}'
       pr_number_dispatch: '${{ github.event.inputs.pr_number }}'
       comment_body: '${{ github.event.comment.body }}'
-      review_body: '${{ github.event.review.body }}'
-      review_comment_body: '${{ github.event.comment.body }}'
       app_id: '${{ vars.APP_ID }}'
       prompt: |-
         ## Role

--- a/docs/recipe-checklist.md
+++ b/docs/recipe-checklist.md
@@ -1,4 +1,4 @@
-<!-- word count: 831 (target 900, cap 1200) -->
+<!-- word count: 889 (target 900, cap 1200) -->
 
 # Recipe Checklist
 
@@ -166,6 +166,17 @@ a PR.
   No manual trigger is needed.
 - Want the full story? →
   [handbook overview](./recipe-handbook/README.md)
+
+## 5. Automated review
+
+Three AI reviewers — correctness, security and maintainability — run when
+you open a PR and on every push, forks included. They comment on added
+lines, only for critical or high severity issues, and are advisory: a
+maintainer still reviews and approves.
+
+A maintainer can re-run them by commenting `@ai-review` on the PR,
+optionally followed by what to focus on. PRs above 300 changed files are
+skipped, because GitHub will not serve a diff that large.
 
 ---
 


### PR DESCRIPTION
## Problem

Of the last 60 PRs, excluding Dependabot and maintainers, **10 of 11 came from forks** — and every one was skipped by the AI reviewers. The gate required `head.repo.fork == false`, so automated review has effectively only ever covered maintainer branches. #2530 and #2507 are current examples.

Widening the author allowlist does not fix it. A fork `pull_request` gets no secrets, a read-only `GITHUB_TOKEN` and no OIDC token, so Workload Identity auth and comment posting cannot work on that event — it would just fail later instead of skipping early.

## Change

| | |
|---|---|
| `pull_request` → `pull_request_target` | `opened, reopened, synchronize`, so fork PRs are reviewed on open and every push |
| Fork check + author allowlist | Removed from the automatic path; kept on the comment re-invoke path |
| New-file-only skip | **Removed** |
| `pull_request_review` / `_review_comment` triggers | Removed |
| 4 conditional checkouts | Collapsed into 1 unconditional base-repo checkout |
| `new_files_only_guard` | Renamed `diff_size_guard` |
| `@gemini-cli /review` | Renamed `@ai-review` |

Net **128 insertions / 249 deletions**.

**Why drop the new-file-only skip:** it fired whenever every file was `added`, which covers 4 of those 10 fork PRs. A first-time contributor submitting a new recipe is exactly who benefits most from automated feedback. Without this, changing the trigger alone would have fixed 6 of 10.

**Why the duplicate check rows disappear:** the two review triggers fired on *every* review event regardless of body, so each review spawned three runs that immediately skipped, each with its own check row — the `(pull_request_review)` duplicates on #2530. `issue_comment` re-invocation is unaffected.

## Security

`pull_request_target` is safe here because **nothing in these workflows executes the PR's code**. The diff and metadata arrive through `gh` as data, the agent runs in an empty scratch directory, and the checkout is the base repo — already true since #2536, now unconditional so the invariant can't be broken by adding an event. Carried the `dependabot-auto-merge.yml` convention: `# zizmor: ignore[dangerous-triggers]` on the `on:` line, with *reassess if a step is ever added that runs anything out of the checkout*.

Residual risk is **prompt injection** via the diff. Bounded: findings are validated against the diff (path + line must be an added line) before posting, so the worst case is a misleading comment — not code execution or token access.

`pull_request_target` also bypasses fork-approval, so a PR opening now triggers 3 model calls with no maintainer click.

## Verification

| Check | Result |
|---|---|
| Caller/core input contract, all 3 callers | OK — no undeclared or missing inputs |
| Dangling `steps.*` refs | none (7 ids, all resolve) |
| Per-event step paths | `pull_request_target` / `issue_comment` / `workflow_dispatch` each get 13 steps and exactly one PR-details step |
| **#2530** (fork, 33 all-added) | `skip=false` → **would be reviewed** |
| **#2507** (fork, 9 all-added) | `skip=false` → **would be reviewed** |
| #2535 (804 files) | `skip=true` — size guard intact |
| 300 / 301 file boundary | pass / skip |
| `gh api` failure | exit 1, no output — fails loud, never silently skips |
| `@ai-review` instruction stripping | `@ai-review focus on X` → `focus on X` |
| `uv run --frozen pytest -q` | 1120 passed |

Guard behaviour was checked by extracting the step's `run:` block and executing it against the live PRs with `gh pr comment` stubbed, so nothing was posted.

## ⚠️ Cannot be tested on this PR

`pull_request_target` runs the workflow from the **default branch**, so this PR still exercises the old logic. First real test is after merge — suggest re-running #2530 to confirm, with revert-on-main as rollback.

## Follow-up

`ai-issue-automated-triage.yml` still uses `@gemini-cli /triage`, now the only `@gemini-cli` left. Left out to keep this PR to PR review; happy to rename it to `@ai-triage` separately.