### PR TITLE
fix(ci): stop the triage sweep failing on a batch it correctly declined

### DIFF
--- a/.github/workflows/_ai-issue-triage-core.yml
+++ b/.github/workflows/_ai-issue-triage-core.yml
@@ -50,9 +50,22 @@ on:
           a multi-issue sweep, where "nothing was classifiable" is the
           signature of a broken run. WRONG for a single issue, where it is
           simply an issue too vague to classify — see the caller notes.
+          Only takes effect for batches of at least `none_applied_min_batch`.
         required: false
         type: 'boolean'
         default: true
+      none_applied_min_batch:
+        description: >-
+          Smallest batch for which `fail_when_none_applied` is allowed to
+          fail the run. "The model classified nothing" is an aggregate
+          signal: across a dozen issues it means the run is broken, but for
+          one or two it is the ordinary case of an issue too vague to label,
+          which the prompt explicitly asks the model to answer with an empty
+          list. Below this floor an all-empty decision is reported as a
+          notice and the issues are left for a human.
+        required: false
+        type: 'number'
+        default: 3
     secrets:
       APP_PRIVATE_KEY:
         required: false
@@ -289,6 +302,7 @@ jobs:
           ISSUES_TO_TRIAGE: '${{ inputs.issues }}'
           DECISION: '${{ steps.decide.outputs.decision }}'
           FAIL_WHEN_NONE_APPLIED: '${{ inputs.fail_when_none_applied }}'
+          NONE_APPLIED_MIN_BATCH: '${{ inputs.none_applied_min_batch }}'
         run: |-
           set -euo pipefail
 
@@ -338,12 +352,24 @@ jobs:
 
           BATCH_SIZE="$(echo "${ISSUES_TO_TRIAGE}" | jq 'length')"
           if [[ "${APPLIED}" -eq 0 && "${BATCH_SIZE}" -gt 0 ]]; then
-            if [[ "${FAIL_WHEN_NONE_APPLIED}" == 'true' ]]; then
-              # A whole batch coming back unclassifiable is the signature of
-              # a broken run (a denied tool call, a truncated response)
-              # rather than a batch that genuinely defied classification.
-              echo "::error::agy returned a decision but not one of the ${BATCH_SIZE} issues could be labelled."
-              exit 1
+            # "Nothing was classifiable" only means "the run is broken" in
+            # aggregate. A genuinely broken run is already caught upstream —
+            # a non-zero agy exit, a status other than SUCCESS, or a
+            # response with no parseable decision all fail the Decide step.
+            # What reaches here is a well-formed decision that happened to
+            # label nothing, and for a small batch that is the ordinary
+            # case: the prompt explicitly instructs the model to return an
+            # empty list rather than guess, so a single vague issue produces
+            # exactly this. Failing on it turned an intended outcome into a
+            # red run every hour, for as long as that issue stayed open.
+            if [[ "${BATCH_SIZE}" -ge "${NONE_APPLIED_MIN_BATCH}" ]]; then
+              # Big enough for the aggregate signal to mean something.
+              if [[ "${FAIL_WHEN_NONE_APPLIED}" == 'true' ]]; then
+                echo "::error::agy returned a decision but not one of the ${BATCH_SIZE} issues could be labelled."
+                exit 1
+              fi
+              echo "::warning::None of the ${BATCH_SIZE} issues in this batch could be labelled; leaving them for human triage."
+            else
+              echo "::notice::No applicable labels were identified for the ${BATCH_SIZE} issue(s) in this batch; leaving them for human triage."
             fi
-            echo "::warning::No applicable labels were identified; leaving the issue(s) for human triage."
           fi

--- a/.github/workflows/ai-issue-scheduled-triage.yml
+++ b/.github/workflows/ai-issue-scheduled-triage.yml
@@ -124,7 +124,17 @@ jobs:
       # A whole batch coming back unclassifiable is the signature of a broken
       # run, not of genuinely ambiguous issues — fail loudly rather than
       # report a silent no-op as success.
+      #
+      # ...but only once the batch is big enough for that inference to hold.
+      # This sweep takes up to MAX_BATCH=15 issues, and on a quiet week it
+      # takes one or two, so batch size is not a constant the decision can
+      # ignore. A lone issue the model declines to classify is the intended
+      # answer — the prompt asks for an empty list rather than a guess — not
+      # evidence of breakage. Failing on it made this workflow red every
+      # hour for as long as one such issue stayed open and unlabelled, which
+      # is exactly the state in which a real breakage goes unnoticed.
       fail_when_none_applied: true
+      none_applied_min_batch: 3
       app_id: '${{ vars.APP_ID }}'
     secrets:
       APP_PRIVATE_KEY: '${{ secrets.APP_PRIVATE_KEY }}'


### PR DESCRIPTION
## What's wrong

The hourly `✨ AI Scheduled Issue Triage` sweep has failed on **every run** since #2580 was opened on Aug 30 — 15+ consecutive red runs at the time of writing ([latest](https://github.com/google/adk-samples/actions/runs/33440395318/job/99646934764)).

Nothing was actually broken. The run does exactly what it should:

- The sweep finds one untriaged issue (#2580, a prompt-injection sandbox issue with no classifiable content).
- The model correctly ignores the injection in the body and returns `{"issues":[{"number":2580,"labels":[]}]}` — the empty list the prompt explicitly asks for when an issue is too vague to classify.
- The Apply step then fails the run, because `fail_when_none_applied: true` and nothing got labelled.

```
##[error]agy returned a decision but not one of the 1 issues could be labelled.
```

## Why the guardrail was wrong

"The model classified nothing" is an **aggregate** signal. Across a dozen issues it plausibly means a broken run; for a single issue it is the ordinary case the prompt is designed to produce.

Genuine breakage is already caught upstream in the Decide step — a non-zero `agy` exit, a status other than `SUCCESS`, or a response with no parseable decision each fail the run there. Anything reaching the Apply step is a well-formed decision, so an all-empty result at batch size 1 carries no diagnostic signal at all.

The core workflow's own input documentation already said as much:

> Correct for a multi-issue sweep, where "nothing was classifiable" is the signature of a broken run. **WRONG for a single issue**, where it is simply an issue too vague to classify

The sweep just passed `true` unconditionally, regardless of how many issues `find` actually returned.

## The fix

A batch-size floor on the failure, as a new `none_applied_min_batch` input (default `3`):

| batch | none applied | before | after |
|---|---|---|---|
| 1 | yes | ❌ error | notice |
| 2 | yes | ❌ error | notice |
| 3+ | yes | ❌ error | ❌ error |
| any | some applied | pass | pass |

The on-open workflow (`fail_when_none_applied: false`, always batch size 1) is unaffected in outcome; its annotation moves from warning to notice, which is the accurate level for an expected result.

## Why it matters beyond the noise

An unclassifiable issue keeps no labels, so it re-enters the sweep's candidate set every hour, forever — the sweep never converges and burns a model call each tick. More importantly, a workflow that is permanently red is one where a *real* triage breakage looks identical to the status quo and nobody notices.

## Verification

- `actionlint` clean on all three triage workflows.
- All three parse as valid YAML; the new input and both call sites resolve as expected.
- The guardrail branch logic was extracted and exercised against the exact inputs of the failing run plus the surrounding cases (batch 1/2/3/15, applied and not, `fail_when_none_applied` true and false) — the regression case now yields a notice, and the aggregate signal at batch ≥ 3 still fails.

Not covered here: #2580 itself is being closed separately, which stops today's bleeding. This PR stops the *next* lone unclassifiable issue from doing the same thing.