### PR TITLE
docs(safety-plugins): point to first-party ModelArmorPlugin

### DIFF
--- a/core/python/safety-plugins/README.md
+++ b/core/python/safety-plugins/README.md
@@ -1,5 +1,9 @@
 # Agent-Agnostic Safety Plugins
 
+> **Note (ADK 2.8+):** For production input and model-output screening, use the first-party [`ModelArmorPlugin`](https://github.com/google/adk-python/blob/main/docs/guides/integrations/model_armor/index.md) (`google.adk.integrations.model_armor`). A dedicated adk.dev page is tracked in [google/adk-docs#2179](https://github.com/google/adk-docs/issues/2179).
+>
+> This sample remains a **reference** for custom plugin hooks, including **`after_tool_callback` tool-output screening**, which the first-party plugin does not cover today. Do not copy this sample wholesale as your production guardrail.
+
 ## Overview
 
 This repository provides an example of a multi-agent system built with the Agent Development Kit (ADK), focusing on how to implement global safety guardrails using ADK's plugin feature. The system includes two distinct safety plugins: one that uses an agent as a judge and another that leverages the Model Armor API.

--- a/python/agents/safety-plugins/README.md
+++ b/python/agents/safety-plugins/README.md
@@ -1,5 +1,9 @@
 # Agent-Agnostic Safety Plugins
 
+> **Note (ADK 2.8+):** For production input and model-output screening, use the first-party [`ModelArmorPlugin`](https://github.com/google/adk-python/blob/main/docs/guides/integrations/model_armor/index.md) (`google.adk.integrations.model_armor`). A dedicated adk.dev page is tracked in [google/adk-docs#2179](https://github.com/google/adk-docs/issues/2179).
+>
+> This sample remains a **reference** for custom plugin hooks, including **`after_tool_callback` tool-output screening**, which the first-party plugin does not cover today. Do not copy this sample wholesale as your production guardrail.
+
 ## Overview
 
 This repository provides an example of a multi-agent system built with the Agent Development Kit (ADK), focusing on how to implement global safety guardrails using ADK's plugin feature. The system includes two distinct safety plugins: one that uses an agent as a judge and another that leverages the Model Armor API.


### PR DESCRIPTION
## Problem

The safety-plugins sample implements `ModelArmorSafetyFilterPlugin`, but ADK 2.8.0 ships a first-party `ModelArmorPlugin` (`google.adk.integrations.model_armor`) with unit tests and an in-repo integration guide. New readers may copy this sample for production input/output guardrails when the first-party plugin is the supported path.

The sample remains valuable for demonstrating `after_tool_callback` hooks (tool-output screening), which the first-party plugin documents as out of scope.

## Solution

Add a prominent note at the top of the README (both mirrored copies under `python/agents/` and `core/python/`) pointing to the first-party plugin and clarifying this sample's role as a reference for custom hooks.

## Testing

- [x] Markdown only; no code changes
- [x] Both README paths updated (identical content on `main` as of 2026-08-31)

## Files

- `python/agents/safety-plugins/README.md`
- `core/python/safety-plugins/README.md`
