### PR TITLE
fix(long-horizon-harness): bump ADK to 2.8.0 and drop the workarounds it obsoletes

### DIFF
--- a/core/python/long-horizon-harness/AGENTS.md
+++ b/core/python/long-horizon-harness/AGENTS.md
@@ -190,7 +190,7 @@ lha/
 | Horizon feature | ADK mechanism |
 |---|---|
 | `on_session_start` | `before_agent_callback` (first invocation only, state-key guarded) |
-| Memory prefetch | `HorizonPreloadMemoryTool()` in root agent's `tools` (`horizon/memory/preload.py`) — calls `memory_service.search_memory()`, injects hits into the **contents tail**, not `system_instruction` |
+| Memory prefetch | `HorizonPreloadMemoryTool()` in root agent's `tools` (`horizon/memory/preload.py`) — calls `memory_service.search_memory()`, injects capped hits into the **contents**, not `system_instruction` |
 | Post-turn memory sync | `auto_capture_callback` (after_agent) — NOT a blanket `add_session_to_memory()` |
 | Tool block | `before_tool_callback` returns `{"error": ...}` |
 | Output transform | `after_model_callback` returns modified `LlmResponse` |
@@ -370,7 +370,7 @@ The routine fire path (`routine_tick_endpoint.py:_fire_routine`) wraps the turn 
 - Don't reintroduce Next.js or SWR. The UI is a Vite SPA, same-origin backend calls, served in prod by `web/server/` and in dev by the Vite proxy.
 - Don't reintroduce `recipe-*` color tokens or `RECIPE_*` env vars. Canonical: `LHA_*` / `lh-*`.
 - Don't pass kwargs to `PreloadMemoryTool()` — installed ADK's `__init__` is `(self)` only.
-- Don't put per-turn content in `system_instruction`. `GeminiContextCacheManager._generate_cache_fingerprint` hashes the whole string, so anything that varies turn to turn invalidates the context cache for the entire prefix. This is why `HorizonPreloadMemoryTool` (`horizon/memory/preload.py`) overrides ADK's stock `PreloadMemoryTool`: the stock one appends `<PAST_CONVERSATIONS>` to `system_instruction`, and that block is rebuilt every turn from a similarity search keyed on the current user text, so with memories present the cache never validated and the whole static prefix was re-billed at full price. The block now rides the trailing `role="user"` contents, which `_find_count_of_contents_to_cache` excludes by design, and is capped by `LHA_PRELOAD_MAX_MEMORIES` / `LHA_PRELOAD_MAX_CHARS` because `BaseMemoryService.search_memory` has no `top_k`.
+- Don't put per-turn content in `system_instruction`. `GeminiContextCacheManager._generate_cache_fingerprint` hashes the whole string, so anything that varies turn to turn invalidates the context cache for the entire prefix. A memory block rebuilt every turn from a similarity search is the worst case: with memories present the cache never validates and the whole static prefix is re-billed at full price. ADK places the block via `LlmRequest._insert_transient_user_content`, which `_find_count_of_contents_to_cache` excludes by design; `HorizonPreloadMemoryTool` (`horizon/memory/preload.py`) subclasses the stock `PreloadMemoryTool` only to cap it with `LHA_PRELOAD_MAX_MEMORIES` / `LHA_PRELOAD_MAX_CHARS`, because `BaseMemoryService.search_memory` has no `top_k`.
 
 ## Operational Guidelines
 
@@ -383,7 +383,7 @@ The routine fire path (`routine_tick_endpoint.py:_fire_routine`) wraps the turn 
 
 ## Pinned versions
 
-- `google-adk[mcp,otel-gcp,a2a]>=2.5.0,<3.0.0` (ADK **2.5.x** — ships the a2a 0.3↔1.x `_compat` bridge).
+- `google-adk[mcp,otel-gcp,a2a]>=2.8.0,<3.0.0` (ADK **2.8.x** — ships the a2a 0.3↔1.x `_compat` bridge).
 - `a2a-sdk[http-server,sqlite]>=1.0,<2` (a2a **1.x**; proto types, `[http-server]` routes + `[sqlite]` `DatabaseTaskStore`. The v0.3 compat layer keeps Gemini Enterprise working). Web `@a2a-js/sdk` **1.0.1** — the web UI speaks the native 1.0 wire; Gemini Enterprise uses the v0.3 interface, served from the same `/a2a` endpoint.
 - `croniter>=6.2.2` — 5-field cron for routine schedules (`scheduler/cron.py`).
 - Lint stack: `ruff` + `ty` (Astral's Rust type checker, replacing mypy) + `codespell`.

--- a/core/python/long-horizon-harness/docs/context-budget.md
+++ b/core/python/long-horizon-harness/docs/context-budget.md
@@ -48,11 +48,12 @@ Config is `ContextCacheConfig` in `agent.py`. `min_tokens` there matches
 
 Never put per-turn content in `system_instruction`.
 `_generate_cache_fingerprint` hashes the entire string, so one varying line
-invalidates the whole prefix on every turn. ADK's stock `PreloadMemoryTool`
-writes `<PAST_CONVERSATIONS>` there, which kept the cache from ever forming
-until `memory/preload.py`'s `HorizonPreloadMemoryTool` moved that block to the
-cache-excluded contents tail. Per-turn steering (iteration count, last error,
-date, todos) rides the same tail, as trailing `<system-reminder>` content from
+invalidates the whole prefix on every turn. `PreloadMemoryTool`'s
+`<PAST_CONVERSATIONS>` block is the case to watch: it is rebuilt per turn from a
+similarity search, so it only stays out of the fingerprint because ADK inserts
+it through `LlmRequest._insert_transient_user_content`, which the cache window
+excludes. Per-turn steering (iteration count, last error, date, todos) rides the
+same region, as trailing `<system-reminder>` content from
 `conversation/reminders.py`.
 
 ## What bounds growth during a session

--- a/core/python/long-horizon-harness/horizon/a2a/executor.py
+++ b/core/python/long-horizon-harness/horizon/a2a/executor.py
@@ -23,7 +23,6 @@ import uuid
 from collections import defaultdict
 
 from a2a.server.agent_execution import RequestContext
-from a2a.server.tasks.task_updater import TaskUpdater
 from google.adk.a2a import _compat as a2a_compat
 from google.adk.a2a.converters import part_converter
 from google.adk.a2a.executor.a2a_agent_executor import (
@@ -354,15 +353,6 @@ class _TaskTrackingExecutor(A2aAgentExecutor):
         self._session_locks: dict[tuple[str, str, str], asyncio.Lock] = (
             defaultdict(asyncio.Lock)
         )
-
-    async def cancel(self, context: RequestContext, event_queue) -> None:
-        # ADK's A2aAgentExecutor.cancel raises NotImplementedError, which aborts
-        # a2a's on_cancel_task before it cancels the producer task. Emit a
-        # terminal `canceled` status so on_cancel_task proceeds; it then cancels
-        # the producer, raising CancelledError into our running execute() —
-        # already handled, and the shielded _mark_task_done clears the flag.
-        updater = TaskUpdater(event_queue, context.task_id, context.context_id)
-        await updater.cancel()
 
     async def execute(self, context: RequestContext, event_queue):
         runner = await self._resolve_runner()

--- a/core/python/long-horizon-harness/horizon/memory/adapter.py
+++ b/core/python/long-horizon-harness/horizon/memory/adapter.py
@@ -172,8 +172,7 @@ class InMemoryMemoryAdapter(NoopMemoryAdapter):
     ) -> list[MemoryWriteEntry]:
         # Private attribute: ADK's BaseMemoryService exposes no list-all API and
         # search_memory keyword-matches. Revisit when ADK adds one.
-        user_key = f"{app_name}/{user_id}"
-        sessions = self._service._session_events.get(user_key, {})
+        sessions = self._service._session_events.get((app_name, user_id), {})
         out: list[MemoryWriteEntry] = []
         for session_id, events in sessions.items():
             for event in events:

--- a/core/python/long-horizon-harness/horizon/memory/preload.py
+++ b/core/python/long-horizon-harness/horizon/memory/preload.py
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Memory preload that does not defeat the context cache.
+"""Memory preload with a bounded block.
 
-ADK's stock ``PreloadMemoryTool`` appends ``<PAST_CONVERSATIONS>`` to
-``system_instruction``, rebuilt every turn from a similarity search, so it's
-rarely byte-identical twice; since the cache fingerprint hashes the whole
-``system_instruction``, the cache never validates for any user with memories.
-This subclass writes the same text into the trailing ``role="user"``
-contents instead, the region ADK's own cache-window calculation excludes.
-
-It also caps the block: ``BaseMemoryService.search_memory`` takes no
-``top_k``, so it otherwise grows without bound as memories accumulate.
+``BaseMemoryService.search_memory`` takes no ``top_k``, so ADK's stock
+``PreloadMemoryTool`` block grows without bound as memories accumulate. This
+subclass renders the same text under a count and character cap. Placement stays
+ADK's (``_insert_transient_user_content`` keeps the block out of the cached
+prefix); only the caps are ours.
 """
 
 from __future__ import annotations
@@ -57,7 +53,7 @@ def _int_env(name: str, default: int) -> int:
 
 
 class HorizonPreloadMemoryTool(PreloadMemoryTool):
-    """PreloadMemoryTool that rides the cache-excluded contents tail."""
+    """PreloadMemoryTool with a capped recall block."""
 
     @override
     async def process_llm_request(
@@ -111,16 +107,18 @@ class HorizonPreloadMemoryTool(PreloadMemoryTool):
         if dropped:
             logger.info("preload: trimmed %d memory entries", dropped)
 
-        llm_request.contents.append(
-            types.Content(
-                role="user",
-                parts=[
-                    types.Part(
-                        text=f"{_HEADER}\n<PAST_CONVERSATIONS>\n{body}\n"
-                        "</PAST_CONVERSATIONS>"
-                    )
-                ],
-            )
+        llm_request._insert_transient_user_content(
+            [
+                types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            text=f"{_HEADER}\n<PAST_CONVERSATIONS>\n{body}\n"
+                            "</PAST_CONVERSATIONS>"
+                        )
+                    ],
+                )
+            ]
         )
 
 

--- a/core/python/long-horizon-harness/pyproject.toml
+++ b/core/python/long-horizon-harness/pyproject.toml
@@ -11,7 +11,7 @@ description = "Horizon — a self-improving long-horizon agent on Google ADK + V
 # external harness can install a minimal slice; this repo's own dev/test env
 # pulls them all back via the `long-horizon-harness[full]` self-reference in [dependency-groups].
 dependencies = [
-    "google-adk[mcp,otel-gcp,a2a]>=2.5.0,<3.0.0",
+    "google-adk[mcp,otel-gcp,a2a]>=2.8.0,<3.0.0",
     "opentelemetry-instrumentation-google-genai>=0.1.0,<1.0.0",
     "google-cloud-logging>=3.12.0,<4.0.0",
     "fastapi>=0.136.1",
@@ -77,7 +77,7 @@ all = [
     "long-horizon-harness[full]",
 ]
 eval = [
-    "google-adk[eval]>=2.5.0,<3.0.0",
+    "google-adk[eval]>=2.8.0,<3.0.0",
 ]
 lint = [
     "ruff>=0.4.6,<1.0.0",

--- a/core/python/long-horizon-harness/tests/unit/test_executor_cancel.py
+++ b/core/python/long-horizon-harness/tests/unit/test_executor_cancel.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the ``cancel()`` override on ``_TaskTrackingExecutor``.
+"""Unit tests for ``cancel()`` on ``_TaskTrackingExecutor``.
 
-ADK's ``A2aAgentExecutor.cancel`` raises ``NotImplementedError``, which aborts
-a2a's ``on_cancel_task`` before it can cancel the running producer task. We
-override ``cancel`` to emit a terminal ``canceled`` status so ``on_cancel_task``
-proceeds. These tests pin that contract; no LLM is exercised.
+``cancel`` must emit a terminal ``canceled`` status rather than raise, or a2a's
+``on_cancel_task`` aborts before it cancels the running producer task. ADK
+provides that behavior; these tests pin that we still get it. No LLM is
+exercised.
 """
 
 from __future__ import annotations
@@ -26,7 +26,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from a2a.types import TaskState
-from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 
 from horizon.a2a.executor import build_executor
 from horizon.auth.identity import _user_id_var
@@ -72,21 +71,4 @@ async def test_cancel_does_not_raise() -> None:
     event_queue = MagicMock()
     event_queue.enqueue_event = AsyncMock()
 
-    # The whole point of the override: it must NOT raise (the parent does).
     await executor.cancel(context, event_queue)
-
-
-@pytest.mark.asyncio
-async def test_base_executor_cancel_raises_not_implemented() -> None:
-    """Regression guard documenting why the override exists: the ADK base
-    ``cancel`` raises ``NotImplementedError`` when no executor impl is set,
-    which would abort a2a's ``on_cancel_task`` before the producer is cancelled.
-    """
-    executor = build_executor(runner=MagicMock())
-    executor._executor_impl = None
-    context = _make_context(task_id="task-y")
-    event_queue = MagicMock()
-    event_queue.enqueue_event = AsyncMock()
-
-    with pytest.raises(NotImplementedError):
-        await A2aAgentExecutor.cancel(executor, context, event_queue)

--- a/core/python/long-horizon-harness/tests/unit/test_preload_memory.py
+++ b/core/python/long-horizon-harness/tests/unit/test_preload_memory.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The preload block must stay out of the cache fingerprint.
+"""The preload block must stay out of the cached prefix, and stay bounded.
 
-GeminiContextCacheManager hashes the whole system_instruction. A block
-rebuilt per turn from a similarity search can never be byte-stable, so
-putting it there means the cache never validates.
+GeminiContextCacheManager hashes the whole system_instruction, so a block
+rebuilt per turn from a similarity search can never be byte-stable there. ADK
+owns the placement; the caps are ours.
 """
 
 from __future__ import annotations
@@ -26,6 +26,9 @@ from dataclasses import dataclass
 
 import pytest
 from google.adk.models import LlmRequest
+from google.adk.models.gemini_context_cache_manager import (
+    GeminiContextCacheManager,
+)
 from google.genai import types
 
 from horizon.memory.preload import HorizonPreloadMemoryTool
@@ -76,14 +79,27 @@ async def test_block_lands_in_contents_not_system_instruction():
     assert "your name is Sam" in text
 
 
-async def test_block_is_the_trailing_user_content():
-    # _find_count_of_contents_to_cache excludes the trailing run of user
-    # contents; the block only escapes the fingerprint if it lands there.
+async def test_block_lands_outside_the_cached_prefix():
     req = _request()
+    req.contents = [
+        types.Content(role="user", parts=[types.Part(text="hi")]),
+        types.Content(role="model", parts=[types.Part(text="hello")]),
+        types.Content(role="user", parts=[types.Part(text="and now?")]),
+    ]
     await HorizonPreloadMemoryTool().process_llm_request(
         tool_context=_Ctx([_memory("fact")]), llm_request=req
     )
-    assert req.contents[-1].role == "user"
+
+    manager = GeminiContextCacheManager(
+        genai_client=pytypes.SimpleNamespace(vertexai=True)
+    )
+    cached = manager._find_count_of_contents_to_cache(req.contents)
+    block = next(
+        i
+        for i, c in enumerate(req.contents)
+        if "<PAST_CONVERSATIONS>" in (c.parts[0].text or "")
+    )
+    assert block >= cached
 
 
 async def test_memory_count_is_capped(monkeypatch):

--- a/core/python/long-horizon-harness/uv.lock
+++ b/core/python/long-horizon-harness/uv.lock
@@ -665,6 +665,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -856,9 +865,10 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "2.5.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "authlib" },
     { name = "click" },
@@ -884,22 +894,26 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/8b/d014c98e987ed3a95ac3740d2b5c8e8e891bfd88c3ac2253fca9547f3b1f/google_adk-2.5.0.tar.gz", hash = "sha256:55b88cac9d5072d511fd3224e5f334e57fb2b0ae567507e531e03fdfb60c82c2", size = 3608134, upload-time = "2026-07-16T20:43:06.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/29/db8042eb489515ef64fc16d24f1a621523451bfc2cbbae0103527b4066f4/google_adk-2.8.0.tar.gz", hash = "sha256:f51524e18cf0a0cdeb4fdd6f0fa16f31bc5e53021647b3e6c72a90f40f583915", size = 3902380, upload-time = "2026-08-26T23:26:20.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/fe/699d21edebd1305b6d23fd570140cf0cf921f34f66e4611d840684717c3a/google_adk-2.5.0-py3-none-any.whl", hash = "sha256:d247ca3639921a54a86feb797a88d08c1d2c9a60c3f5ff2805e49beb29a9cb8d", size = 4169976, upload-time = "2026-07-16T20:43:04.647Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9d/8447a0912dcba1fa5dae83697e1af0a7ca9afa4701f93c82f3a1caf20561/google_adk-2.8.0-py3-none-any.whl", hash = "sha256:616bfa21959ae2726432670cb0b1c549e4908d9bf6908bff6fbc08382b075429", size = 4502706, upload-time = "2026-08-26T23:26:17.53Z" },
 ]
 
 [package.optional-dependencies]
 a2a = [
-    { name = "a2a-sdk" },
+    { name = "a2a-sdk", extra = ["http-server"] },
 ]
 eval = [
     { name = "gepa" },
     { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+    { name = "google-cloud-texttospeech" },
     { name = "jinja2" },
+    { name = "nltk" },
+    { name = "openpyxl" },
     { name = "pandas" },
     { name = "rouge-score" },
     { name = "tabulate" },
+    { name = "xlrd" },
 ]
 mcp = [
     { name = "anyio" },
@@ -951,20 +965,20 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.53.0"
+version = "2.57.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
 ]
 
 [package.optional-dependencies]
 pyopenssl = [
-    { name = "pyopenssl" },
+    { name = "cryptography" },
 ]
 requests = [
     { name = "requests" },
@@ -1193,6 +1207,22 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-texttospeech"
+version = "2.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/bf/42e7d2f32d79c75bc23f949e97a278d46b7d08638e94b570947be02e3bce/google_cloud_texttospeech-2.37.0.tar.gz", hash = "sha256:db726382f393ceb6b36002c35abd62b53c4d8e17fc2f31df8b07fd0fabbe4f8b", size = 196465, upload-time = "2026-06-22T23:22:37.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/44/675358f0b939f14ae6481dddecbde5fd91b92b51f7991a70d98d3c68c02e/google_cloud_texttospeech-2.37.0-py3-none-any.whl", hash = "sha256:911f42f327027975d7781efcace1993afdf311b692b95b6814b71085750cc38a", size = 199697, upload-time = "2026-06-22T23:20:37.235Z" },
+]
+
+[[package]]
 name = "google-cloud-trace"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1235,7 +1265,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "2.9.0"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1249,9 +1279,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/75/81c01294db3a3005dc8a807ed889a10ecd66ef89462c118adcffa5f7981c/google_genai-2.9.0.tar.gz", hash = "sha256:a8a10e9113f460cc668c1d9deeb62ba393ad1ba704bf3166d5a0f32a434f9415", size = 595700, upload-time = "2026-06-19T08:23:42.718Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f1/f2f31b2a6bd826bc2cb73068df880954a026474c03a4315637d20cc13965/google_genai-2.22.0.tar.gz", hash = "sha256:9fa3b5d9ddb635005d8ab2d6206fb2b3d7204b66965bbce7de13ecd1a866ebcd", size = 684719, upload-time = "2026-09-02T18:06:02.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/17/bb2cdd0a6c6fec32f14e85735917d1052f82430b1de58c2b606740740419/google_genai-2.9.0-py3-none-any.whl", hash = "sha256:2a79e2b08e8439f5f25c2b42f98e3f3e8ea4be9c9265f5d7321580dbaf2764f4", size = 950790, upload-time = "2026-06-19T08:23:40.995Z" },
+    { url = "https://files.pythonhosted.org/packages/de/96/0120d214958cb54f2b9c48da9f564a0e6eae269e9dd702415fb1d0551cc7/google_genai-2.22.0-py3-none-any.whl", hash = "sha256:c514001c45470cc0a942440ae1b8215445d12bfb6c373aac94637127e1f74ec6", size = 1088792, upload-time = "2026-09-02T18:06:00.629Z" },
 ]
 
 [[package]]
@@ -1839,8 +1869,8 @@ requires-dist = [
     { name = "dateparser", specifier = ">=1.4.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.136.1" },
-    { name = "google-adk", extras = ["eval"], marker = "extra == 'eval'", specifier = ">=2.5.0,<3.0.0" },
-    { name = "google-adk", extras = ["mcp", "otel-gcp", "a2a"], specifier = ">=2.5.0,<3.0.0" },
+    { name = "google-adk", extras = ["eval"], marker = "extra == 'eval'", specifier = ">=2.8.0,<3.0.0" },
+    { name = "google-adk", extras = ["mcp", "otel-gcp", "a2a"], specifier = ">=2.8.0,<3.0.0" },
     { name = "google-api-python-client", specifier = ">=2.0.0,<3.0.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.0,<2.0.0" },
     { name = "google-cloud-aiplatform", extras = ["agent-engines"], specifier = ">=1.153.1" },
@@ -2216,6 +2246,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -3781,6 +3823,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
     { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- ADK 2.5's `PreloadMemoryTool` appended the recalled-memory block to
  `system_instruction`. `GeminiContextCacheManager` fingerprints that whole
  string, so the per-turn similarity search invalidated the context cache on
  every turn for any user with memories. Fixed upstream in 2.7 by
  `_insert_transient_user_content`.
- Bumps `google-adk` 2.5.0 → 2.8.0 and removes the local workarounds that
  duplicate what ADK now does.

## Changes
- `preload.py`: placement delegated to ADK; the subclass keeps only the
  `LHA_PRELOAD_MAX_MEMORIES` / `LHA_PRELOAD_MAX_CHARS` caps, since
  `search_memory` still has no `top_k`.
- `a2a/executor.py`: dropped the `cancel` override, ADK's base now emits the
  terminal `canceled` status itself.
- `memory/adapter.py`: `InMemoryMemoryService._session_events` is keyed by
  `(app_name, user_id)` in 2.8, not `"app/user"`.
- Docs: `AGENTS.md` pinned versions + the `system_instruction` don't,
  `docs/context-budget.md`.

Tests: `uv run pytest tests/unit tests/integration` → 2330 passed.
