### PR TITLE
fix(ci): anchor AI reviews to the combined diff, not the patch series

### DIFF
--- a/.github/scripts/prepare_review_diff.py
+++ b/.github/scripts/prepare_review_diff.py
@@ -215,7 +215,14 @@ def filter_diff(diff: str) -> tuple[str, dict]:
         churn = _section_churn(section)
 
         if path is None:
-            skipped.append((section[0][11:] or "<unknown>", "deleted", churn))
+            # `_section_path` returns None for a deletion, so recover the name
+            # from the `diff --git` header. Slicing off "diff --git " left the
+            # raw "a/x b/x" pair in the log, which reads as a path containing
+            # a space and hides which file was actually dropped.
+            header = GIT_HEADER_PATHS.match(section[0]) if section else None
+            skipped.append(
+                (header.group(2) if header else "<unknown>", "deleted", churn)
+            )
             continue
         # A section with no churn is a pure rename or a mode change. There is
         # nothing in it to comment on, and on a migration PR it can be most of

--- a/.github/workflows/_ai-pr-review-core.yml
+++ b/.github/workflows/_ai-pr-review-core.yml
@@ -273,6 +273,25 @@ jobs:
         run: |-
           set -euo pipefail
 
+          # Fetched WITHOUT `--patch`. That flag asks for the `.patch` media
+          # type, which is a git-format-patch SERIES — one patch per commit,
+          # concatenated — not the PR's combined diff. Every later step here
+          # assumes a combined diff, and on a multi-commit PR the two disagree
+          # about what the PR even changes:
+          #
+          # #2566 has 6 commits that add a scratch recipe in commit 1 and
+          # delete it again in commit 5. Its combined diff is ONE file, 12KB.
+          # Its patch series is 42 file entries, 872KB, listing every file of
+          # that scratch recipe as added and then again as deleted. The
+          # reviewers duly reviewed a recipe the PR does not touch, and GitHub
+          # rejected every resulting comment with HTTP 422 — the anchors name
+          # paths and lines that are not in the PR's diff, because they are
+          # not in the PR. Three of the four lanes failed that way; the fourth
+          # passed only because it had nothing left to post.
+          #
+          # A review comment can only ever be anchored to the combined diff,
+          # so that is the only thing worth reviewing.
+          #
           # Track success explicitly. `set -e` cannot catch a failure here:
           # a command used as an `if` condition is a tested condition, not an
           # error, so an exhausted retry loop would fall through with an empty
@@ -280,7 +299,7 @@ jobs:
           # which the model answers by finding nothing and exiting 0.
           FETCHED='false'
           for attempt in 1 2 3; do
-            if gh pr diff "${PR_NUMBER}" --patch > pr_diff.txt; then
+            if gh pr diff "${PR_NUMBER}" > pr_diff.txt; then
               FETCHED='true'
               break
             fi


### PR DESCRIPTION
## Problem

The AI review lanes fetched the diff with `gh pr diff --patch`. That flag asks for the `.patch` media type, which is a **git-format-patch series — one patch per commit, concatenated** — not the PR's combined diff. Every step downstream (`prepare_review_diff.py`, the prompt, `post_review_comments.py` anchor validation) assumes a combined diff.

On a multi-commit PR the two disagree about what the PR changes at all. #2566 adds a scratch recipe in commit 1 and deletes it again in commit 5:

| | combined diff (what the PR *is*) | `--patch` series (what was reviewed) |
|---|---|---|
| bytes | 12,506 | 872,257 |
| file entries | 1 | 42 |

So the reviewers analysed `contrib/typescript/customer-service/**`, a recipe the PR does not touch, and GitHub rejected every resulting comment with `HTTP 422` — the anchors name paths and lines that are not in the PR's diff, because they are not in the PR. Three of the four lanes on #2566 failed this way; the fourth passed only because dedup left it nothing to post.

This silently degraded reviews on *every* multi-commit PR, not just the ones that went red: where phantom files overlapped real ones, lanes spent their comment budget on code that was not under review.

`--patch` was never a deliberate choice. It dates from when the model shelled out for its own diff (80aac0a0) and was carried into the workflow verbatim in #2531.

## Fix

Drop the flag. A review comment can only ever be anchored to the combined diff, so that is the only thing worth reviewing.

## Verification

Replayed the real reviewer output from the failing run through `post_review_comments.py` against both diffs:

- **old `--patch` path** — validates and would post anchors on `config.ts:34` and `function_tools.ts:1`: exactly the phantom comments GitHub 422'd
- **fixed path** — drops all three phantoms, keeps the one genuine finding on `.github/workflows/typescript-tests.yml` with a valid anchor

`prepare_review_diff.py` on the real PR goes from `25 file(s) / 2192 lines reviewable` to `1 file(s) / 315 lines` — the actual PR.

363 tests pass, workflow YAML parses, ruff clean.

## Also

One adjacent one-liner: deleted files were logged as `a/x b/x` instead of `x`, because the skip path sliced off `"diff --git "` rather than parsing the header. Log-only, no behaviour change — but it is the noise that made this failure hard to read in the first place.

---
🤖 Generated with CloudCode — session `ses_e5fc0adaa36ffeRd4j8cH5xVH6`