### PR TITLE
fix(long-horizon-harness): five defects found auditing every tool

### DIFF
--- a/core/python/long-horizon-harness/horizon/routines/tools.py
+++ b/core/python/long-horizon-harness/horizon/routines/tools.py
@@ -23,13 +23,18 @@ routine's blast-radius bound.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from datetime import UTC, datetime
 from typing import Any, Literal
 
 from horizon.environment_context import active_environment
-from horizon.routines.manifest import DEFAULT_DELIVERY, write_routine_via_env
+from horizon.routines.manifest import (
+    DEFAULT_DELIVERY,
+    ROUTINE_OVERLAY_DIR,
+    write_routine_via_env,
+)
 from horizon.routines.run_once import run_routine_once
 from horizon.scheduler.cron import is_valid_cron, next_cron_fire
 from horizon.scheduler.routine_store import RoutineRow, get_routine_store
@@ -164,7 +169,7 @@ async def _list(tool_context) -> dict[str, Any]:
     }
 
 
-async def _cancel(id: str, tool_context) -> dict[str, Any]:
+async def _cancel(id: str, tool_context: Any) -> dict[str, Any]:
     if not id:
         return {"success": False, "error": "cancel requires id"}
     ident = _identity(tool_context)
@@ -172,11 +177,21 @@ async def _cancel(id: str, tool_context) -> dict[str, Any]:
         return {"success": False, "error": "no active invocation context"}
     user_id, _ = ident
     ok = await get_routine_store().cancel(id, user_id)
-    return (
-        {"success": ok, "id": id}
-        if ok
-        else {"success": False, "error": "no such routine"}
-    )
+    if not ok:
+        return {"success": False, "error": "no such routine"}
+
+    env = active_environment()
+    manifest_path = env.working_dir / ROUTINE_OVERLAY_DIR / f"{id}.yaml"
+    try:
+        await env.delete_file(manifest_path)
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        raise
+    except Exception as exc:
+        logger.debug(
+            "Failed to delete manifest for canceled routine %s: %s", id, exc
+        )
+
+    return {"success": True, "id": id}
 
 
 async def routine(

--- a/core/python/long-horizon-harness/horizon/tools/file_ops.py
+++ b/core/python/long-horizon-harness/horizon/tools/file_ops.py
@@ -469,15 +469,17 @@ async def write(
     if _is_write_denied(str(target)):
         return _error(f"Write denied: {path} is on the protected paths list.")
 
+    env = active_environment()
     try:
-        await active_environment().write_file(target, content)
+        await env.write_file(target, content)
     except OSError as exc:
         return _error(f"Failed to write {path}: {exc}")
 
     maybe_seed_window(
         _state_of(tool_context),
         target,
-        active_environment().working_dir.resolve(),
+        env.working_dir.resolve(),
+        check_host_fs=env.on_host_fs,
     )
 
     result: dict[str, Any] = {"success": True, "path": str(target)}
@@ -648,6 +650,13 @@ async def edit(
         await env.write_file(target, updated)
     except OSError as exc:
         return _error(f"Failed to write {path}: {exc}")
+
+    maybe_seed_window(
+        _state_of(tool_context),
+        target,
+        env.working_dir.resolve(),
+        check_host_fs=env.on_host_fs,
+    )
 
     result: dict[str, Any] = {
         "success": True,

--- a/core/python/long-horizon-harness/horizon/tools/processes/process.py
+++ b/core/python/long-horizon-harness/horizon/tools/processes/process.py
@@ -269,8 +269,10 @@ async def process(
             payload += b"\n"
         try:
             await handle.write(payload)
-        except RuntimeError as exc:
-            return {"error": str(exc)}
+        except (RuntimeError, OSError) as exc:
+            return {
+                "error": f"write failed ({exc}); the process may have exited"
+            }
         return {
             "session_id": handle.session_id,
             "status": "written",

--- a/core/python/long-horizon-harness/horizon/tools/read.py
+++ b/core/python/long-horizon-harness/horizon/tools/read.py
@@ -285,8 +285,16 @@ class ReadTool(BaseTool):
             )
             return result
 
+        env_root = active_environment().working_dir.resolve()
+        try:
+            label = str(target.resolve().relative_to(env_root))
+        except ValueError:
+            label = target.name
+
         pending = list(tool_context.state.get(_PENDING_STATE_KEY, []))
-        pending.append(filename)
+        pending.append(
+            {"filename": filename, "version": version, "label": label}
+        )
         tool_context.state[_PENDING_STATE_KEY] = pending
         return result
 
@@ -301,20 +309,30 @@ class ReadTool(BaseTool):
         pending = tool_context.state.get(_PENDING_STATE_KEY)
         if not pending:
             return
-        # Clear regardless of load outcome — never re-inject the same file.
+        # Clear regardless of load outcome: never re-inject the same file.
         tool_context.state[_PENDING_STATE_KEY] = []
 
-        for filename in pending:
-            part = await tool_context.load_artifact(filename=filename)
+        for entry in pending:
+            if isinstance(entry, dict):
+                fn = entry.get("filename")
+                ver = entry.get("version")
+                lbl = entry.get("label") or fn
+            elif isinstance(entry, str):
+                fn = entry
+                ver = None
+                lbl = entry
+            else:
+                continue
+            if not fn:
+                continue
+            part = await tool_context.load_artifact(filename=fn, version=ver)
             if part is None:
                 continue
             llm_request.contents.append(
                 genai_types.Content(
                     role="user",
                     parts=[
-                        genai_types.Part.from_text(
-                            text=f"Contents of {filename}:"
-                        ),
+                        genai_types.Part.from_text(text=f"Contents of {lbl}:"),
                         part,
                     ],
                 )

--- a/core/python/long-horizon-harness/horizon/workspace_window.py
+++ b/core/python/long-horizon-harness/horizon/workspace_window.py
@@ -138,7 +138,13 @@ def render_window(window: list[str]) -> str | None:
     )
 
 
-def maybe_seed_window(state: Any, resolved: Path, env_root: Path) -> None:
+def maybe_seed_window(
+    state: Any,
+    resolved: Path,
+    env_root: Path,
+    *,
+    check_host_fs: bool = True,
+) -> None:
     """Seed an empty window to the top-level subdir a first write landed in.
 
     No-op when a window already exists, when ``state`` can't be written, or when
@@ -149,14 +155,14 @@ def maybe_seed_window(state: Any, resolved: Path, env_root: Path) -> None:
     if window_dirs(state):
         return
     try:
-        rel = resolved.resolve().relative_to(env_root)
+        rel = resolved.resolve().relative_to(env_root.resolve())
     except ValueError:
         return
     parts = rel.parts
     if len(parts) < 2:
         return
     top = parts[0]
-    if not (env_root / top).is_dir():
+    if check_host_fs and not (env_root.resolve() / top).is_dir():
         return
     try:
         state[WORKSPACE_WINDOW_STATE_KEY] = [top]

--- a/core/python/long-horizon-harness/tests/unit/routines/test_routine_tool.py
+++ b/core/python/long-horizon-harness/tests/unit/routines/test_routine_tool.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -185,3 +186,90 @@ async def test_list_and_cancel():
     assert (await routine_tools.routine(action="list", tool_context=_Ctx()))[
         "routines"
     ] == []
+
+
+async def test_cancel_deletes_manifest_file(tmp_path):
+    body = {
+        "name": "Digest",
+        "schedule": "0 8 * * *",
+        "task": "summarize",
+        "secrets": [],
+        "delivery": "report_back",
+    }
+    ctx = _Ctx(
+        user_id="alice@x",
+        tool_confirmation=_TC(
+            confirmed=True, payload={"manifest": body, "routine_id": "digest"}
+        ),
+    )
+    res = await routine_tools.routine(
+        action="create",
+        name="Digest",
+        schedule="0 8 * * *",
+        task="summarize",
+        tool_context=ctx,
+    )
+    assert res["success"] is True
+    manifest_path = tmp_path / ".lha/routines/digest.yaml"
+    assert manifest_path.is_file()
+
+    cancelled = await routine_tools.routine(
+        action="cancel", id="digest", tool_context=_Ctx(user_id="alice@x")
+    )
+    assert cancelled["success"] is True
+    assert not manifest_path.exists()
+
+
+async def test_cancel_wrong_user_leaves_manifest_file(tmp_path):
+    body = {
+        "name": "Digest",
+        "schedule": "0 8 * * *",
+        "task": "summarize",
+        "secrets": [],
+        "delivery": "report_back",
+    }
+    ctx = _Ctx(
+        user_id="alice@x",
+        tool_confirmation=_TC(
+            confirmed=True, payload={"manifest": body, "routine_id": "digest"}
+        ),
+    )
+    res = await routine_tools.routine(
+        action="create",
+        name="Digest",
+        schedule="0 8 * * *",
+        task="summarize",
+        tool_context=ctx,
+    )
+    assert res["success"] is True
+    manifest_path = tmp_path / ".lha/routines/digest.yaml"
+    assert manifest_path.is_file()
+
+    # Bob tries to cancel Alice's routine
+    cancelled = await routine_tools.routine(
+        action="cancel", id="digest", tool_context=_Ctx(user_id="bob@x")
+    )
+    assert cancelled["success"] is False
+    assert manifest_path.is_file()
+
+
+async def test_cancel_missing_manifest_still_succeeds():
+    store = store_mod.get_routine_store()
+    now = datetime.now(UTC)
+    await store.add(
+        store_mod.RoutineRow(
+            id="orphan",
+            user_id="alice@x",
+            app_name="app",
+            schedule="0 8 * * *",
+            task="t",
+            secrets=(),
+            delivery="report_back",
+            created_at=now,
+            next_fire_at=now,
+        )
+    )
+    cancelled = await routine_tools.routine(
+        action="cancel", id="orphan", tool_context=_Ctx(user_id="alice@x")
+    )
+    assert cancelled["success"] is True

--- a/core/python/long-horizon-harness/tests/unit/test_file_ops.py
+++ b/core/python/long-horizon-harness/tests/unit/test_file_ops.py
@@ -722,6 +722,30 @@ class TestPatch:
         assert result["error"]
         assert target.read_text() == original
 
+    async def test_edit_first_action_seeds_workspace_window(
+        self, tmp_path: Path
+    ) -> None:
+        """First edit into a subdirectory must seed the workspace window."""
+        from types import SimpleNamespace
+
+        from horizon.tools.file_ops import edit
+        from horizon.workspace_window import WORKSPACE_WINDOW_STATE_KEY
+
+        sub = tmp_path.resolve() / "pkg"
+        sub.mkdir()
+        target = sub / "app.py"
+        target.write_text("old = 1\n")
+
+        ctx = SimpleNamespace(state={})
+        result = await edit(
+            str(target),
+            _edits(("old = 1", "new = 2")),
+            tool_context=ctx,
+        )
+
+        assert result["success"] is True
+        assert ctx.state.get(WORKSPACE_WINDOW_STATE_KEY) == ["pkg"]
+
 
 # =============================================================================
 # search_files

--- a/core/python/long-horizon-harness/tests/unit/test_post_edit_lint.py
+++ b/core/python/long-horizon-harness/tests/unit/test_post_edit_lint.py
@@ -42,6 +42,8 @@ class _Result:
 class _StubEnv:
     """Minimal BaseEnvironment stand-in capturing the executed command."""
 
+    on_host_fs = True
+
     def __init__(self, result: _Result | Exception) -> None:
         self._result = result
         self.commands: list[str] = []

--- a/core/python/long-horizon-harness/tests/unit/test_read_tool.py
+++ b/core/python/long-horizon-harness/tests/unit/test_read_tool.py
@@ -554,3 +554,83 @@ async def test_extensionless_file_stays_text(
     # which decodes the bytes with errors="replace" rather than erroring.
     assert result["success"] is True
     assert "content" in result
+
+
+async def test_two_same_basename_media_files_inject_distinct_payloads(
+    local_env: LocalEnvironment, ctx: _FakeToolContext
+) -> None:
+    """Reading a/logo.png then b/logo.png must inject both distinct versions."""
+    sub1 = local_env.working_dir / "sub1"
+    sub2 = local_env.working_dir / "sub2"
+    sub1.mkdir()
+    sub2.mkdir()
+
+    png_head = b"\x89PNG\r\n\x1a\n"
+    (sub1 / "logo.png").write_bytes(png_head + b"FIRST_IMAGE_PAYLOAD")
+    (sub2 / "logo.png").write_bytes(png_head + b"SECOND_IMAGE_PAYLOAD")
+
+    tool = _tool()
+    res1 = await tool.run_async(
+        args={"path": "sub1/logo.png"}, tool_context=ctx
+    )
+    res2 = await tool.run_async(
+        args={"path": "sub2/logo.png"}, tool_context=ctx
+    )
+    assert res1["success"] is True
+    assert res2["success"] is True
+
+    req = LlmRequest(model="gemini-3.6-flash")
+    await tool.process_llm_request(tool_context=ctx, llm_request=req)
+
+    # Must have injected both distinct parts
+    injected_data = [
+        p.inline_data.data
+        for c in req.contents
+        for p in (c.parts or [])
+        if getattr(p, "inline_data", None)
+    ]
+    assert len(injected_data) == 2
+    assert b"FIRST_IMAGE_PAYLOAD" in injected_data[0]
+    assert b"SECOND_IMAGE_PAYLOAD" in injected_data[1]
+
+    # Labels must reflect workspace-relative paths
+    labels = [
+        p.text
+        for c in req.contents
+        for p in (c.parts or [])
+        if getattr(p, "text", None) and "Contents of" in p.text
+    ]
+    assert len(labels) == 2
+    assert "sub1/logo.png" in labels[0]
+    assert "sub2/logo.png" in labels[1]
+
+
+async def test_legacy_string_pending_entry_still_loads(
+    local_env: LocalEnvironment, ctx: _FakeToolContext
+) -> None:
+    """Plain-string entries in _pending_media_reads must still inject."""
+    from horizon.tools.read import _PENDING_STATE_KEY
+
+    png_data = b"\x89PNG\r\n\x1a\nlegacy"
+    part = genai_types.Part(
+        inline_data=genai_types.Blob(
+            data=png_data,
+            mime_type="image/png",
+            display_name="legacy.png",
+        )
+    )
+    await ctx.save_artifact(filename="legacy.png", artifact=part)
+    ctx.state[_PENDING_STATE_KEY] = ["legacy.png"]
+
+    tool = _tool()
+    req = LlmRequest(model="gemini-3.6-flash")
+    await tool.process_llm_request(tool_context=ctx, llm_request=req)
+
+    injected = [
+        p.inline_data.data
+        for c in req.contents
+        for p in (c.parts or [])
+        if getattr(p, "inline_data", None)
+    ]
+    assert len(injected) == 1
+    assert injected[0] == png_data

--- a/core/python/long-horizon-harness/tests/unit/test_workspace_window.py
+++ b/core/python/long-horizon-harness/tests/unit/test_workspace_window.py
@@ -15,9 +15,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from horizon.workspace_window import (
     WORKSPACE_WINDOW_STATE_KEY,
+    maybe_seed_window,
     render_window,
     resolve_in_window,
     window_dirs,
@@ -100,3 +102,61 @@ def test_render_window_empty_is_none():
 
 def test_render_window_lists_dirs():
     assert "projA" in (render_window(["projA"]) or "")
+
+
+def test_maybe_seed_window_sandbox_off_host_root():
+    """When check_host_fs=False (sandbox), non-host root paths seed correctly."""
+    state: dict[str, Any] = {}
+    maybe_seed_window(
+        state,
+        Path("/workspace/project_a/main.py"),
+        Path("/workspace"),
+        check_host_fs=False,
+    )
+    assert state.get(WORKSPACE_WINDOW_STATE_KEY) == ["project_a"]
+
+
+def test_maybe_seed_window_default_requires_host_dir():
+    """Default check_host_fs=True does not seed if directory is absent on host."""
+    state: dict[str, Any] = {}
+    maybe_seed_window(
+        state,
+        Path("/nonexistent_sandbox_root/proj/app.py"),
+        Path("/nonexistent_sandbox_root"),
+    )
+    assert WORKSPACE_WINDOW_STATE_KEY not in state
+
+
+def test_maybe_seed_window_root_level_file_does_not_seed(tmp_path: Path):
+    """Root-level files with no subdirectory component must not seed window."""
+    root = tmp_path.resolve()
+    state_host: dict[str, Any] = {}
+    maybe_seed_window(
+        state_host,
+        root / "README.md",
+        root,
+        check_host_fs=True,
+    )
+    assert WORKSPACE_WINDOW_STATE_KEY not in state_host
+
+    state_sandbox: dict[str, Any] = {}
+    maybe_seed_window(
+        state_sandbox,
+        Path("/workspace/README.md"),
+        Path("/workspace"),
+        check_host_fs=False,
+    )
+    assert WORKSPACE_WINDOW_STATE_KEY not in state_sandbox
+
+
+def test_maybe_seed_window_existing_window_not_overwritten(tmp_path: Path):
+    """An existing window is never overwritten."""
+    root = tmp_path.resolve()
+    (root / "new_proj").mkdir()
+    state: dict[str, Any] = {WORKSPACE_WINDOW_STATE_KEY: ["existing_proj"]}
+    maybe_seed_window(
+        state,
+        root / "new_proj" / "app.py",
+        root,
+    )
+    assert state[WORKSPACE_WINDOW_STATE_KEY] == ["existing_proj"]

--- a/core/python/long-horizon-harness/tests/unit/tools/processes/test_process_tool.py
+++ b/core/python/long-horizon-harness/tests/unit/tools/processes/test_process_tool.py
@@ -248,6 +248,34 @@ class TestWriteAction:
         )
         assert "error" in result
 
+    async def test_write_oserror_returns_error_envelope(
+        self, context_factory
+    ) -> None:
+        from horizon.environment.registry import ProcessRegistry
+        from horizon.tools.processes.process import process
+
+        class _DeadPtyHandle:
+            session_id = "proc_dead_pty"
+            is_running = True
+
+            async def write(self, data: bytes) -> None:
+                raise OSError(5, "Input/output error")
+
+        ctx = context_factory()
+        ProcessRegistry.for_state(ctx.state).register(_DeadPtyHandle())
+
+        result = await process(
+            action="write",
+            session_id="proc_dead_pty",
+            data="payload",
+            tool_context=ctx,
+        )
+        assert "error" in result
+        assert (
+            "write failed" in result["error"].lower()
+            or "input/output" in result["error"].lower()
+        )
+
 
 @pytest.mark.asyncio
 class TestActionEnum:


### PR DESCRIPTION
## Summary
Each was reproduced before being fixed.
- `read` staged media artifacts by basename and dropped the version, so reading two same-named files in one turn sent the model the second twice and never the first, silently.
- `maybe_seed_window` did a host filesystem check, so the workspace window never seeded under the sandbox. `edit` never seeded it at all.
- `process(write)` caught only `RuntimeError`; a process dying mid-write raises `OSError` EIO, which escaped as an unhandled crash.
- `routine(cancel)` left `.lha/routines/<id>.yaml` behind. Deletion is gated on the store's user-scoped result so one user cannot unlink another's manifest.

Suite 2331.

Stacked on #2544.
