### PR TITLE
fix(ci): read a reviewer's findings when it forgets to escape a quote

### DIFF
--- a/.github/scripts/post_review_comments.py
+++ b/.github/scripts/post_review_comments.py
@@ -63,6 +63,7 @@ Exit codes:
 """
 
 import argparse
+import itertools
 import json
 import re
 import subprocess
@@ -94,6 +95,40 @@ FENCED_BLOCK = re.compile(r"```(?:json)?\s*(\[.*?)```", re.DOTALL)
 # A window row: "  42: os.system(cmd)". Both ":" and "|" are seen as the
 # separator, and the leading whitespace is the model aligning its numbers.
 WINDOW_LINE = re.compile(r"^\s*(\d+)\s*[:|]\s?(.*)$")
+
+# The keys a finding is built from. Used to find where a string value ENDS
+# when the model has left raw quotes inside it — see _repair_string_values.
+FINDING_KEYS = "path|line|body|window|verify_steps"
+
+# The opener of a string-valued field: '"window": "'.
+STRING_FIELD_OPEN = re.compile(rf'"(?:{FINDING_KEYS})"\s*:\s*"')
+
+# Where such a value ends: a quote followed by the next key, or by the end of
+# the object. Anything else that looks like a terminator is part of the value.
+STRING_FIELD_END = re.compile(rf'"(?=\s*(?:,\s*"(?:{FINDING_KEYS})"\s*:|\}}))')
+
+# How much work to spend reading a malformed block before giving up on it.
+# The choices multiply per field, so this is a ceiling on a combinatorial walk.
+# Proving a reading UNIQUE means exhausting the walk, so the cap has to clear
+# a real block with room to spare: the three-finding block in
+# fixtures/malformed_findings_response.txt spends 6091 of it and the
+# two-finding #2566 block 383. Exhausting the cap is treated as "ambiguous",
+# never as "unique" — see _repaired_findings.
+MAX_REPAIR_STEPS = 16384
+
+# How many candidate ends to weigh for a single field. Every later field
+# boundary is a candidate end for an earlier field, so this is what stops a
+# many-finding block fanning out by its own width. The correct end is the
+# first in every real case seen; the rest are only there to expose ambiguity,
+# and a reading only reachable past the eighth is one this declines to make.
+MAX_ENDS_PER_FIELD = 8
+
+# String fields past which a block is not a findings array a review produced,
+# and is not worth reading. A lane is asked for about five findings of four
+# string fields each; the two real blocks here carry 8 and 12. Checked before
+# the walk starts, because the walk holds a copy of the reading so far per
+# branch: a runaway thousand-finding block cost 400MB of them before this.
+MAX_REPAIR_FIELDS = 64
 
 # Literal escape text a model writes where the diff holds the real character.
 ESCAPE_SEQ = re.compile(
@@ -271,14 +306,23 @@ def extract_findings(response: str) -> list:
     answer — the prompt says the findings block comes last, and this reads it
     from the same end.
 
-    A block that will not parse AT ALL is salvaged finding by finding rather
-    than thrown away whole. Findings now quote source verbatim in `window`,
-    and source is full of double quotes: a reviewer emitted
+    A block that will not parse AT ALL is repaired, and failing that salvaged
+    finding by finding, rather than thrown away whole. Findings quote source
+    verbatim in `window`, and source is full of double quotes: a reviewer
+    emitted
 
         "window": "  211:     assert res["success"] is True\\n ..."
 
     which is one unescaped pair away from valid and killed an entire review
-    of three good findings. One malformed finding should cost that finding.
+    of three good findings.
+
+    Repair runs first because it recovers the WHOLE block, where salvage keeps
+    only the findings that happened to be well-formed already. Salvage alone
+    is not enough: the same quoting habit corrupts every window drawn from the
+    same file, so on a quote-dense diff there are no well-formed siblings left
+    to keep. Repair declines anything it cannot read one single way, so salvage
+    remains the fallback for a block that is malformed in some other way, and
+    one malformed finding still costs only that finding.
     """
     matches = list(FENCED_BLOCK.finditer(response))
     # Both branches guarantee a block starting at "[", so the scan below
@@ -300,6 +344,15 @@ def extract_findings(response: str) -> list:
         except json.JSONDecodeError as exc:
             if parsed_any:
                 break
+            # Repair before salvage: it recovers every finding in the block,
+            # where salvage keeps only the ones that were already well-formed.
+            repaired = _repaired_findings(block)
+            if repaired is not None:
+                print(
+                    f"  findings block is malformed JSON ({exc}); "
+                    f"repaired {len(repaired)} finding(s) in it"
+                )
+                return _dedupe(repaired)
             salvaged = _salvage_findings(block, decoder)
             if salvaged:
                 print(
@@ -328,6 +381,126 @@ def _dedupe(findings: list) -> list:
             seen.add(key)
             unique.append(finding)
     return unique
+
+
+def _escape_value(value: str) -> str:
+    """Re-escape a value's double quotes, normalising first so it is idempotent."""
+    return value.replace('\\"', '"').replace('"', '\\"')
+
+
+def _repair_readings(block: str, budget: list[int]):
+    """Every way of escaping the block, one per choice of where values end.
+
+    A value's end is looked for from the SCHEMA — the quote that precedes the
+    next known key, or the one that closes the object — because the obvious
+    cheap rule, "a quote followed by `,`, `]` or `}`", is wrong on the very
+    input this exists for: `[ -f "yarn.lock" ]` puts a `]` right after the
+    stray quote and would end the array mid-string.
+
+    The schema rule is not unambiguous either, so the first MAX_ENDS_PER_FIELD
+    candidate ends are branched on rather than just the first, and the caller
+    decides between the readings they produce.
+
+    Depth-first over an explicit stack, not recursion: one field is one frame,
+    and a runaway model answering with hundreds of findings would exceed the
+    interpreter's limit. That mattered — a RecursionError escapes the caller
+    entirely, so a block salvage could have read went to a CI fault instead.
+    `budget` is charged for every reading completed and every branch taken, so
+    the walk is capped whatever shape it takes: the combinations multiply per
+    field, and a block nobody can read is not worth an unbounded search.
+    """
+    stack: list[tuple[int, str]] = [(0, "")]
+
+    while stack:
+        if budget[0] <= 0:
+            return
+        index, prefix = stack.pop()
+
+        opener = STRING_FIELD_OPEN.search(block, index)
+        if opener is None:
+            budget[0] -= 1
+            yield prefix + block[index:]
+            continue
+
+        head = prefix + block[index : opener.end()]
+        ends = list(
+            itertools.islice(
+                STRING_FIELD_END.finditer(block, opener.end()),
+                MAX_ENDS_PER_FIELD,
+            )
+        )
+        if not ends:
+            # No end to find, so there is nothing to repair past this point.
+            budget[0] -= 1
+            yield head + block[opener.end() :]
+            continue
+
+        # Reversed, so the earliest end is popped first and the cheapest
+        # reading is the one a budget-limited walk is most likely to reach.
+        #
+        # Each push copies the reading so far, so pushes are charged to the
+        # budget as well. Counting only the steps that reached a leaf let a
+        # wide block spend minutes building readings it never finished: every
+        # later field boundary is a candidate end for every earlier field, so
+        # a 400-finding block pushed ~1600 copies per step and ran for over
+        # two minutes before this.
+        for end in reversed(ends):
+            budget[0] -= 1
+            value = block[opener.end() : end.start()]
+            stack.append((end.end(), f'{head}{_escape_value(value)}"'))
+
+
+def _repaired_findings(block: str) -> list | None:
+    """The findings a malformed block yields, when exactly one reading fits.
+
+    Findings quote source verbatim in `window`, and source is full of double
+    quotes, so the model regularly emits
+
+        "window": "  252:   elif [ -f "yarn.lock" ]; then\\n ..."
+
+    which is not JSON. `_salvage_findings` cannot help: it drops a finding it
+    cannot decode, and one quoting habit corrupts EVERY window drawn from the
+    same file, so a quote-dense diff loses the whole review rather than one
+    finding of it. That is what happened on #2566, where both findings quoted
+    shell out of a workflow file and the run died as a CI fault.
+
+    Escaping alone is not enough, because where a value ENDS can be genuinely
+    ambiguous. A window that quotes findings-shaped source — which this repo's
+    own tests contain — offers a second reading in which the value stops early
+    and the source's own `"line":` and `"body":` become the finding's fields:
+
+        "window": "  919: [{"path": "a.py", "line": 1, "body": "real"}]"
+
+    reads just as well as a finding anchored at line 1 with the body "real".
+    That parses, so parsing cannot be the test. Posting source scraped out of
+    a window as though it were a review comment is worse than posting nothing,
+    so a block is repaired ONLY when exactly one reading survives; anything
+    else falls through to salvage and, failing that, to the CI fault. The two
+    real regressions this exists for both have exactly one reading.
+    """
+    fields = sum(1 for _ in STRING_FIELD_OPEN.finditer(block))
+    if fields > MAX_REPAIR_FIELDS:
+        return None
+
+    readings: dict[str, list] = {}
+    decoder = json.JSONDecoder()
+    budget = [MAX_REPAIR_STEPS]
+
+    for candidate in _repair_readings(block, budget):
+        try:
+            array, _ = decoder.raw_decode(candidate, candidate.find("["))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(array, list) and array:
+            readings.setdefault(json.dumps(array, sort_keys=True), array)
+            if len(readings) > 1:
+                return None
+
+    # An exhausted budget means readings beyond the ones seen may exist, so
+    # "exactly one" has not actually been established.
+    if budget[0] <= 0 or len(readings) != 1:
+        return None
+    return next(iter(readings.values()))
 
 
 def _salvage_findings(block: str, decoder: json.JSONDecoder) -> list[dict]:

--- a/.github/scripts/tests/fixtures/unescaped_quotes_response.txt
+++ b/.github/scripts/tests/fixtures/unescaped_quotes_response.txt
@@ -1,0 +1,30 @@
+I have performed a thorough review of the newly added `.github/workflows/typescript-tests.yml` workflow file, focusing exclusively on correctness, logic errors, and runtime failures.
+
+Here is a summary of the findings:
+
+1. **Bun runtime dependency missing (Runtime Failure)**:
+   The workflow attempts to detect and run Bun-specific tests if `bun.lockb` or `bun.lock` is present using `npx bun install` and `npx bun test`. However, the runner environment (`ubuntu-latest`) does not have Bun pre-installed, and Node.js setup alone does not provide it. Relying on `npx bun` is slow and unreliable as the npm package wrapper is deprecated and fails on many CI configurations. To fix this, the official `oven-sh/setup-bun` action should be used before running tests for Bun-based recipes.
+
+2. **Corepack not enabled for Yarn (Potential Version Mismatches)**:
+   Modern Yarn (v2+) relies on Corepack to automatically match and run the correct package manager version specified in the recipe's `package.json`'s `"packageManager"` field. While the workflow correctly executes `corepack enable` in the `pnpm` block, it misses this step in the `yarn` block. This can lead to recipes failing to install or executing with an incorrect/fallback version of Yarn.
+
+No other major logic errors, shell scripting issues, or incorrect API usages were found in the path detection, file filtering, or gate-results checking code.
+
+```json
+[
+  {
+    "path": ".github/workflows/typescript-tests.yml",
+    "line": 256,
+    "body": "Modern Yarn (v2+) relies on Corepack to invoke the package manager version specified in package.json. Run 'corepack enable' before executing Yarn commands to avoid version mismatches or installation failures.",
+    "window": "  252:           elif [ -f "yarn.lock" ]; then\n  253:             yarn install --frozen-lockfile || yarn install\n  254:             yarn test",
+    "verify_steps": "Read lines 252-254; compare with the pnpm-lock block on lines 248-251 where 'corepack enable' is correctly included."
+  },
+  {
+    "path": ".github/workflows/typescript-tests.yml",
+    "line": 256,
+    "body": "Bun is not pre-installed on the ubuntu-latest runner, making 'npx bun' slow and prone to runtime failures. Use the oven-sh/setup-bun action to properly provision Bun before running tests for Bun recipes.",
+    "window": "  255:           elif [ -f "bun.lockb" ] || [ -f "bun.lock" ]; then\n  256:             npx bun install --frozen-lockfile || npx bun install\n  257:             npx bun test",
+    "verify_steps": "Read lines 255-257; observe that the workflow executes bun commands without first setting up Bun via a setup-bun action step."
+  }
+]
+```

--- a/.github/scripts/tests/test_post_review_comments.py
+++ b/.github/scripts/tests/test_post_review_comments.py
@@ -25,6 +25,7 @@ Every test below pins one of those.
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import post_review_comments as m
@@ -893,6 +894,11 @@ def test_one_unescaped_quote_does_not_destroy_the_whole_review():
     The reviewer emitted `"window": "  211:     assert res["success"] is True"`
     — valid but for one unescaped pair. Three good findings were thrown away
     and the job failed with a CI-fault annotation on the contributor's PR.
+
+    All three come back now. Salvage used to keep the two findings that were
+    already well-formed and drop the third; repair rebuilds the block, so the
+    malformed one is no longer a casualty either — and its window keeps the
+    quotes that broke it.
     """
     response = (FIXTURES / "malformed_findings_response.txt").read_text(
         encoding="utf-8"
@@ -901,13 +907,12 @@ def test_one_unescaped_quote_does_not_destroy_the_whole_review():
         json.loads(m.FENCED_BLOCK.findall(response)[-1])
 
     findings = m.extract_findings(response)
-    assert len(findings) == 2
+    assert len(findings) == 3
     paths = {f["path"].split("/")[-1] for f in findings}
     assert paths == {"test_routine_tool.py", "test_process_tool.py"}
-    # The malformed one is the casualty, and only it.
-    assert all(
-        "errno" in f["body"] or "duplicated" in f["body"] for f in findings
-    )
+
+    recovered = next(f for f in findings if f["line"] == 212)
+    assert 'assert res["success"] is True' in recovered["window"]
 
 
 def test_salvage_keeps_only_things_shaped_like_findings():
@@ -925,6 +930,146 @@ def test_salvage_keeps_only_things_shaped_like_findings():
 
 
 def test_a_block_that_salvages_nothing_is_still_a_ci_fault():
-    """Silence must not be mistaken for a clean review."""
+    """Silence must not be mistaken for a clean review.
+
+    Nothing here carries a finding key, so there is no value for repair to
+    delimit and nothing for salvage to keep. The fault must survive both.
+    """
     with pytest.raises(m.ReviewerOutputError):
         m.extract_findings("```json\n[{totally broken}\n```")
+
+
+def test_every_finding_malformed_still_yields_a_review():
+    """Regression: the Correctness lane on PR #2566.
+
+    Both findings quoted shell out of a workflow file, so both windows came
+    back with raw quotes and salvage — which only keeps findings that were
+    already well-formed — recovered nothing. The review died as a CI fault
+    over output that was one escape away from usable.
+    """
+    response = (FIXTURES / "unescaped_quotes_response.txt").read_text(
+        encoding="utf-8"
+    )
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(m.FENCED_BLOCK.findall(response)[-1])
+    assert (
+        m._salvage_findings(
+            m.FENCED_BLOCK.findall(response)[-1], json.JSONDecoder()
+        )
+        == []
+    )
+
+    findings = m.extract_findings(response)
+    assert len(findings) == 2
+    assert all(
+        f["path"] == ".github/workflows/typescript-tests.yml" for f in findings
+    )
+    assert '[ -f "yarn.lock" ]' in findings[0]["window"]
+    assert '[ -f "bun.lockb" ]' in findings[1]["window"]
+
+
+def test_a_bracket_after_a_stray_quote_is_not_a_value_end():
+    """The trap that rules out the cheap way of finding a value's end.
+
+    `[ -f "x.lock" ]` puts a `]` immediately after the stray quote. Ending a
+    value at the next quote followed by `,`, `]` or `}` would stop there,
+    truncating the array mid-string and losing every finding after it. Only a
+    schema boundary — the next key, or the close of the object — ends a value.
+    """
+    block = '{"window": "  1: [ -f "x.lock" ]; then", "verify_steps": "x"}'
+    start = block.index('"  1:') + 1
+
+    end = m.STRING_FIELD_END.search(block, start)
+    assert end is not None
+    assert block[start : end.start()] == '  1: [ -f "x.lock" ]; then'
+
+
+def test_repair_leaves_a_field_it_cannot_delimit_alone():
+    """An unterminated value has no schema anchor after it.
+
+    Rewriting on a guess would corrupt the one field still readable, so there
+    is no reading to accept and the existing paths decide.
+    """
+    assert (
+        m._repaired_findings('[{"path": "a.py", "body": "unterminated') is None
+    )
+
+
+def test_escaping_a_value_is_idempotent():
+    """A value already escaped must not gain a second layer of backslashes.
+
+    Repair normalises before it escapes, so re-reading a block that was only
+    partly malformed cannot double up the quotes that were already correct.
+    """
+    assert m._escape_value('says \\"hi\\" loudly') == 'says \\"hi\\" loudly'
+    assert m._escape_value('says "hi" loudly') == 'says \\"hi\\" loudly'
+
+
+def test_repair_refuses_a_window_that_quotes_findings_shaped_source():
+    """A second reading scrapes the finding's own fields out of the window.
+
+    The window quotes source that is itself a findings array — which this
+    repo's own tests contain — so one reading anchors at line 919 with the
+    body "dup", and another stops the value early and takes `line` 1 and the
+    body "real" from inside the quoted source. Both parse, so parsing cannot
+    be the test. Posting the second would put source text on a contributor's
+    PR as though it were a review, so the block is declined outright.
+    """
+    block = (
+        '[{"path": "t.py", "line": 919, "body": "dup",'
+        ' "window": "  919: [{"path": "a.py", "line": 1, "body": "real"}]"}]'
+    )
+    assert m._repaired_findings(block) is None
+
+
+def test_repair_declines_rather_than_guessing_past_its_budget():
+    """An exhausted search has not established that a reading is unique."""
+    block = (
+        '[{"path": "a.py", "line": 1, "body": "b",'
+        ' "window": "' + '", "body": "x' * 40 + '"}]'
+    )
+    assert m._repaired_findings(block) is None
+
+
+def _wide_malformed_block(findings: int) -> str:
+    """A block with far more findings than a review ever asks for, one bad."""
+    body = ",".join(
+        f'{{"path": "f{i}.py", "line": 1, "body": "b", "window": "  1: x"}}'
+        for i in range(findings)
+    )
+    return f"[{body}]".replace("  1: x", '  1: [ -f "a.lock" ]', 1)
+
+
+def test_a_runaway_block_does_not_blow_the_stack():
+    """Recursion made a wide block fatal instead of merely unreadable.
+
+    One field was one frame, so a model answering with hundreds of findings
+    raised RecursionError — and that escapes extract_findings entirely, so a
+    block salvage could have read reached the CI fault instead. The walk is
+    iterative for that reason; here it must simply decline.
+    """
+    assert m._repaired_findings(_wide_malformed_block(400)) is None
+
+
+def test_a_runaway_block_is_bounded_in_time():
+    """Charging only completed readings let a wide block run for minutes.
+
+    Every later field boundary is a candidate end for every earlier field, so
+    a 400-finding block pushed ~1600 copies of the reading per step and took
+    over two minutes. Pushes are charged to the budget, and the ends weighed
+    per field are capped, so the walk is bounded by shape as well as depth.
+    """
+    start = time.monotonic()
+    assert m._repaired_findings(_wide_malformed_block(1000)) is None
+    assert time.monotonic() - start < 5
+
+
+def test_a_runaway_block_still_reaches_salvage():
+    """Declining to repair must hand the block on, not end the review.
+
+    The findings that were well-formed are still there to be kept, and before
+    the walk was bounded they were lost with the rest.
+    """
+    findings = m.extract_findings(f"```json\n{_wide_malformed_block(400)}\n```")
+    assert len(findings) == 399
+    assert all(f["path"].endswith(".py") for f in findings)

--- a/.github/workflows/_ai-pr-review-core.yml
+++ b/.github/workflows/_ai-pr-review-core.yml
@@ -756,6 +756,12 @@ jobs:
             computed above. **The anchored line MUST be one of these rows.** Copy the
             text verbatim from the diff.
 
+            Verbatim source goes inside a JSON string, so every double quote in it
+            MUST be escaped as `\"` — a row like `elif [ -f "yarn.lock" ]; then`
+            becomes `"  252: elif [ -f \"yarn.lock\" ]; then"`. The same applies to
+            any double quote in `body` or `verify_steps`. Unescaped, the block is
+            not JSON.
+
             This is checked mechanically, and getting it right is the single most
             useful thing you can do for a finding. A window that matches nothing in the
             diff means the finding is discarded as invented. A window that matches a


### PR DESCRIPTION
## Problem

Findings quote source verbatim in `window`, and source is full of double quotes, so a reviewer regularly answers with

```json
"window": "  252:   elif [ -f "yarn.lock" ]; then\n ..."
```

which is not JSON. `_salvage_findings` cannot help — it *drops* a finding it cannot decode, and one quoting habit corrupts **every** window drawn from the same file, so a quote-dense diff loses the whole review rather than one finding of it.

The Correctness lane on #2566 died exactly that way: two findings, both quoting shell out of a workflow file, nothing salvaged, `[CI FAULT]` on a contributor's PR. Any PR touching a shell-in-YAML, JS or Python file is a candidate.

## Fix

Repair the block before falling back to salvage — but only when it can be read **one** way.

Escaping alone is not sufficient, because where a value *ends* is genuinely ambiguous:

```json
"window": "  919: [{"path": "a.py", "line": 1, "body": "real"}]"
```

reads just as well as a finding anchored at line 1 with the body `"real"` — fields scraped out of the quoted source. **That reading parses**, so parsing cannot be the test. Posting source out of a window as though it were a review comment is worse than posting nothing, so an ambiguous block is declined and the existing fault stands.

Not hypothetical: this repo's own `test_post_review_comments.py` contains a findings-shaped literal.

## Bounds

The uniqueness walk is bounded three ways, each for a failure it hit while being built:

| Bound | Failure it prevents |
|---|---|
| iterative, not recursive | one field was one frame; a runaway block raised `RecursionError` **past** the caller, losing findings salvage would have kept |
| branches charged to the step budget | a wide block spent **>2 min** building readings it never finished |
| declined past 64 string fields | the walk holds a copy of the reading per branch — a 1000-finding block cost **400 MB** |

After: pathological blocks decline in 0.4 ms / 23 MB, and still reach salvage.

## Verification

| Command | Result |
|---|---|
| `pytest .github/scripts/tests/` | **372 passed** |
| `ruff check .github/scripts/` | All checks passed |
| `ruff format --check .github/scripts/` | 23 files already formatted |
| workflow YAML parse | OK |
| end-to-end replay vs live #2566 diff | `repaired 2 finding(s)` → 2 postable, **exit 0** (was exit 2) |
| prompt render (heredoc) | `\"` survives verbatim into `full_prompt.txt` |

Real reviewer output from the failing run is captured as `fixtures/unescaped_quotes_response.txt`. The pre-existing `#2545` fixture now recovers **3** findings instead of 2 — its old assertion had codified losing one to salvage, which its own docstring called a bug.

## Also

The output spec's example used single quotes throughout, so it never showed the model a double quote being escaped. Added that.

## Known, not fixed here (pre-existing)

`_salvage_findings` can itself scrape a findings-shaped object out of a window, and `post_review_comments.py:801` (`if not verified and finding.get("window")`) lets a **windowless** finding skip window verification and post. Both predate this branch, and this change strictly *reduces* how often salvage runs. Worth a follow-up — happy to take it.

---
🤖 Generated with CloudCode — session `ses_e5fc0adaa36ffeRd4j8cH5xVH6`