### PR TITLE
fix(long-horizon-harness): scope the compact-declaration flag to our own tools

### DIFF
--- a/core/python/long-horizon-harness/docs/configuration.md
+++ b/core/python/long-horizon-harness/docs/configuration.md
@@ -108,7 +108,7 @@ longer rebuilt per session.
 | `LHA_PRUNE_TOOL_OUTPUTS` | on | `0` disables zeroing of old large tool-result bodies. |
 | `LHA_PRELOAD_MAX_MEMORIES` | `20` | Cap on memories injected into the per-turn `<PAST_CONVERSATIONS>` block. ADK's `search_memory` takes no `top_k`, so without this the block grows with the user's memory count forever. |
 | `LHA_PRELOAD_MAX_CHARS` | `4000` | Character cap on the same block, applied after the count cap. |
-| `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` | `1` (set by `agent.py`) | Selects ADK's lean declaration path. The pydantic path ships `title` on every parameter, `default: null`, and `anyOf[X, null]`: 2,812 chars of the tool surface on every turn for no meaning. An explicit value in the environment wins. |
+| `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` | unset | Selects ADK's lean declaration path process-wide. The root agent no longer needs it: `context/declaration_compaction.py` scopes the same switch to its own tool builds, worth 2,549 chars of the tool surface on every turn. Set it yourself only if you also want it for the child agents, and only if nothing else in the process would be re-rendered by it. |
 | `LHA_COMPACTION_WINDOW_FRACTION` | `0.75` | Fraction (0,1) of the model's input window at which compaction fires. |
 
 ### Scheduler / routines

--- a/core/python/long-horizon-harness/docs/context-budget.md
+++ b/core/python/long-horizon-harness/docs/context-budget.md
@@ -74,9 +74,13 @@ individually fine. Dropping either one leaves a real session unbounded.
 
 Tool declarations are usually the largest component, so two settings matter:
 
-- `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL=1` (set in `agent.py`). ADK's pydantic
-  path emits `title` on every parameter, `default: null`, and `anyOf[X, null]`.
-  The legacy path expresses the same parameters without them.
+- `context/declaration_compaction.py` builds the root agent's declarations on
+  ADK's legacy path, worth 2,549 chars a turn. The pydantic path emits `title`
+  on every parameter, `default: null`, and `anyOf[X, null]`; the legacy path
+  expresses the same parameters without them.
+  `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` selects it process-wide, so the
+  module scopes it to one build; child agents (`delegate_builder`, the memory
+  forks, `web_research`) stay on the pydantic path.
 - `context/schema_normalization.py` runs `inspect.cleandoc` over tool
   descriptions, since the legacy path otherwise ships raw indented docstrings.
 

--- a/core/python/long-horizon-harness/horizon/agent.py
+++ b/core/python/long-horizon-harness/horizon/agent.py
@@ -36,6 +36,7 @@ from horizon.memory.preload import HorizonPreloadMemoryTool
 from horizon.commands.dispatcher import make_slash_command_dispatcher
 from horizon.context.summarizer import HorizonSummarizer
 from horizon.context.artifact_url_redaction import redact_artifact_urls_callback
+from horizon.context.declaration_compaction import compact_tool_declarations
 from horizon.context.schema_normalization import (
     normalize_tool_schemas_callback,
 )
@@ -97,11 +98,6 @@ _logger = logging.getLogger(__name__)
 # building the agent keeps it (the project-wide default is global Vertex).
 os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
 os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
-# ADK's pydantic-JSON-Schema declaration path ships model_json_schema()
-# artifacts verbatim: a "title" next to every self-describing param name,
-# "default":null on every optional, and anyOf[X,null] instead of nullable.
-# That is 2,812 chars of the tool surface on every turn for zero meaning.
-os.environ.setdefault("ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL", "1")
 if not os.environ.get("GOOGLE_CLOUD_PROJECT"):
     try:
         _, project_id = google.auth.default()
@@ -229,7 +225,10 @@ def _build_app_object() -> App:
         static_instruction=_static_instruction_for(
             tools, has_code_executor=code_executor is not None
         ),
-        tools=tools,
+        # Compact declarations, scoped to our own tools: the env var that
+        # selects them is process-wide and would re-render the tool surface
+        # of any other ADK agent sharing this process.
+        tools=compact_tool_declarations(tools),
         code_executor=code_executor,
         # Order in each list matters — callbacks run top-to-bottom; later entries
         # can read state mutated by earlier ones.

--- a/core/python/long-horizon-harness/horizon/context/declaration_compaction.py
+++ b/core/python/long-horizon-harness/horizon/context/declaration_compaction.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build the root agent's tool declarations on ADK's legacy schema path.
+
+ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL selects that path process-wide, and
+agents-cli imports this package to reach root_agent, so setting it would
+re-render the declarations of every other ADK agent in the process. Scope
+it to one build instead. Child agents stay on the pydantic path rather than
+pay a call site each.
+
+docs/context-budget.md has what the legacy path is worth.
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+from typing import Any
+
+from google.adk.features._feature_registry import (
+    FeatureName,
+    temporary_feature_override,
+)
+from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.function_tool import FunctionTool
+
+__all__ = ["compact_tool_declarations"]
+
+# temporary_feature_override mutates process-global state, so builds are
+# serialised; the guarded section is synchronous, so only threads can race.
+_BUILD = threading.Lock()
+
+
+def _compact(tool: BaseTool) -> BaseTool:
+    inner = tool._get_declaration
+
+    def scoped() -> Any:
+        with (
+            _BUILD,
+            temporary_feature_override(
+                FeatureName.JSON_SCHEMA_FOR_FUNC_DECL, False
+            ),
+        ):
+            return inner()
+
+    # copy.copy, never a BaseTool subclass: an override returning None would
+    # delete the tool from the model's view in silence. Rebuilt per call
+    # rather than pinned, so a session-varying declaration keeps varying.
+    clone = copy.copy(tool)
+    object.__setattr__(clone, "_get_declaration", scoped)
+    return clone
+
+
+def compact_tool_declarations(tools: list[Any]) -> list[Any]:
+    """Compact our own declarations, leaving the rest of the process alone."""
+    out: list[Any] = []
+    for tool in tools:
+        if isinstance(tool, BaseTool):
+            out.append(_compact(tool))
+        elif callable(tool):
+            out.append(_compact(FunctionTool(tool)))  # what ADK does anyway
+        else:
+            out.append(tool)  # a BaseToolset builds its own declarations
+    return out

--- a/core/python/long-horizon-harness/tests/unit/test_clarify.py
+++ b/core/python/long-horizon-harness/tests/unit/test_clarify.py
@@ -333,6 +333,11 @@ def test_tool_context_is_keyword_only():
 
 def test_clarify_registered_on_root_agent():
     from horizon.agent import root_agent
-    from horizon.tools.clarify import clarify
 
-    assert clarify in root_agent.tools
+    # By name, not identity: the tool list holds the FunctionTool wrappers
+    # that carry the compact declaration, not the bare functions.
+    names = {
+        getattr(t, "name", None) or getattr(t, "__name__", "")
+        for t in root_agent.tools
+    }
+    assert "clarify" in names

--- a/core/python/long-horizon-harness/tests/unit/test_declaration_compaction.py
+++ b/core/python/long-horizon-harness/tests/unit/test_declaration_compaction.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compact declarations are ours alone, and every param keeps a type."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.features._feature_registry import (
+    FeatureName,
+    is_feature_enabled,
+)
+from google.adk.tools.function_tool import FunctionTool
+
+from horizon.context.declaration_compaction import compact_tool_declarations
+
+
+def _sample(query: str | None = None) -> str:
+    """Somebody else's tool."""
+    return ""
+
+
+def _is_compact(tool: Any) -> bool:
+    # .parameters is the compact rendering; JSON Schema leaves it None.
+    return tool._get_declaration().parameters is not None
+
+
+def test_ours_compact_theirs_untouched() -> None:
+    (ours,) = compact_tool_declarations([_sample])
+    assert _is_compact(ours)
+    assert not _is_compact(FunctionTool(_sample))
+
+
+def test_a_toolset_passes_through() -> None:
+    ts = object()
+    assert compact_tool_declarations([ts])[0] is ts
+
+
+def test_importing_horizon_leaves_the_process_default_alone() -> None:
+    import horizon.agent  # noqa: F401
+
+    # Catches the env var and override_feature_enabled alike: either would
+    # re-render the declarations of every other ADK agent in the process.
+    assert is_feature_enabled(FeatureName.JSON_SCHEMA_FOR_FUNC_DECL)
+
+
+def _typeless(node: Any, path: str) -> list[str]:
+    if not isinstance(node, dict):
+        return []
+    bad = [path] if path and not (node.get("type") or node.get("enum")) else []
+    kids = list((node.get("properties") or {}).items())
+    kids += [("[]", node["items"])] if "items" in node else []
+    return bad + [p for k, v in kids for p in _typeless(v, f"{path}.{k}")]
+
+
+def test_no_param_reaches_vertex_without_a_type() -> None:
+    # Compact rendering drops anyOf, so a param annotated `Any` becomes a
+    # bare {"nullable": true} and Vertex 400s the whole request with
+    # "didn't specify the schema type field".
+    probe = {"type": "OBJECT", "properties": {"m": {"nullable": True}}}
+    assert _typeless(probe, "p") == ["p.m"]
+
+    from horizon.agent import root_agent
+
+    offenders = []
+    for tool in root_agent.tools:
+        decl = getattr(tool, "_get_declaration", lambda: None)()
+        if decl is None:
+            continue
+        params = decl.parameters or decl.parameters_json_schema or {}
+        if not isinstance(params, dict):
+            params = params.model_dump(exclude_none=True)
+        offenders += _typeless(params, decl.name)
+    assert not offenders, f"Vertex will reject: {offenders}"


### PR DESCRIPTION
## Summary

- `horizon/agent.py` set `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` at import. That flag is process-wide, and agents-cli imports the package to reach `root_agent`, so importing horizon re-rendered the tool declarations of any other ADK agent in the process.
- The re-render can be fatal, not just cosmetic. A param annotated `Any` is `anyOf[{}, null]` under JSON Schema, which Vertex accepts, and a bare `{"nullable": true}` under the compact path, which it rejects: `functionDeclaration ... didn't specify the schema type field`. Measured against gemini-3.7-flash on Vertex, both shapes, one accepted and one 400.
- Same saving for the root agent, scoped to one declaration build. Its surface is byte-identical before and after: 13 declarations, 11,349 chars.

## Scope: root agent only

Deliberate. The env var also compacted the four child agents (`delegate_builder.py:269`, `review_fork.py:137`, `flush_fork.py:87`, `web_research.py:42`), and they now render on the pydantic path. The review-fork child goes 1,533 -> 1,957 chars; a delegate child carrying the full tool set would give back the whole 2,549.

The alternative was a `build_agent` factory plus an AST test forbidding direct `Agent(...)`, so no future agent could miss it. Not worth the coupling for short-lived children. Set the env var yourself if you want it process-wide and nothing else in the process would be re-rendered.

## Changes

- `horizon/context/declaration_compaction.py`: build the root agent's declarations under `temporary_feature_override`, via `copy.copy` + `object.__setattr__` rather than a `BaseTool` subclass. Rebuilt per call, not pinned, so a session-varying declaration keeps varying. `HorizonSkillToolset` passes through untouched; it writes its own schema and never read the flag.
- `horizon/agent.py`: drop the env var, wrap the tool list.
- `tests/unit/test_declaration_compaction.py`: importing horizon leaves the process default alone, and no declaration on the root agent has a typeless param.
- `tests/unit/test_clarify.py`: assert by name. The list now holds the `FunctionTool` wrappers carrying the compact declaration, which is what ADK builds from a bare function anyway.
- `docs/configuration.md`, `docs/context-budget.md`: both said `agent.py` sets the var.

Unit suite 2,276 -> 2,280, ruff clean. Each test was run against the mutant it exists to catch: restoring the env var fails the leak test, so does swapping it for `override_feature_enabled`, a no-op wrapper fails two others, and blinding the typeless detector fails its own self-check.

Also corrected in passing: the old comment claimed 2,812 chars saved, the current 14-tool surface measures 2,549.
