### PR TITLE
docs(long-horizon-harness): stop pinning the declaration saving to a number

### DIFF
--- a/core/python/long-horizon-harness/docs/configuration.md
+++ b/core/python/long-horizon-harness/docs/configuration.md
@@ -108,7 +108,7 @@ longer rebuilt per session.
 | `LHA_PRUNE_TOOL_OUTPUTS` | on | `0` disables zeroing of old large tool-result bodies. |
 | `LHA_PRELOAD_MAX_MEMORIES` | `20` | Cap on memories injected into the per-turn `<PAST_CONVERSATIONS>` block. ADK's `search_memory` takes no `top_k`, so without this the block grows with the user's memory count forever. |
 | `LHA_PRELOAD_MAX_CHARS` | `4000` | Character cap on the same block, applied after the count cap. |
-| `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` | unset | Selects ADK's lean declaration path process-wide. The root agent no longer needs it: `context/declaration_compaction.py` scopes the same switch to its own tool builds, worth 2,549 chars of the tool surface on every turn. Set it yourself only if you also want it for the child agents, and only if nothing else in the process would be re-rendered by it. |
+| `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` | unset | Selects ADK's lean declaration path process-wide. The root agent no longer needs it: `context/declaration_compaction.py` scopes the same switch to its own tool builds. Set it yourself only if you also want it for the child agents, and only if nothing else in the process would be re-rendered by it. |
 | `LHA_COMPACTION_WINDOW_FRACTION` | `0.75` | Fraction (0,1) of the model's input window at which compaction fires. |
 
 ### Scheduler / routines

--- a/core/python/long-horizon-harness/docs/context-budget.md
+++ b/core/python/long-horizon-harness/docs/context-budget.md
@@ -75,9 +75,9 @@ individually fine. Dropping either one leaves a real session unbounded.
 Tool declarations are usually the largest component, so two settings matter:
 
 - `context/declaration_compaction.py` builds the root agent's declarations on
-  ADK's legacy path, worth 2,549 chars a turn. The pydantic path emits `title`
-  on every parameter, `default: null`, and `anyOf[X, null]`; the legacy path
-  expresses the same parameters without them.
+  ADK's legacy path. The pydantic path emits `title` on every parameter,
+  `default: null`, and `anyOf[X, null]`; the legacy path expresses the same
+  parameters without them, which `measure_prefix.py` prices.
   `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` selects it process-wide, so the
   module scopes it to one build; child agents (`delegate_builder`, the memory
   forks, `web_research`) stay on the pydantic path.


### PR DESCRIPTION
Follow-up to #2561, docs only.

Both entries stated the saving as 2,549 chars. That is the figure that rots: the comment #2561 replaced claimed 2,812, and the surface had moved to 2,549 without anyone noticing. Point at `measure_prefix.py`, which the doc already tells you to run, instead of freezing a new one.
