### PR TITLE
ci: add TypeScript format and lint workflow using Biome

### DIFF
--- a/.github/workflows/typescript-format.yml
+++ b/.github/workflows/typescript-format.yml
@@ -1,0 +1,273 @@
+name: 🟦 TypeScript Format PR Checks
+
+# Runs Biome format and lint on TypeScript and JavaScript files changed in a
+# PR and posts diff-style suggestion comments via reviewdog. The TypeScript
+# counterpart to python-format.yml and go-format.yml.
+#
+# Style configuration lives in the root `biome.json` and is the repo's single
+# source of truth for TypeScript/JavaScript style. This workflow deliberately
+# does NOT pass formatting flags on the CLI, so Biome discovers configuration
+# by walking up from each target file. Update `biome.json` (not this file) to
+# change the standard.
+
+on:
+  pull_request:
+    paths:
+      - "core/**/*.ts"
+      - "core/**/*.tsx"
+      - "core/**/*.js"
+      - "core/**/*.jsx"
+      - "core/**/*.mjs"
+      - "core/**/*.cjs"
+      - "core/**/*.mts"
+      - "core/**/*.cts"
+      - "contrib/**/*.ts"
+      - "contrib/**/*.tsx"
+      - "contrib/**/*.js"
+      - "contrib/**/*.jsx"
+      - "contrib/**/*.mjs"
+      - "contrib/**/*.cjs"
+      - "contrib/**/*.mts"
+      - "contrib/**/*.cts"
+      - "skills/**/*.ts"
+      - "skills/**/*.tsx"
+      - "skills/**/*.js"
+      - "skills/**/*.jsx"
+      - "skills/**/*.mjs"
+      - "skills/**/*.cjs"
+      - "skills/**/*.mts"
+      - "skills/**/*.cts"
+      - "core/**/package.json"
+      - "contrib/**/package.json"
+      - "skills/**/package.json"
+      - "core/**/biome.json"
+      - "core/**/biome.jsonc"
+      - "contrib/**/biome.json"
+      - "contrib/**/biome.jsonc"
+      - "skills/**/biome.json"
+      - "skills/**/biome.jsonc"
+      - "biome.json"
+      - "biome.jsonc"
+      - ".github/workflows/typescript-format.yml"
+
+# Declared per job rather than here. `pull-requests: write` at the workflow
+# level is inherited by EVERY job, including any added later that only need
+# to read — keeping permissions job-local enforces least privilege.
+permissions: {}
+
+# Cancel superseded runs on the same PR to save runner minutes and avoid
+# stale suggestion comments from an older commit lingering on the PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  # Pinned rather than `latest` so a Biome release cannot turn every
+  # open PR red without warning. Bump deliberately.
+  BIOME_VERSION: "2.5.10"
+
+jobs:
+  biome-format:
+    name: Biome Format Suggestions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Checkout
+      pull-requests: write # Post reviewdog suggestion comments
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch complete history to locate the merge-base cleanly
+          persist-credentials: false
+
+      - name: Setup Biome
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # ratchet:biomejs/setup-biome@v2.7.1
+        with:
+          version: ${{ env.BIOME_VERSION }}
+
+      - name: Install Reviewdog
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # ratchet:reviewdog/action-setup@v1
+        with:
+          reviewdog_version: v0.21.0
+
+      - name: Run Biome Format & Suggest Changes
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "$WORK"' EXIT
+
+          # 1. Fetch the target branch reference commits
+          git fetch origin "$BASE_REF"
+
+          # 2. Resolve TypeScript/JavaScript files modified in this PR diff
+          git diff -z --name-only --diff-filter=d "origin/$BASE_REF...HEAD" \
+            -- core contrib skills > "$WORK/changed"
+
+          ALL_CHANGED=()
+          mapfile -d '' -t ALL_CHANGED < "$WORK/changed"
+
+          CHANGED_FILES=()
+          for f in "${ALL_CHANGED[@]}"; do
+            case "$f" in
+              *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.mts|*.cts|*.json|*.jsonc)
+                CHANGED_FILES+=("$f")
+                ;;
+            esac
+          done
+
+          if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
+            echo "No TypeScript/JavaScript files were modified under core/, contrib/ or skills/. Skipping formatting."
+            exit 0
+          fi
+
+          echo "Formatting files: ${CHANGED_FILES[*]}"
+
+          # 3. Format modified files
+          biome format --write "${CHANGED_FILES[@]}"
+
+          # 4. Check formatting diff
+          git diff --no-color -- "${CHANGED_FILES[@]}" > "$WORK/fmt.diff"
+
+          if [ ! -s "$WORK/fmt.diff" ]; then
+            echo "[PASS] All modified TypeScript/JavaScript files are already formatted."
+            exit 0
+          fi
+
+          mapfile -t UNFORMATTED < <(git diff --name-only -- "${CHANGED_FILES[@]}")
+
+          echo "::group::Reformatting diff (what Biome would change)"
+          cat "$WORK/fmt.diff"
+          echo "::endgroup::"
+          echo ""
+          echo "[FAIL] ${#UNFORMATTED[@]} file(s) are not formatted:"
+          printf '  - %s\n' "${UNFORMATTED[@]}"
+          echo ""
+          echo "Fix locally by running:"
+          echo ""
+          echo "  npx @biomejs/biome format --write ${UNFORMATTED[*]}"
+          echo ""
+          echo "Then commit the result."
+
+          for f in "${UNFORMATTED[@]}"; do
+            echo "::error file=$f::This file is not formatted. Run 'npx @biomejs/biome format --write $f' and commit the result."
+          done
+
+          # 5. Post inline suggestions via reviewdog
+          reviewdog -f=diff \
+                    -name="biome-formatter" \
+                    -reporter=github-pr-review \
+                    -filter-mode=added \
+                    -fail-level=none < "$WORK/fmt.diff" || true
+
+          exit 1
+
+  biome-lint:
+    name: Biome Lint Suggestions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Checkout
+      pull-requests: write # Post reviewdog suggestion comments
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch complete history to locate the merge-base cleanly
+          persist-credentials: false
+
+      - name: Setup Biome
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # ratchet:biomejs/setup-biome@v2.7.1
+        with:
+          version: ${{ env.BIOME_VERSION }}
+
+      - name: Install Reviewdog
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # ratchet:reviewdog/action-setup@v1
+        with:
+          reviewdog_version: v0.21.0
+
+      - name: Run Biome Lint Suggestions & Fail on Violations
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "$WORK"' EXIT
+
+          # 1. Fetch the target branch reference commits
+          git fetch origin "$BASE_REF"
+
+          # 2. Resolve TypeScript/JavaScript files modified in this PR diff
+          git diff -z --name-only --diff-filter=d "origin/$BASE_REF...HEAD" \
+            -- core contrib skills > "$WORK/changed"
+
+          ALL_CHANGED=()
+          mapfile -d '' -t ALL_CHANGED < "$WORK/changed"
+
+          CHANGED_FILES=()
+          for f in "${ALL_CHANGED[@]}"; do
+            case "$f" in
+              *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.mts|*.cts|*.json|*.jsonc)
+                CHANGED_FILES+=("$f")
+                ;;
+            esac
+          done
+
+          if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
+            echo "No TypeScript/JavaScript files were modified under core/, contrib/ or skills/. Skipping lint."
+            exit 0
+          fi
+
+          echo "Applying auto-fixes to: ${CHANGED_FILES[*]}"
+
+          # 3. Apply safe auto-fixes ONLY to the modified files
+          biome lint --write "${CHANGED_FILES[@]}" || true
+
+          # 4. Post auto-fix suggestion comments strictly targeting modified files
+          git diff --no-color -- "${CHANGED_FILES[@]}" > "$WORK/fix.diff"
+          if [ -s "$WORK/fix.diff" ]; then
+            reviewdog -f=diff \
+                      -name="biome-lint-suggestions" \
+                      -reporter=github-pr-review \
+                      -filter-mode=added \
+                      -fail-level=none < "$WORK/fix.diff" || true
+          fi
+
+          # 5. Restore files so diagnostic pass runs against original commits
+          git checkout -- .
+
+          # 6. Run diagnostic lint and print human-readable output to log first
+          LINT_STATUS=0
+          biome lint --error-on-warnings "${CHANGED_FILES[@]}" || LINT_STATUS=$?
+
+          # 7. Post inline annotations via reviewdog using rdjson format
+          biome lint --reporter=rdjson "${CHANGED_FILES[@]}" > "$WORK/lint.rdjson" || true
+
+          if [ -s "$WORK/lint.rdjson" ]; then
+            reviewdog -f=rdjson \
+                      -name="biome-linter" \
+                      -reporter=github-pr-review \
+                      -filter-mode=added \
+                      -fail-level=none < "$WORK/lint.rdjson" || true
+          fi
+
+          if [ "$LINT_STATUS" -ne 0 ]; then
+            echo ""
+            echo "========================================"
+            echo "  ACTION REQUIRED: Biome lint findings"
+            echo "========================================"
+            echo ""
+            echo "Fix auto-fixable issues locally by running:"
+            echo ""
+            echo "  npx @biomejs/biome lint --write ${CHANGED_FILES[*]}"
+            echo ""
+            exit 1
+          fi
+
+          echo "[PASS] No Biome lint violations in the modified files."

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "bracketSpacing": true,
+      "arrowParentheses": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds Biome-based formatting and linting for TypeScript/JavaScript, in two files:

- **`.github/workflows/typescript-format.yml`** — two jobs, `biome-format` and
  `biome-lint`, that run on pull requests touching TS/JS under `core/`, `contrib/` or
  `skills/`. Each resolves the files changed in the PR, runs Biome over just those
  files, posts inline suggestions through reviewdog, and fails the check if anything is
  unformatted or violates a lint rule.
- **`biome.json`** at the repo root — the style definition: 2-space indent, 80-column
  width, LF endings, double quotes, always-semicolons, trailing commas in JS but not
  JSON, and Biome's `recommended` linter preset.

This is the TypeScript counterpart to the existing `python-format.yml` and
`go-format.yml`.

## Why

The repo has TS/JS today and nothing checks it. It is not organised as TypeScript
recipes — no manifest declares `language: typescript` — it arrives as **frontends inside
Python recipes**: `core/python/deep-search/frontend`,
`core/python/genmedia-for-commerce/frontend`, `core/python/long-horizon-harness/web`,
and `skills/retail/virtual-tryon`. That is 309 `.ts`/`.tsx`/`.js`/`.jsx` files with no
formatter and no linter, while the Python and Go code sitting beside them has both.

Because that code already exists, this workflow is **not inert on merge** — which makes
it different from adding a language workflow ahead of its first recipe. See Testing for
what it would flag today; that number is the main thing worth a decision on this PR.

The style config is a single root `biome.json` rather than per-recipe configs, and the
workflow deliberately passes no formatting flags on the CLI so Biome discovers config by
walking up from each file. There are currently no nested `biome.json` files anywhere
under the recipe roots, so the root file is genuinely the single source of truth, and
changing the standard means editing it rather than the workflow.

## How it works

- **Both jobs are diff-scoped.** They `git fetch` the base ref, take
  `git diff --name-only --diff-filter=d "origin/$BASE_REF...HEAD"` over `core contrib
  skills`, and filter to TS/JS/JSON extensions. Zero matches exits 0 early. `-z` plus
  `mapfile -d ''` means paths with spaces survive intact.
- **Format job**: runs `biome format --write`, diffs the result, and if the diff is
  non-empty prints it in a collapsed `::group::`, emits a `::error file=` annotation per
  file, prints a copy-pasteable `npx @biomejs/biome format --write ...` fix command, and
  exits 1. reviewdog posts the same diff as suggestions.
- **Lint job**: applies safe auto-fixes, posts the resulting diff as suggestions, then
  **restores the tree with `git checkout -- .`** so the diagnostic pass runs against
  what the author actually committed rather than against Biome's fixes. It then runs
  `biome lint --error-on-warnings` for the pass/fail decision and a second
  `--reporter=rdjson` pass to feed reviewdog inline annotations.
- **reviewdog can never change the verdict.** Every reviewdog call carries
  `-fail-level=none` and `|| true`; the exit status comes solely from Biome. This
  matters because reviewdog cannot post review comments on PRs from forks, so the
  check has to stand on its own log output.
- **`permissions: {}` at workflow level, granted per job** — a deliberate deviation from
  `python-format.yml`, which declares `contents: read` at the top. Declaring
  `pull-requests: write` at workflow level would hand it to every job added later; here
  each job asks for exactly what it needs. `persist-credentials: false` on both
  checkouts.
- **Everything is pinned.** Biome `2.5.10` via a `BIOME_VERSION` env var, reviewdog
  `v0.21.0`, and all three actions to commit SHAs with `# ratchet:` comments, matching
  the rest of `.github/workflows/`. The `$schema` URL in `biome.json` is pinned to the
  same 2.5.10, so config and binary cannot drift apart silently.

## Testing

**`actionlint` 1.7.12 — clean:**

```
$ actionlint .github/workflows/typescript-format.yml
$ echo $?
0
```

**CI on this PR is green but proves almost nothing.** Both jobs ran and passed, and the
log says why:

```
No TypeScript/JavaScript files were modified under core/, contrib/ or skills/.
Skipping formatting.
```

This PR only touches `.github/` and the root `biome.json`, neither of which is under a
recipe root, so `CHANGED_FILES` is empty and both jobs take the early `exit 0`. The
green checks demonstrate the workflow parses, installs Biome and reviewdog, and reaches
the no-op path. They exercise no formatting and no linting whatsoever.

**So the real behaviour was measured locally**, with the pinned Biome 2.5.10 binary
against the exact extension set the workflow forwards, over all tracked files under
`core/`, `contrib/` and `skills/` (276 files reach Biome; the rest are gitignored):

| Check | Files affected | Findings |
| :-- | --: | :-- |
| `biome format` | **182** | 131 `.tsx`, 24 `.ts`, 22 `.json`, 5 `.js` |
| `biome lint --error-on-warnings` | **100** | 653 errors, 112 warnings, 27 infos |

None of those 182 are gitignored, so all of them are reachable by a PR diff.

**Not proven:** the reviewdog round trip. Neither suggestion path has posted a comment
on a real PR, because no run has yet had a non-empty file list. Token scope, the
`github-pr-review` reporter, `-filter-mode=added`, and the fork-PR degradation stay
untested until a PR touches a frontend file. Same for the `--write` auto-fix and the
`git checkout -- .` restore step in the lint job.

## Notes for the reviewer

- **The pass/fail gate is whole-file; the suggestions are added-lines-only.** reviewdog
  runs with `-filter-mode=added`, so comments land only on lines the PR touched — but
  the exit status comes from `biome lint --error-on-warnings "${CHANGED_FILES[@]}"`,
  which lints the entire file. A one-line edit to any of the 100 files above therefore
  fails the check on pre-existing findings the author did not introduce, and the
  suggestions shown will not correspond to the failure. This is the behaviour most
  likely to need a decision before merge — options are to keep it strict, drop
  `--error-on-warnings`, or gate on new findings only.
- **`--error-on-warnings` means 112 warnings are hard failures**, not advisories.
- **The JSON arm reaches beyond TypeScript.** The `case` filter accepts `*.json` and
  `*.jsonc`, so once a PR triggers the workflow with any TS change, *every* changed JSON
  file under the recipe roots is formatted and linted too. 22 of the 182 are JSON, and
  three are ADK eval fixtures — `tests/eval/eval_config.json`,
  `evalsets/basic.evalset.json` — in Python recipes that have no TypeScript at all. The
  `on.paths` trigger list is narrower than the `case` arm (it lists only `package.json`
  and `biome.json`), so this only bites in mixed PRs, but the two filters not matching
  is worth a deliberate yes/no.
- **Nothing reformats the existing 182 files.** This PR adds enforcement only; the
  backlog gets fixed incrementally as PRs touch each file, which is why the whole-file
  gate above matters. A one-off `biome format --write` sweep would be a separate PR.
- **`fetch-depth: 0` on both checkouts** pulls full history for the merge-base. Fine
  now; if clone time becomes an issue, a targeted `git fetch --depth` of the base ref
  would do.
- Left deliberately alone: the ~40-line file-resolution preamble is duplicated verbatim
  between the two jobs. Factoring it into a composite action or a matrix would touch the
  Python and Go format workflows too, and does not belong in the PR that adds the
  TypeScript one.
