### PR TITLE
fix(deep-search): remove google.auth requirement and fix misleading deploy docs

### DIFF
--- a/python/agents/deep-search/README.md
+++ b/python/agents/deep-search/README.md
@@ -123,36 +123,7 @@ Then run `make install && make dev` to start the agent.
 
 ## Cloud Deployment
 
-> **Note:** Cloud deployment applies only to projects created with **google-agents-cli**.
-
-**Prerequisites:**
-```bash
-gcloud components update
-gcloud config set project YOUR_PROJECT_ID
-```
-
-#### Option 1: Deploy with ADK Web UI (Default)
-
-For a quick deployment using the built-in [adk-web](https://github.com/google/adk-web) interface:
-
-```bash
-make deploy IAP=true
-```
-
-#### Option 2: Deploy with Custom UI (React Frontend)
-
-This agent includes a custom React frontend. To deploy it:
-
-1. **Configure the Dockerfile** - See the [Deploy UI Guide](https://github.com/google/agents-cli) for the required Dockerfile changes.
-
-2. **Deploy with the frontend port:**
-```bash
-make deploy IAP=true PORT=5173
-```
-
-#### After Deployment
-
-Once deployed, grant users access to your IAP-protected service by following the [Manage User Access](https://cloud.google.com/run/docs/securing/identity-aware-proxy-cloud-run#manage_user_or_group_access) documentation.
+> **Note:** Cloud deployment applies only to projects created with **google-agents-cli**. For this sample repo, please follow the [Local development](#alternative-local-development-run-from-this-sample-repo) instructions above.
 
 For production deployments with CI/CD, see the [Google Agents CLI Development Guide](https://github.com/google/agents-cli).
 

--- a/python/agents/deep-search/app/__init__.py
+++ b/python/agents/deep-search/app/__init__.py
@@ -16,11 +16,11 @@
 
 import os
 
-import google.auth
+# import google.auth
 
-_, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id or "")
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
-os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+# _, project_id = google.auth.default()
+# os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id or "")
+# os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+# os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
 
 from app.agent import root_agent


### PR DESCRIPTION
## Summary

- **Issue #2574**: Comment out `google.auth` code in `app/__init__.py` to allow local AI Studio usage without requiring Cloud credentials.
- **Issue #2575**: Remove misleading `make deploy` commands from README since the Makefile has no deploy target (cloud deployment only applies to google-agents-cli created projects).

## Changes

1. `python/agents/deep-search/app/__init__.py`: Comment out 5 lines of google.auth code
2. `python/agents/deep-search/README.md`: Remove misleading deploy documentation that references non-existent make deploy target

## Testing

- Local AI Studio mode should work without GOOGLE_CLOUD_PROJECT set
- README now correctly directs users to local development instructions