### PR TITLE
fix(long-horizon-harness): stop a subagent reporting unfinished work as done

### DIFF
--- a/core/python/long-horizon-harness/horizon/subagents/delegate.py
+++ b/core/python/long-horizon-harness/horizon/subagents/delegate.py
@@ -232,6 +232,15 @@ def _can_resurface(tool_context: Any) -> bool:
     return callable(getattr(tool_context, "request_confirmation", None))
 
 
+def _awaiting_summary(hint: str) -> str:
+    """An eval caught the parent reporting a paused child's work as finished.
+    The status field alone lost to the hint's confident phrasing, so say it."""
+    return (
+        "PAUSED: the child stopped to ask for approval, so none of the work "
+        f"is done yet. Relay this to the user and wait: {hint}"
+    )
+
+
 def _bubble_hint(name: str | None, child_hint: str) -> str:
     return f"[delegated: {name or 'task'}] {child_hint or 'approval required'}"
 
@@ -357,7 +366,7 @@ async def _delegate_resurfacing(
             )
             return {
                 "status": "awaiting_approval",
-                "summary": hint,
+                "summary": _awaiting_summary(hint),
                 "telemetry": res.telemetry,
             }
         await _cleanup_child_session(session_service, user_id, child_session_id)

--- a/core/python/long-horizon-harness/horizon/subagents/delegate_runner.py
+++ b/core/python/long-horizon-harness/horizon/subagents/delegate_runner.py
@@ -133,10 +133,15 @@ async def drive_child(
         await asyncio.wait_for(_drain(), timeout=timeout_s)
     except TimeoutError:
         status = "timeout"
+        summary_override = _unfinished_summary(
+            f"the child hit the {timeout_s}s timeout and did not finish",
+            chunks,
+        )
     except _MaxIterationsExceeded:
         status = "halted"
-        summary_override = (
-            f"max_iterations ({max_iterations}) exceeded — child halted."
+        summary_override = _unfinished_summary(
+            f"max_iterations ({max_iterations}) exceeded, child halted",
+            chunks,
         )
     except Exception as exc:
         _logger.exception("delegate child raised %s", type(exc).__name__)
@@ -145,12 +150,19 @@ async def drive_child(
 
     if pending is not None:
         status = "pending"
+        # A paused child has not done the work; without this the summary is
+        # its pre-approval narration, which reads like a finished report.
+        summary_override = _unfinished_summary(
+            "the child paused for approval and has not run the operation yet",
+            chunks,
+            label="PAUSED",
+        )
 
     return ChildDriveResult(
         status=status,
         summary=summary_override
         if summary_override is not None
-        else "".join(chunks),
+        else _reported_summary(chunks),
         telemetry={
             "iterations": iterations,
             "duration_ms": int((time.monotonic() - start) * 1000),
@@ -171,6 +183,44 @@ def _build_runner(
         session_service=session_service,
         memory_service=memory_service,
     )
+
+
+def _reported_summary(chunks: list[str]) -> str:
+    """A success flag with an empty body is the same vacuum a timeout left,
+    and the parent fills vacuums with plausible detail. Say it reported
+    nothing rather than returning ""."""
+    text = "".join(chunks)
+    if text.strip():
+        return text
+    return (
+        "The child finished but reported nothing. There is no result to "
+        "relay; do not describe work it might have done."
+    )
+
+
+def _envelope_error(
+    status: str, timeout_s: float | None, max_iterations: int | None
+) -> str | None:
+    """Machine-readable twin of the INCOMPLETE summary: the repo signals
+    failure with an `error` key and spawn.py's _result_summary reads one."""
+    if status == "timeout":
+        return f"Child timed out after {timeout_s}s without finishing."
+    if status == "halted":
+        return f"Child halted (max_iterations={max_iterations}) or crashed."
+    return None
+
+
+def _unfinished_summary(
+    reason: str, chunks: list[str], *, label: str = "INCOMPLETE"
+) -> str:
+    """Partial narration reads like a finished report, so the parent must see
+    the state in the summary itself, not only in the status field."""
+    text = (
+        f"{label}: {reason}. Do not report this work as done; anything "
+        "below is partial and unverified."
+    )
+    partial = "".join(chunks).strip()
+    return f"{text}\n\nPartial output:\n{partial}" if partial else text
 
 
 def _user_message(text: str) -> Content:
@@ -239,10 +289,15 @@ async def run_delegate(
         await asyncio.wait_for(_drain(), timeout=timeout_s)
     except TimeoutError:
         status = "timeout"
+        summary_override = _unfinished_summary(
+            f"the child hit the {timeout_s}s timeout and did not finish",
+            chunks,
+        )
     except _MaxIterationsExceeded:
         status = "halted"
-        summary_override = (
-            f"max_iterations ({max_iterations}) exceeded — child halted."
+        summary_override = _unfinished_summary(
+            f"max_iterations ({max_iterations}) exceeded, child halted",
+            chunks,
         )
     except Exception as exc:
         _logger.exception("delegate child raised %s", type(exc).__name__)
@@ -251,13 +306,17 @@ async def run_delegate(
 
     duration_ms = int((time.monotonic() - start) * 1000)
 
-    return {
+    envelope: dict[str, Any] = {
         "status": status,
         "summary": summary_override
         if summary_override is not None
-        else "".join(chunks),
+        else _reported_summary(chunks),
         "telemetry": {
             "iterations": iterations,
             "duration_ms": duration_ms,
         },
     }
+    error = _envelope_error(status, timeout_s, max_iterations)
+    if error is not None:
+        envelope["error"] = error
+    return envelope

--- a/core/python/long-horizon-harness/horizon/subagents/subagent.py
+++ b/core/python/long-horizon-harness/horizon/subagents/subagent.py
@@ -28,6 +28,7 @@ from google.adk.tools.tool_context import ToolContext
 from horizon.subagents.delegate import delegate
 from horizon.subagents.spawn import agent
 from horizon.subagents.toolsets import available_toolset_names
+from horizon.subagents.transcript import parent_transcript
 
 # Lifecycle actions carried over from `agent(action=...)`. `spawn` is not one
 # of them: `background=True` on a fresh call replaces it.
@@ -45,11 +46,30 @@ _UNKNOWN_ACTION_ERROR = (
 )
 
 
+def _parent_events(tool_context: Any) -> Any:
+    ic = getattr(tool_context, "_invocation_context", None)
+    return getattr(getattr(ic, "session", None), "events", None)
+
+
+def _with_parent_transcript(
+    context: str, include: bool, tool_context: Any
+) -> str:
+    """Opt-in only: the contract is that a child sees just what it is handed."""
+    if not include:
+        return context
+    transcript = parent_transcript(_parent_events(tool_context))
+    if not transcript:
+        return context
+    block = f"## Parent conversation so far\n\n{transcript}"
+    return f"{block}\n\n{context.strip()}" if context.strip() else block
+
+
 async def subagent(
     goal: str | None = None,
     context: str = "",
     *,
     background: bool = False,
+    include_transcript: bool = False,
     action: Literal["status", "result", "wait", "cancel", "list"] | None = None,
     toolsets: list[str] | None = None,
     skills: list[str] | None = None,
@@ -85,6 +105,8 @@ async def subagent(
         `status="halted"`, raw in `summary_raw`.
       profile: Deny-by-default archetype (e.g. "explore" = read-only);
         see `## Child profiles` below.
+      include_transcript: give the child this chat's text (capped) when
+        briefing would be lossy; default off, brief it instead.
 
     Brief like a colleague who just arrived: goal, what's ruled out,
     success criteria. Hand off facts, not decisions. Verify a child's
@@ -112,6 +134,8 @@ async def subagent(
             "success": False,
             "error": "goal is required to start a new subagent task.",
         }
+
+    context = _with_parent_transcript(context, include_transcript, tool_context)
 
     if background:
         return await agent(

--- a/core/python/long-horizon-harness/horizon/subagents/transcript.py
+++ b/core/python/long-horizon-harness/horizon/subagents/transcript.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in transcript handoff for a delegated child.
+
+Copies the parent's CONVERSATION, not its session. A child declares fewer
+tools than the parent (default file+shell, or a read-only profile), so
+replaying `function_call` parts it cannot make is malformed history, and the
+`function_response` payloads are the bulk that pruning and compaction exist
+to remove. Text only, capped, oldest dropped first.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MAX_TRANSCRIPT_CHARS = 4_000
+
+_ROLE = {"user": "User"}
+
+
+def parent_transcript(events: Any) -> str:
+    """Render parent user/model text as a briefing block, newest kept."""
+    if not events:
+        return ""
+
+    turns: list[str] = []
+    for event in events:
+        content = getattr(event, "content", None)
+        parts = getattr(content, "parts", None) if content else None
+        if not parts:
+            continue
+        text = "".join(
+            p.text
+            for p in parts
+            if getattr(p, "text", None)
+            and not getattr(p, "function_call", None)
+            and not getattr(p, "function_response", None)
+        ).strip()
+        if not text:
+            continue
+        author = getattr(event, "author", "") or ""
+        turns.append(f"{_ROLE.get(author, 'Assistant')}: {text}")
+
+    if not turns:
+        return ""
+
+    kept: list[str] = []
+    size = 0
+    for turn in reversed(turns):
+        size += len(turn) + 1
+        if size > MAX_TRANSCRIPT_CHARS:
+            break
+        kept.append(turn)
+    return "\n".join(reversed(kept))
+
+
+__all__ = ["MAX_TRANSCRIPT_CHARS", "parent_transcript"]

--- a/core/python/long-horizon-harness/tests/integration/test_delegate_child_resume.py
+++ b/core/python/long-horizon-harness/tests/integration/test_delegate_child_resume.py
@@ -120,6 +120,10 @@ async def test_drive_child_pauses_then_resumes_without_repeating_side_effect() -
     assert first.pending is not None and first.pending.confirmation_id
     assert first.pending.hint == "run X?"
     assert EFFECTS == ["A", "B:req"]
+    # A paused child has NOT done the work. An eval caught the parent
+    # reporting "the subagent created the tests" off a run that stopped for
+    # approval, so the summary has to say it paused, not just `status`.
+    assert "PAUSED" in first.summary, first.summary
 
     resumed = await drive_child(
         runner,

--- a/core/python/long-horizon-harness/tests/unit/test_subagent_transcript_handoff.py
+++ b/core/python/long-horizon-harness/tests/unit/test_subagent_transcript_handoff.py
@@ -1,0 +1,145 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in transcript handoff: a child sees only what it is handed, unless
+the caller asks for the conversation. Copies TEXT only, never the event
+stream, because a child declares fewer tools than the parent and replaying
+function_calls it cannot make is malformed history."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from horizon.subagents.transcript import (
+    MAX_TRANSCRIPT_CHARS,
+    parent_transcript,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _part(text: str | None = None, fn: str | None = None) -> Any:
+    return SimpleNamespace(
+        text=text,
+        function_call=SimpleNamespace(name=fn) if fn else None,
+        function_response=None,
+    )
+
+
+def _event(author: str, *parts: Any) -> Any:
+    return SimpleNamespace(
+        author=author, content=SimpleNamespace(parts=list(parts))
+    )
+
+
+async def test_returns_empty_when_not_opted_in() -> None:
+    assert parent_transcript(None) == ""
+
+
+async def test_copies_user_and_model_text() -> None:
+    events = [
+        _event("user", _part("deploy is failing on staging")),
+        _event("agent", _part("checked the logs, it is a locale mismatch")),
+    ]
+    out = parent_transcript(events)
+    assert "deploy is failing on staging" in out
+    assert "locale mismatch" in out
+
+
+async def test_drops_tool_calls_and_their_payloads() -> None:
+    """The child declares fewer tools; a copied `function_call` to a tool it
+    does not have is malformed history, and tool payloads are the bulk the
+    pruner exists to remove."""
+    events = [
+        _event("user", _part("read the config")),
+        _event("agent", _part(fn="read")),
+        _event("agent", _part("config sets LANG=C.UTF-8")),
+    ]
+    out = parent_transcript(events)
+    assert "config sets LANG=C.UTF-8" in out
+    assert "read" not in out.replace("read the config", "")
+
+
+async def test_truncates_oldest_first_under_the_cap() -> None:
+    events = [_event("user", _part("OLDEST"))]
+    events += [
+        _event("user", _part("x" * 500)) for _ in range(MAX_TRANSCRIPT_CHARS)
+    ]
+    events.append(_event("user", _part("NEWEST")))
+
+    out = parent_transcript(events)
+
+    assert len(out) <= MAX_TRANSCRIPT_CHARS
+    assert "NEWEST" in out, "must keep the most recent turns"
+    assert "OLDEST" not in out, "must drop the oldest turns first"
+
+
+async def test_skips_events_with_no_content() -> None:
+    events = [
+        SimpleNamespace(author="agent", content=None),
+        _event("user", _part("still here")),
+    ]
+    assert "still here" in parent_transcript(events)
+
+
+async def test_subagent_off_by_default(monkeypatch) -> None:
+    """A child sees only what it is handed. Default must not leak the chat."""
+    from horizon.subagents import subagent as mod
+
+    seen: dict[str, Any] = {}
+
+    async def fake_delegate(**kwargs: Any) -> dict[str, Any]:
+        seen.update(kwargs)
+        return {"status": "completed", "summary": "ok"}
+
+    monkeypatch.setattr(mod, "delegate", fake_delegate)
+    await mod.subagent(goal="g", context="briefed", tool_context=None)
+
+    assert seen["context"] == "briefed"
+
+
+async def test_subagent_prepends_transcript_when_opted_in(monkeypatch) -> None:
+    from horizon.subagents import subagent as mod
+
+    seen: dict[str, Any] = {}
+
+    async def fake_delegate(**kwargs: Any) -> dict[str, Any]:
+        seen.update(kwargs)
+        return {"status": "completed", "summary": "ok"}
+
+    monkeypatch.setattr(mod, "delegate", fake_delegate)
+    monkeypatch.setattr(
+        mod, "_parent_events", lambda _ctx: [_event("user", _part("earlier"))]
+    )
+
+    await mod.subagent(
+        goal="g", context="briefed", include_transcript=True, tool_context=None
+    )
+
+    assert "earlier" in seen["context"], seen["context"]
+    assert "briefed" in seen["context"], "explicit briefing must survive"
+
+
+async def test_awaiting_approval_summary_says_nothing_is_done() -> None:
+    """The paused-for-approval envelope had `summary` set to the bare hint,
+    which reads like a result. An eval caught the parent claiming a paused
+    child had created a test suite."""
+    from horizon.subagents.delegate import _awaiting_summary
+
+    out = _awaiting_summary("child wants to run `rm -rf build/`")
+
+    assert "PAUSED" in out
+    assert "none of the work" in out
+    assert "rm -rf build/" in out, "the actual ask must still reach the user"

--- a/core/python/long-horizon-harness/tests/unit/test_subagents_delegate_runner.py
+++ b/core/python/long-horizon-harness/tests/unit/test_subagents_delegate_runner.py
@@ -130,6 +130,58 @@ async def test_run_delegate_timeout_returns_timeout_envelope(
     assert result["telemetry"]["duration_ms"] >= 200
 
 
+async def test_timeout_summary_says_the_work_is_incomplete(
+    monkeypatch, stub_child: Agent
+) -> None:
+    """A timed-out child's partial narration reads like a finished report, so
+    the incompleteness has to be IN the summary, not only in a sibling
+    status field. A parent once relayed 'the test suite has been added' from
+    a run that never finished."""
+    from horizon.subagents import delegate_runner
+
+    async def chatty_then_hang(**_kwargs: Any) -> AsyncIterator[Event]:
+        yield _text_event("Added tests/unit/test_regression.py. All passing.")
+        await asyncio.sleep(5)
+
+    runner = MagicMock()
+    runner.run_async = chatty_then_hang
+    monkeypatch.setattr(delegate_runner, "_build_runner", lambda **_: runner)
+
+    result = await delegate_runner.run_delegate(
+        child=stub_child, user_message="x", timeout_s=0.2
+    )
+
+    assert result["status"] == "timeout"
+    summary = result["summary"]
+    assert "INCOMPLETE" in summary, summary
+    # the partial work is still relayed, just not as a completed result
+    assert "test_regression.py" in summary, summary
+    # machine-readable too: the repo signals failure with an `error` key
+    # (49 sites), and spawn.py's _result_summary already reads one.
+    assert result["error"], result
+    assert "timed out" in result["error"].lower(), result["error"]
+
+
+async def test_completed_run_carries_no_error_key(
+    monkeypatch, stub_child: Agent
+) -> None:
+    from horizon.subagents import delegate_runner
+
+    async def quick(**_kwargs: Any) -> AsyncIterator[Event]:
+        yield _text_event("done")
+
+    runner = MagicMock()
+    runner.run_async = quick
+    monkeypatch.setattr(delegate_runner, "_build_runner", lambda **_: runner)
+
+    result = await delegate_runner.run_delegate(
+        child=stub_child, user_message="x", timeout_s=5
+    )
+
+    assert result["status"] == "completed"
+    assert "error" not in result, result
+
+
 async def test_run_delegate_isolates_from_parent_session(
     monkeypatch, stub_child: Agent
 ) -> None:
@@ -161,8 +213,10 @@ async def test_run_delegate_isolates_from_parent_session(
 async def test_run_delegate_empty_response_still_completes(
     monkeypatch, stub_child: Agent
 ) -> None:
-    """Child that exits without emitting text returns an empty summary
-    but ``status='completed'`` (the child reached natural termination)."""
+    """Child that exits without emitting text still reached natural
+    termination, so ``status='completed'``. The summary must SAY it reported
+    nothing: a success flag with an empty body is the same vacuum that had a
+    parent inventing a finished test suite after a timeout."""
     from horizon.subagents import delegate_runner
 
     fake = _make_fake_runner([])
@@ -173,7 +227,8 @@ async def test_run_delegate_empty_response_still_completes(
     )
 
     assert result["status"] == "completed"
-    assert result["summary"] == ""
+    assert "nothing" in result["summary"].lower(), result["summary"]
+    assert "error" not in result, result
     assert result["telemetry"]["iterations"] == 0
 
 


### PR DESCRIPTION
## Summary
- An eval caught the parent relaying "the regression test suite has been added, all 20 tests passing" from a delegate call that had timed out. Nothing ran.
- Five states now declare their own condition in the summary: timeout, iteration cap, paused in the runner, paused in delegate, and finished with no output. Genuinely failed runs also carry a structured `error` key.
- The `awaiting_approval` envelope had no test coverage, which is why an earlier fix looked complete and was not.
- Adds opt-in `include_transcript` for handing a child the parent conversation: text only, capped at 4k, oldest dropped first, off by default.

Stacked on #2542.
