### PR TITLE
fix(long-horizon-harness): bound search_files output

### DIFF
--- a/core/python/long-horizon-harness/horizon/tools/file_ops.py
+++ b/core/python/long-horizon-harness/horizon/tools/file_ops.py
@@ -21,6 +21,7 @@ parsing, file-locking, and in-memory checkpoint snapshots are out of scope.
 
 from __future__ import annotations
 
+import itertools
 import mimetypes
 import os
 import shlex
@@ -243,10 +244,31 @@ def _is_write_denied(path: str) -> bool:
 
 _SEARCH_DELIMITER = "###__LHA_SEARCH_RESULT__###"
 _SEARCH_ERROR_KEY = "__lha_search_error__"
+_SEARCH_MAX_FILE_SIZE = 10 * 1024 * 1024
+_SEARCH_SNIPPET_MAX_CHARS = 300
+_SEARCH_IGNORED_DIRS = frozenset(
+    {
+        "node_modules",
+        "__pycache__",
+        "build",
+        "dist",
+        "coverage",
+        "target",
+        ".next",
+        ".terraform",
+        "vendor",
+        "site-packages",
+    }
+)
 
 
 def _build_search_script(
-    root: str, pattern: str, file_glob: str | None, limit: int
+    root: str,
+    pattern: str,
+    file_glob: str | None,
+    limit: int,
+    ignore_case: bool = False,
+    no_ignore: bool = False,
 ) -> str:
     return (
         "import fnmatch, json, os, re, sys\n"
@@ -254,12 +276,16 @@ def _build_search_script(
         f"_pattern = {pattern!r}\n"
         f"_file_glob = {file_glob!r}\n"
         f"_limit = {limit!r}\n"
+        f"_ignore_case = {ignore_case!r}\n"
+        f"_no_ignore = {no_ignore!r}\n"
         f"_error_key = {_SEARCH_ERROR_KEY!r}\n"
         f"_delim = {_SEARCH_DELIMITER!r}\n"
-        f"_binary = {list(_BINARY_EXTENSIONS)!r}\n"
-        "_binary = frozenset(_binary)\n"
+        f"_binary = {set(_BINARY_EXTENSIONS)!r}\n"
+        f"_ignored = {set(_SEARCH_IGNORED_DIRS)!r}\n"
+        f"_max_size = {_SEARCH_MAX_FILE_SIZE!r}\n"
+        f"_snip_max = {_SEARCH_SNIPPET_MAX_CHARS!r}\n"
         "try:\n"
-        "    _re = re.compile(_pattern)\n"
+        "    _re = re.compile(_pattern, re.IGNORECASE if _ignore_case else 0)\n"
         "except re.error as _exc:\n"
         "    print(_delim + json.dumps({_error_key: str(_exc)}) + _delim)\n"
         "    sys.exit(0)\n"
@@ -268,7 +294,7 @@ def _build_search_script(
         "    sys.exit(2)\n"
         "_matches = []\n"
         "for _dp, _dns, _fns in os.walk(_root):\n"
-        "    _dns[:] = [d for d in _dns if not d.startswith('.')]\n"
+        "    _dns[:] = [d for d in _dns if not d.startswith('.') and (_no_ignore or d not in _ignored)]\n"
         "    for _fn in _fns:\n"
         "        if _fn.startswith('.'):\n"
         "            continue\n"
@@ -279,15 +305,25 @@ def _build_search_script(
         "            continue\n"
         "        _full = os.path.join(_dp, _fn)\n"
         "        try:\n"
-        "            _mtime = os.stat(_full).st_mtime\n"
+        "            _st = os.stat(_full)\n"
+        "            if _st.st_size > _max_size:\n"
+        "                continue\n"
+        "            _mtime = _st.st_mtime\n"
         "        except OSError:\n"
         "            continue\n"
         "        try:\n"
         "            with open(_full, 'r', encoding='utf-8', errors='replace') as _fh:\n"
         "                for _ln, _line in enumerate(_fh, start=1):\n"
         "                    _line = _line.rstrip('\\n')\n"
-        "                    if _re.search(_line):\n"
-        "                        _matches.append({'path': _full, 'line': _ln, 'text': _line, 'mtime': _mtime})\n"
+        "                    _m = _re.search(_line)\n"
+        "                    if _m:\n"
+        "                        _left = max(0, _m.start() - 100)\n"
+        "                        _snip = _line[_left:_left + _snip_max]\n"
+        "                        if _left > 0:\n"
+        "                            _snip = '...' + _snip\n"
+        "                        if _left + _snip_max < len(_line):\n"
+        "                            _snip = _snip + '...'\n"
+        "                        _matches.append({'path': _full, 'line': _ln, 'text': _snip, 'mtime': _mtime})\n"
         "                        if len(_matches) >= _limit:\n"
         "                            break\n"
         "        except OSError:\n"
@@ -547,11 +583,11 @@ def _resolve_edits(
         )
 
     resolved.sort(key=lambda r: r.start)
-    for a, b in zip(resolved, resolved[1:]):
+    for a, b in itertools.pairwise(resolved):
         if b.start < a.end:
             return None, (
                 f"edits[{a.index}] and edits[{b.index}] target overlapping or "
-                "adjacent regions — merge them into one edit"
+                "adjacent regions: merge them into one edit"
             )
     return resolved, None
 
@@ -632,15 +668,18 @@ async def search_files(
     file_glob: str | None = None,
     limit: int = 50,
     scope: str = "window",
+    ignore_case: bool = False,
+    no_ignore: bool = False,
     tool_context: Any | None = None,
 ) -> dict[str, Any]:
     """Search text files for `pattern` (regex); scope="workspace" searches
     everywhere. Paths: see routing.
 
     Returns the first `limit` matches in directory-walk order, sorted by
-    mtime (most recent first) — on a large tree this is a prefix of the
+    mtime (most recent first): on a large tree this is a prefix of the
     walk, not a global top-N.
     """
+    import asyncio
     import json
 
     env_root = active_environment().working_dir.resolve()
@@ -652,9 +691,26 @@ async def search_files(
         return _error(err)
     assert root is not None
 
-    script = _build_search_script(str(root), pattern, file_glob, limit)
+    script = _build_search_script(
+        str(root),
+        pattern,
+        file_glob,
+        limit,
+        ignore_case=ignore_case,
+        no_ignore=no_ignore,
+    )
     command = f"python3 -c {shlex.quote(script)}"
-    result = await active_environment().execute(command)
+    try:
+        result = await active_environment().execute(command, timeout=30.0)
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        raise
+    except TimeoutError:
+        return _error(
+            f"Search timed out after 30s for {path}. Narrow the path or pattern."
+        )
+    except Exception as exc:
+        return _error(f"Search failed for {path}: {exc}")
+
     if result.exit_code != 0:
         msg = result.stderr.strip() or "search failed"
         if "not a directory" in msg.lower() or "No such file" in msg:
@@ -674,5 +730,16 @@ async def search_files(
     if isinstance(parsed, dict) and _SEARCH_ERROR_KEY in parsed:
         return _error(f"Invalid regex pattern: {parsed[_SEARCH_ERROR_KEY]}")
 
-    matches = sorted(parsed, key=lambda m: m.get("mtime", 0), reverse=True)
-    return {"success": True, "matches": matches}
+    is_truncated = len(parsed) >= limit
+    sorted_matches = sorted(
+        parsed, key=lambda m: m.get("mtime", 0), reverse=True
+    )
+    matches = [
+        {"path": m["path"], "line": m["line"], "text": m["text"]}
+        for m in sorted_matches
+    ]
+    return {
+        "success": True,
+        "matches": matches,
+        "truncated": is_truncated,
+    }

--- a/core/python/long-horizon-harness/tests/smoke/backend/test_search_and_read_smoke.py
+++ b/core/python/long-horizon-harness/tests/smoke/backend/test_search_and_read_smoke.py
@@ -68,7 +68,8 @@ async def test_search_files_ranks_recent_first(
     ordered_paths = [m["path"] for m in result["matches"]]
     assert ordered_paths[0].endswith("new.py")
     assert ordered_paths[-1].endswith("old.py")
-    assert all("mtime" in m for m in result["matches"])
+    assert all("mtime" not in m for m in result["matches"])
+    assert "truncated" in result
 
 
 async def test_search_invalid_regex_returns_error(

--- a/core/python/long-horizon-harness/tests/unit/test_file_ops.py
+++ b/core/python/long-horizon-harness/tests/unit/test_file_ops.py
@@ -864,23 +864,20 @@ class TestSearchFilesRegex:
             result["error"].lower()
         )
 
-    async def test_matches_include_mtime(self, tmp_path: Path) -> None:
+    async def test_matches_do_not_leak_mtime(self, tmp_path: Path) -> None:
         from horizon.tools.file_ops import search_files
 
         (tmp_path / "a.py").write_text("needle\n")
-
         result = await search_files("needle", path=str(tmp_path))
 
         assert result["success"] is True
         assert result["matches"]
-        assert all(
-            isinstance(m["mtime"], (int, float)) for m in result["matches"]
-        )
+        assert all("mtime" not in m for m in result["matches"])
+        assert result["truncated"] is False
 
     async def test_results_sorted_by_mtime_descending(
         self, tmp_path: Path
     ) -> None:
-        """Most-recently-modified file's match must come first."""
         import os
         import time
 
@@ -890,7 +887,6 @@ class TestSearchFilesRegex:
         new = tmp_path / "new.py"
         old.write_text("needle\n")
         new.write_text("needle\n")
-        # Force a clear mtime ordering: old is older than new.
         now = time.time()
         os.utime(old, (now - 1000, now - 1000))
         os.utime(new, (now, now))
@@ -901,6 +897,95 @@ class TestSearchFilesRegex:
         ordered_paths = [m["path"] for m in result["matches"]]
         assert ordered_paths[0].endswith("new.py")
         assert ordered_paths[-1].endswith("old.py")
+
+    async def test_ignore_case_search(self, tmp_path: Path) -> None:
+        from horizon.tools.file_ops import search_files
+
+        (tmp_path / "a.py").write_text("def NeedleCase(): pass\n")
+
+        res_case = await search_files("needlecase", path=str(tmp_path))
+        assert res_case["matches"] == []
+
+        res_ic = await search_files(
+            "needlecase", path=str(tmp_path), ignore_case=True
+        )
+        assert len(res_ic["matches"]) == 1
+        assert res_ic["matches"][0]["line"] == 1
+
+    async def test_excludes_noise_directories_by_default(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import search_files
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("target_token\n")
+
+        nm = tmp_path / "node_modules" / "pkg"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("target_token\n")
+
+        pycache = tmp_path / "__pycache__"
+        pycache.mkdir()
+        (pycache / "app.cpython.py").write_text("target_token\n")
+
+        result = await search_files("target_token", path=str(tmp_path))
+        assert result["success"] is True
+        paths = [m["path"] for m in result["matches"]]
+        assert len(paths) == 1
+        assert "src/app.py" in paths[0] or "src" in paths[0]
+
+    async def test_no_ignore_includes_noise_directories(
+        self, tmp_path: Path
+    ) -> None:
+        from horizon.tools.file_ops import search_files
+
+        nm = tmp_path / "node_modules" / "pkg"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("target_token\n")
+
+        result = await search_files(
+            "target_token", path=str(tmp_path), no_ignore=True
+        )
+        assert result["success"] is True
+        assert len(result["matches"]) == 1
+        assert "node_modules" in result["matches"][0]["path"]
+
+    async def test_truncates_long_matched_lines(self, tmp_path: Path) -> None:
+        from horizon.tools.file_ops import search_files
+
+        prefix = "x" * 200
+        suffix = "y" * 200
+        (tmp_path / "bundle.js").write_text(f"{prefix}TARGET{suffix}\n")
+
+        result = await search_files("TARGET", path=str(tmp_path))
+        assert result["success"] is True
+        assert len(result["matches"]) == 1
+        text = result["matches"][0]["text"]
+        assert "TARGET" in text
+        assert len(text) <= 310
+        assert text.startswith("...")
+        assert text.endswith("...")
+
+    async def test_skips_files_exceeding_max_size(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from horizon.tools import file_ops
+        from horizon.tools.file_ops import search_files
+
+        monkeypatch.setattr(file_ops, "_SEARCH_MAX_FILE_SIZE", 100)
+
+        small = tmp_path / "small.txt"
+        small.write_text("needle small\n")
+
+        large = tmp_path / "large.txt"
+        large.write_text("needle " + ("z" * 200) + "\n")
+
+        result = await search_files("needle", path=str(tmp_path))
+        assert result["success"] is True
+        paths = [m["path"] for m in result["matches"]]
+        assert len(paths) == 1
+        assert "small.txt" in paths[0]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- The tool returned whole matched lines, so a single hit inside a minified bundle could put kilobytes into context.
- Snippets truncated to 300 chars centred on the match, inside the search script so the cap also bounds the transport. Truncating from column 0 would return a snippet that does not contain the match.
- Prunes node_modules and similar, where `limit=50` could be spent before any first-party file was reached. `no_ignore=True` is the escape hatch.
- Skips files over 10MB, adds `ignore_case` and a 30s timeout, strips `mtime` while still sorting by it, and adds a `truncated` flag.

Stacked on #2543.
