### PR TITLE
feat(ci): declare which recipe images publish to Artifact Registry

### DIFF
--- a/.github/policy.yml
+++ b/.github/policy.yml
@@ -749,3 +749,95 @@ deployability:
       - contrib/python/financial-advisor
       - core/python/rag-agent-search
       - core/python/rag-vector-search
+
+  # --------------------------------------------------------------------------
+  # PUBLISHING
+  #
+  # Which recipe container images are built and pushed to a public Artifact
+  # Registry. Read by .github/scripts/publish_matrix.py, which validates this
+  # block and turns it into the job matrix for the image build workflow.
+  #
+  # An ALLOWLIST, not a scan. Two reasons it is not derived from "the recipe
+  # has a Dockerfile":
+  #
+  #   1. `docker build` executes every RUN instruction it is handed, and these
+  #      images are published publicly under Google's name. Which Dockerfiles
+  #      earn that is an admin decision recorded here, not a side effect of a
+  #      contributor adding a file. Same reasoning as `run_allowlist` above.
+  #
+  #   2. Most Dockerfiles in the repo are not ready to publish. Several
+  #      re-resolve dependencies at build time rather than installing from a
+  #      committed lockfile, so two builds of one commit can produce different
+  #      images. Listing the conforming ones lets publishing start now instead
+  #      of blocking on every owner at once.
+  #
+  # `manifest.deployable` is deliberately NOT the selector. It means "can be
+  # deployed with one click" for ANY target, Agent Engine included, so it
+  # marks recipes that have no container at all (contrib/python/llm-auditor,
+  # core/python/oauth-user-consent-flow) while missing recipes that do have
+  # one (core/python/cross-session-memory, core/python/genmedia-for-commerce).
+  # Reconciling that field is a separate piece of work.
+  publish:
+    # Cloud Run runs amd64. Building for the target rather than for the
+    # runner keeps an arm64 host from producing an image the target cannot
+    # run — a no-op on x86, and the whole ballgame elsewhere.
+    platforms:
+      - linux/amd64
+
+    # One entry per published image. A recipe may declare more than one.
+    #
+    #   recipe       Repo-relative recipe directory. Must be under core/ or
+    #                contrib/ and contain a manifest.yaml. That constraint is
+    #                also what keeps the pre-migration python/agents/ and
+    #                java/agents/ trees, and skills/ (out of scope for
+    #                deployability, see above), unpublishable.
+    #
+    #   dockerfile   Path to the Dockerfile, relative to `recipe`.
+    #
+    #   context      Build context, relative to `recipe`. DECLARED, not
+    #                inferred from the Dockerfile's location: several
+    #                Dockerfiles here live in a subdirectory and COPY from the
+    #                recipe root, so `dirname(dockerfile)` is the wrong answer
+    #                often enough that guessing it would be a bug generator.
+    #
+    #   image        Published image name. Becomes part of the public pull
+    #                address, so it is expensive to change once anything
+    #                references it. The convention is the recipe directory's
+    #                basename, plus a qualifier suffix for a recipe's
+    #                secondary images. Uniqueness is ENFORCED rather than
+    #                assumed: two recipes in this repo already share a
+    #                basename (llm-auditor, in Python and Kotlin), so the
+    #                collision is real and would otherwise surface as one
+    #                image silently overwriting another.
+    #
+    #   serves_http  Whether the image serves HTTP. Recorded so a later probe
+    #                step knows what it may poll — not every publishable image
+    #                is a server. The KFP base image under
+    #                multiformat-hybrid-rag has no CMD at all, and probing it
+    #                would report a healthy image as broken.
+    #
+    # Registry coordinates (project, repository, region) are deliberately
+    # absent. They arrive as repository variables at build time, so choosing
+    # or moving the hosting project never means editing this file.
+    images:
+      - recipe: core/python/long-horizon-harness
+        dockerfile: Dockerfile
+        context: .
+        image: long-horizon-harness
+        serves_http: true
+
+      # The sandbox the harness runs agent-authored code inside. Published
+      # because the recipe cannot be used without it: its quickstart makes
+      # every user build and push this image into their own project by hand
+      # before anything works (docs/quickstart.md, step 3 of 4).
+      - recipe: core/python/long-horizon-harness
+        dockerfile: horizon/sandbox/runtime/Dockerfile
+        context: horizon/sandbox/runtime
+        image: long-horizon-harness-sandbox-runtime
+        serves_http: true
+
+      - recipe: contrib/python/multiformat-hybrid-rag
+        dockerfile: Dockerfile
+        context: .
+        image: multiformat-hybrid-rag
+        serves_http: true

--- a/.github/policy.yml
+++ b/.github/policy.yml
@@ -781,6 +781,14 @@ deployability:
     # Cloud Run runs amd64. Building for the target rather than for the
     # runner keeps an arm64 host from producing an image the target cannot
     # run — a no-op on x86, and the whole ballgame elsewhere.
+    #
+    # ADDING A SECOND PLATFORM IS NOT A ONE-LINE CHANGE. The classic docker
+    # builder rejects more than one outright, and under buildx a multi-
+    # platform build cannot be loaded into the local daemon — it has to go
+    # straight to a registry with `--push`. So a second entry here obliges
+    # the build workflow to switch to buildx and to give up anything that
+    # needs the image locally, such as probing it before publishing. Change
+    # the workflow first, this list second.
     platforms:
       - linux/amd64
 

--- a/.github/scripts/publish_matrix.py
+++ b/.github/scripts/publish_matrix.py
@@ -107,7 +107,16 @@ PUBLISHABLE_ROOTS = ("core/", "contrib/")
 # than the registry strictly requires — these names are public and permanent
 # in practice, so the uppercase and slash-bearing forms a registry would
 # tolerate are refused rather than debated later.
+#
+# The tightness is also load-bearing downstream. These names are pasted into
+# an image reference in the build workflow, so a name containing whitespace,
+# a quote or a shell metacharacter would be an injection point. The character
+# class here makes every emitted name shell-safe by construction, which is
+# cheaper and more reliable than quoting correctly at each use site.
 IMAGE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+# `os/arch`, optionally `os/arch/variant` — linux/amd64, linux/arm64/v8.
+PLATFORM_RE = re.compile(r"^[a-z0-9]+/[a-z0-9]+(?:/[a-z0-9]+)?$")
 
 REQUIRED_KEYS = frozenset(
     {"recipe", "dockerfile", "context", "image", "serves_http"}
@@ -139,6 +148,12 @@ def load_publish_block(repo_root: Path) -> dict[str, Any]:
             data = yaml.safe_load(handle)
     except FileNotFoundError as exc:
         raise PublishMatrixError(f"{path} not found") from exc
+    except OSError as exc:
+        # Permission denied, a directory where the file should be, an I/O
+        # error. Reported as a policy failure rather than a traceback: the
+        # caller is a workflow, and a stack trace in its log says nothing a
+        # reader can act on.
+        raise PublishMatrixError(f"cannot read {path}: {exc}") from exc
     except yaml.YAMLError as exc:
         raise PublishMatrixError(f"{path} is not valid YAML: {exc}") from exc
 
@@ -165,6 +180,18 @@ def _platforms(publish: dict[str, Any]) -> str:
 
     Carried on every matrix entry rather than fetched separately by the
     workflow. One lookup, one shape, and no way for the two to disagree.
+
+    MORE THAN ONE PLATFORM IS NOT FREE. `docker build --platform a,b` is
+    rejected by the classic builder outright, and under buildx a multi-
+    platform build cannot be loaded into the local daemon — it has to go
+    straight to a registry with `--push` (or to `--output`). So a second
+    entry here is not a one-line change: it obliges the consuming workflow
+    to use buildx and to stop doing anything that needs the image locally,
+    such as probing it before publishing.
+
+    Validated rather than trusted because the failure is remote and late: a
+    typo'd `linux/amd46` costs a runner slot and a confusing docker error,
+    when it can be caught here for nothing.
     """
     raw = publish.get("platforms")
     if raw is None:
@@ -177,13 +204,32 @@ def _platforms(publish: dict[str, Any]) -> str:
         raise PublishMatrixError(
             "`deployability.publish.platforms` must be a non-empty list"
         )
+
+    cleaned: list[str] = []
     for item in raw:
-        if not isinstance(item, str) or not item.strip():
+        if not isinstance(item, str):
             raise PublishMatrixError(
                 f"`deployability.publish.platforms` contains a non-string "
                 f"entry: {item!r}"
             )
-    return ",".join(raw)
+        # Stripped before use: a stray space survives the join and reaches
+        # `docker build --platform " linux/amd64"`, which docker rejects.
+        # An entry that is ONLY whitespace falls through to the shape check
+        # below, which names the real problem — calling it "non-string" when
+        # it is a string sends the reader looking for the wrong mistake.
+        value = item.strip()
+        if not PLATFORM_RE.match(value):
+            raise PublishMatrixError(
+                f"`deployability.publish.platforms` entry {item!r} is not a "
+                f"platform. Expected os/arch, optionally with a variant — "
+                f"for example linux/amd64 or linux/arm64/v8."
+            )
+        if value in cleaned:
+            raise PublishMatrixError(
+                f"`deployability.publish.platforms` lists {value!r} twice"
+            )
+        cleaned.append(value)
+    return ",".join(cleaned)
 
 
 def _check_relative(value: str, field: str, image: str) -> None:
@@ -327,9 +373,15 @@ def build_matrix(
     platforms = _platforms(publish)
 
     images = publish.get("images")
+    if images is None:
+        raise PublishMatrixError(
+            "`deployability.publish.images` is missing. Declare the images "
+            "to publish, or remove the `publish` block entirely."
+        )
     if not isinstance(images, list):
         raise PublishMatrixError(
-            "`deployability.publish.images` must be a list"
+            f"`deployability.publish.images` must be a list, got "
+            f"{type(images).__name__}"
         )
 
     entries: list[dict[str, Any]] = []

--- a/.github/scripts/publish_matrix.py
+++ b/.github/scripts/publish_matrix.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Build the job matrix for the recipe image publishing workflow.
+
+Reads `deployability.publish` from .github/policy.yml, validates every
+declared image against the filesystem, and emits one entry per image as a
+JSON array on stdout:
+
+    [{"recipe": "core/python/long-horizon-harness",
+      "image": "long-horizon-harness",
+      "dockerfile": "core/python/long-horizon-harness/Dockerfile",
+      "context": "core/python/long-horizon-harness",
+      "serves_http": true,
+      "platforms": "linux/amd64"}, ...]
+
+`dockerfile` and `context` come back REPO-RELATIVE, already joined onto the
+recipe, because that is what `docker build -f <dockerfile> <context>` wants
+from a workspace checkout. The policy file stores them relative to the recipe
+because that is what is readable when editing it; resolving the difference
+here rather than in shell keeps the workflow free of path arithmetic.
+
+Why an allowlist rather than a scan
+-----------------------------------
+`docker build` runs every RUN instruction it is given, and these images are
+published publicly. Deriving the set from "a Dockerfile exists" would let a
+contributor add one and have it built and pushed under Google's name without
+an admin ever agreeing. It would also pick up Dockerfiles that cannot be
+published as they stand: several in this repo re-resolve dependencies at
+build time instead of installing from a committed lockfile, and one is a
+template full of `{{PLACEHOLDER}}` that does not build at all.
+
+Why validation is strict
+------------------------
+Every rule below turns a silent, expensive failure into a loud, cheap one.
+A typo'd path fails the build minutes in, on a runner, with a message about a
+missing file rather than about the policy entry that named it. A duplicate
+image name is worse than a failure: two entries push to the same address and
+the second silently replaces the first, so a green run publishes an image
+nobody asked for. Unknown keys are rejected for the same reason — `dockefile`
+would otherwise be accepted and ignored, and the entry would build the wrong
+thing while looking correct in review.
+
+An empty matrix exits non-zero. A workflow that builds nothing and reports
+success is indistinguishable from one that is working, which is how a broken
+selector survives for months.
+
+Usage:
+    publish_matrix.py                    # every declared image
+    publish_matrix.py --image long-horizon-harness
+    publish_matrix.py --validate         # check only, human-readable output
+
+Invoke in CI as:
+    uv run --no-project --with pyyaml python3 .github/scripts/publish_matrix.py
+
+`--no-project` because this script needs the standard library plus yaml and
+nothing else; without it uv resolves and builds the root project for no
+reason. Matches how stale-sweep.yml invokes load_policy.py.
+
+This script does NOT use load_policy.py. That helper prints scalars and
+lists, and `publish.images` is a list of dicts, which it cannot represent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without pyyaml
+    print(
+        "error: PyYAML not installed. Run via "
+        "`uv run --no-project --with pyyaml python3 ...`.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Recipes may only be published from the curated and community trees.
+#
+# This one rule is also what excludes everything else: the pre-migration
+# python/agents/ and java/agents/ trees, and skills/, which policy.yml
+# already places out of scope for deployability. Naming the two roots that
+# ARE allowed keeps that exclusion from drifting as directories come and go.
+PUBLISHABLE_ROOTS = ("core/", "contrib/")
+
+# Artifact Registry image names: lowercase alphanumerics, dashes,
+# underscores and dots, starting with an alphanumeric. Deliberately tighter
+# than the registry strictly requires — these names are public and permanent
+# in practice, so the uppercase and slash-bearing forms a registry would
+# tolerate are refused rather than debated later.
+IMAGE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+REQUIRED_KEYS = frozenset(
+    {"recipe", "dockerfile", "context", "image", "serves_http"}
+)
+
+
+class PublishMatrixError(RuntimeError):
+    """The matrix cannot be built as declared.
+
+    Always fatal. A publishing workflow that cannot say which images to build
+    must not fall back to building some of them.
+    """
+
+
+def _policy_path(repo_root: Path) -> Path:
+    return repo_root / ".github" / "policy.yml"
+
+
+def load_publish_block(repo_root: Path) -> dict[str, Any]:
+    """Read `deployability.publish` from policy.yml.
+
+    Raises rather than returning a default for a missing block: the caller is
+    a workflow whose entire purpose is publishing these images, so an absent
+    declaration is a broken repository, not an empty one.
+    """
+    path = _policy_path(repo_root)
+    try:
+        with open(path, "rb") as handle:
+            data = yaml.safe_load(handle)
+    except FileNotFoundError as exc:
+        raise PublishMatrixError(f"{path} not found") from exc
+    except yaml.YAMLError as exc:
+        raise PublishMatrixError(f"{path} is not valid YAML: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise PublishMatrixError(f"{path} does not contain a YAML mapping")
+
+    deployability = data.get("deployability")
+    if not isinstance(deployability, dict):
+        raise PublishMatrixError(
+            f"{path} has no `deployability` section; "
+            f"the publish declaration lives under it"
+        )
+
+    publish = deployability.get("publish")
+    if not isinstance(publish, dict):
+        raise PublishMatrixError(
+            f"{path} has no `deployability.publish` section"
+        )
+    return publish
+
+
+def _platforms(publish: dict[str, Any]) -> str:
+    """The `--platform` value for `docker build`, as a comma-joined string.
+
+    Carried on every matrix entry rather than fetched separately by the
+    workflow. One lookup, one shape, and no way for the two to disagree.
+    """
+    raw = publish.get("platforms")
+    if raw is None:
+        raise PublishMatrixError(
+            "`deployability.publish.platforms` is missing. Declare it "
+            "explicitly — defaulting would silently build for the runner's "
+            "architecture, which is not necessarily the deployment target's."
+        )
+    if not isinstance(raw, list) or not raw:
+        raise PublishMatrixError(
+            "`deployability.publish.platforms` must be a non-empty list"
+        )
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise PublishMatrixError(
+                f"`deployability.publish.platforms` contains a non-string "
+                f"entry: {item!r}"
+            )
+    return ",".join(raw)
+
+
+def _check_relative(value: str, field: str, image: str) -> None:
+    """Reject absolute paths and parent-directory escapes.
+
+    Both are containment failures with the same consequence: a build context
+    or Dockerfile outside the recipe it claims to belong to, which puts files
+    the recipe does not own into an image published under its name.
+    """
+    if Path(value).is_absolute():
+        raise PublishMatrixError(
+            f"image {image!r}: `{field}` must be relative to the recipe, "
+            f"got the absolute path {value!r}"
+        )
+    if ".." in Path(value).parts:
+        raise PublishMatrixError(
+            f"image {image!r}: `{field}` must stay inside the recipe, "
+            f"got {value!r}"
+        )
+
+
+def _validate_entry(
+    raw: Any, index: int, repo_root: Path, platforms: str
+) -> dict[str, Any]:
+    """Validate one declared image and return its normalised matrix entry."""
+    where = f"`deployability.publish.images[{index}]`"
+
+    if not isinstance(raw, dict):
+        raise PublishMatrixError(f"{where} is not a mapping")
+
+    keys = set(raw)
+    missing = REQUIRED_KEYS - keys
+    if missing:
+        raise PublishMatrixError(
+            f"{where} is missing required key(s): {', '.join(sorted(missing))}"
+        )
+    # Fail closed on anything unrecognised. A misspelled key would otherwise
+    # be accepted and ignored, and the entry would build something other than
+    # what its author read back in review.
+    unknown = keys - REQUIRED_KEYS
+    if unknown:
+        raise PublishMatrixError(
+            f"{where} has unknown key(s): {', '.join(sorted(unknown))}. "
+            f"Allowed keys: {', '.join(sorted(REQUIRED_KEYS))}"
+        )
+
+    image = raw["image"]
+    if not isinstance(image, str) or not IMAGE_NAME_RE.match(image):
+        raise PublishMatrixError(
+            f"{where}: `image` must be a lowercase name matching "
+            f"{IMAGE_NAME_RE.pattern}, got {image!r}"
+        )
+
+    serves_http = raw["serves_http"]
+    if not isinstance(serves_http, bool):
+        raise PublishMatrixError(
+            f"image {image!r}: `serves_http` must be true or false, "
+            f"got {serves_http!r}"
+        )
+
+    recipe = raw["recipe"]
+    if not isinstance(recipe, str) or not recipe:
+        raise PublishMatrixError(
+            f"image {image!r}: `recipe` must be a non-empty string"
+        )
+    recipe = recipe.rstrip("/")
+    if not recipe.startswith(PUBLISHABLE_ROOTS):
+        raise PublishMatrixError(
+            f"image {image!r}: `recipe` must be under one of "
+            f"{', '.join(PUBLISHABLE_ROOTS)} — got {recipe!r}"
+        )
+    _check_relative(recipe, "recipe", image)
+
+    recipe_dir = repo_root / recipe
+    if not recipe_dir.is_dir():
+        raise PublishMatrixError(
+            f"image {image!r}: recipe directory {recipe!r} does not exist"
+        )
+    if not (recipe_dir / "manifest.yaml").is_file():
+        raise PublishMatrixError(
+            f"image {image!r}: {recipe!r} has no manifest.yaml, so it is not "
+            f"a recipe"
+        )
+
+    dockerfile = raw["dockerfile"]
+    if not isinstance(dockerfile, str) or not dockerfile:
+        raise PublishMatrixError(
+            f"image {image!r}: `dockerfile` must be a non-empty string"
+        )
+    _check_relative(dockerfile, "dockerfile", image)
+    dockerfile_path = recipe_dir / dockerfile
+    if not dockerfile_path.is_file():
+        raise PublishMatrixError(
+            f"image {image!r}: no Dockerfile at {recipe}/{dockerfile}"
+        )
+
+    context = raw["context"]
+    if not isinstance(context, str) or not context:
+        raise PublishMatrixError(
+            f"image {image!r}: `context` must be a non-empty string "
+            f'(use "." for the recipe root)'
+        )
+    _check_relative(context, "context", image)
+    context_path = recipe_dir / context
+    if not context_path.is_dir():
+        raise PublishMatrixError(
+            f"image {image!r}: build context {recipe}/{context} is not a "
+            f"directory"
+        )
+
+    # `docker build -f` accepts a Dockerfile outside the context, but every
+    # COPY in it resolves against the context, so the pairing is almost
+    # always a mistake rather than an intention. Caught here because the
+    # symptom otherwise appears as a confusing COPY failure mid-build.
+    if not dockerfile_path.resolve().is_relative_to(context_path.resolve()):
+        raise PublishMatrixError(
+            f"image {image!r}: the Dockerfile {recipe}/{dockerfile} is "
+            f"outside its build context {recipe}/{context}, so nothing it "
+            f"COPYs can resolve"
+        )
+
+    return {
+        "recipe": recipe,
+        "image": image,
+        # Repo-relative and normalised, ready for `docker build -f X Y`.
+        # pathlib drops "." components, so a context of "." collapses to the
+        # recipe directory on its own.
+        "dockerfile": (Path(recipe) / dockerfile).as_posix(),
+        "context": (Path(recipe) / context).as_posix(),
+        "serves_http": serves_http,
+        "platforms": platforms,
+    }
+
+
+def build_matrix(
+    repo_root: Path | None = None, only: str | None = None
+) -> list[dict[str, Any]]:
+    """Validate the whole publish block and return the job matrix."""
+    root = REPO_ROOT if repo_root is None else repo_root
+    publish = load_publish_block(root)
+    platforms = _platforms(publish)
+
+    images = publish.get("images")
+    if not isinstance(images, list):
+        raise PublishMatrixError(
+            "`deployability.publish.images` must be a list"
+        )
+
+    entries: list[dict[str, Any]] = []
+    seen_names: dict[str, int] = {}
+    seen_builds: dict[tuple[str, str], str] = {}
+
+    for index, raw in enumerate(images):
+        entry = _validate_entry(raw, index, root, platforms)
+
+        name = entry["image"]
+        if name in seen_names:
+            raise PublishMatrixError(
+                f"duplicate image name {name!r} at images[{index}] and "
+                f"images[{seen_names[name]}]. Names become public pull "
+                f"addresses, so two entries sharing one would push to the "
+                f"same place and the second would replace the first."
+            )
+        seen_names[name] = index
+
+        build = (entry["dockerfile"], entry["context"])
+        if build in seen_builds:
+            raise PublishMatrixError(
+                f"{entry['dockerfile']} is already published as "
+                f"{seen_builds[build]!r}; declaring it again as {name!r} "
+                f"would build one image twice under two names"
+            )
+        seen_builds[build] = name
+
+        entries.append(entry)
+
+    if only is not None:
+        matched = [e for e in entries if e["image"] == only]
+        if not matched:
+            # Taking `--image` on trust would produce an empty matrix, which
+            # the caller reports as "nothing to build" rather than as the
+            # typo it is.
+            known = ", ".join(sorted(seen_names)) or "(none declared)"
+            raise PublishMatrixError(
+                f"{only!r} is not a declared image. Known images: {known}"
+            )
+        return matched
+
+    return entries
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the recipe image publishing matrix."
+    )
+    parser.add_argument(
+        "--image",
+        help="Limit the matrix to one declared image name.",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate the declaration and print a summary; emit no JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        matrix = build_matrix(only=args.image)
+    except PublishMatrixError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if not matrix:
+        print(
+            "error: no images are declared in `deployability.publish.images`."
+            " Refusing to report success on an empty matrix — a workflow that"
+            " builds nothing looks exactly like one that is working.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.validate:
+        print(f"{len(matrix)} image(s) declared and valid:")
+        for entry in matrix:
+            serves = "http" if entry["serves_http"] else "no-server"
+            print(
+                f"  {entry['image']:<40} {entry['dockerfile']} "
+                f"(context: {entry['context']}, {serves})"
+            )
+        return 0
+
+    json.dump(matrix, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_matrix.py
+++ b/.github/scripts/publish_matrix.py
@@ -85,12 +85,12 @@ from typing import Any
 try:
     import yaml
 except ImportError:  # pragma: no cover - exercised only without pyyaml
-    print(
-        "error: PyYAML not installed. Run via "
-        "`uv run --no-project --with pyyaml python3 ...`.",
-        file=sys.stderr,
-    )
-    sys.exit(2)
+    # Recorded, not acted on. Calling sys.exit() here would make the module
+    # unimportable rather than merely unusable, so anything that imports it —
+    # the test suite included — would die during collection with a SystemExit
+    # instead of a readable failure. The missing dependency is reported by
+    # load_publish_block(), the first function that actually needs it.
+    yaml = None  # type: ignore[assignment]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -118,6 +118,20 @@ IMAGE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 # `os/arch`, optionally `os/arch/variant` — linux/amd64, linux/arm64/v8.
 PLATFORM_RE = re.compile(r"^[a-z0-9]+/[a-z0-9]+(?:/[a-z0-9]+)?$")
 
+# The characters a recipe, Dockerfile or context path may contain.
+#
+# Same reasoning as IMAGE_NAME_RE above, and for the same reason: these
+# values are pasted into `docker build -f <dockerfile> <context>` by the
+# build workflow. A path holding a space, a quote, a semicolon or a `$`
+# would be a command-injection point at that use site, and the filesystem
+# is perfectly willing to hold such a directory — POSIX permits almost
+# anything but NUL and `/` in a name. Constraining the input is more
+# reliable than hoping every downstream use site quotes correctly.
+#
+# Uppercase is allowed because filenames need it (`Dockerfile`, `README.md`)
+# even though recipe directories are lowercase by convention.
+PATH_CHARS_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
 REQUIRED_KEYS = frozenset(
     {"recipe", "dockerfile", "context", "image", "serves_http"}
 )
@@ -142,6 +156,12 @@ def load_publish_block(repo_root: Path) -> dict[str, Any]:
     a workflow whose entire purpose is publishing these images, so an absent
     declaration is a broken repository, not an empty one.
     """
+    if yaml is None:
+        raise PublishMatrixError(
+            "PyYAML is not installed. Run via "
+            "`uv run --no-project --with pyyaml python3 ...`."
+        )
+
     path = _policy_path(repo_root)
     try:
         with open(path, "rb") as handle:
@@ -233,11 +253,15 @@ def _platforms(publish: dict[str, Any]) -> str:
 
 
 def _check_relative(value: str, field: str, image: str) -> None:
-    """Reject absolute paths and parent-directory escapes.
+    """Reject absolute paths, parent escapes and unsafe characters.
 
-    Both are containment failures with the same consequence: a build context
-    or Dockerfile outside the recipe it claims to belong to, which puts files
-    the recipe does not own into an image published under its name.
+    The first two are containment failures with the same consequence: a build
+    context or Dockerfile outside the recipe it claims to belong to, which
+    puts files the recipe does not own into an image published under its name.
+
+    The third is a downstream concern — see PATH_CHARS_RE. It is enforced
+    here, at the single point every path field passes through, rather than at
+    each place a path is later used.
     """
     if Path(value).is_absolute():
         raise PublishMatrixError(
@@ -248,6 +272,37 @@ def _check_relative(value: str, field: str, image: str) -> None:
         raise PublishMatrixError(
             f"image {image!r}: `{field}` must stay inside the recipe, "
             f"got {value!r}"
+        )
+    if not PATH_CHARS_RE.match(value):
+        raise PublishMatrixError(
+            f"image {image!r}: `{field}` may only contain letters, digits, "
+            f"dot, dash, underscore and slash — got {value!r}. These paths "
+            f"are interpolated into the build command, so a character the "
+            f"shell treats specially is refused rather than quoted."
+        )
+
+
+def _check_inside_repo(
+    resolved: Path, repo_root: Path, field: str, image: str, shown: str
+) -> None:
+    """Refuse a path that resolves outside the repository.
+
+    The textual checks above cannot see symlinks. A recipe may contain one
+    pointing anywhere on the host, and a reviewer reading `context: data` in
+    policy.yml has no way to tell that `data` is a link to /etc — which is
+    precisely why "an admin approved it" is not the safeguard it appears to
+    be. Resolving both sides and comparing is the check that does not depend
+    on anyone noticing.
+
+    repo_root is resolved by the caller as well, so a repository that itself
+    lives under a symlink (/tmp on macOS is the everyday case) compares
+    like with like instead of failing for everyone.
+    """
+    if not resolved.is_relative_to(repo_root):
+        raise PublishMatrixError(
+            f"image {image!r}: `{field}` {shown!r} resolves to {resolved}, "
+            f"outside the repository at {repo_root}. A symlink leading out "
+            f"of the tree would copy host files into a public image."
         )
 
 
@@ -303,11 +358,15 @@ def _validate_entry(
         )
     _check_relative(recipe, "recipe", image)
 
+    # Resolved once here and reused, so every containment comparison below is
+    # made against the same real location.
+    repo_real = repo_root.resolve()
     recipe_dir = repo_root / recipe
     if not recipe_dir.is_dir():
         raise PublishMatrixError(
             f"image {image!r}: recipe directory {recipe!r} does not exist"
         )
+    _check_inside_repo(recipe_dir.resolve(), repo_real, "recipe", image, recipe)
     if not (recipe_dir / "manifest.yaml").is_file():
         raise PublishMatrixError(
             f"image {image!r}: {recipe!r} has no manifest.yaml, so it is not "
@@ -325,6 +384,9 @@ def _validate_entry(
         raise PublishMatrixError(
             f"image {image!r}: no Dockerfile at {recipe}/{dockerfile}"
         )
+    _check_inside_repo(
+        dockerfile_path.resolve(), repo_real, "dockerfile", image, dockerfile
+    )
 
     context = raw["context"]
     if not isinstance(context, str) or not context:
@@ -339,6 +401,9 @@ def _validate_entry(
             f"image {image!r}: build context {recipe}/{context} is not a "
             f"directory"
         )
+    _check_inside_repo(
+        context_path.resolve(), repo_real, "context", image, context
+    )
 
     # `docker build -f` accepts a Dockerfile outside the context, but every
     # COPY in it resolves against the context, so the pairing is almost

--- a/.github/scripts/tests/test_publish_matrix.py
+++ b/.github/scripts/tests/test_publish_matrix.py
@@ -1,0 +1,555 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for publish_matrix.py.
+
+This matrix decides which container images are built and pushed to a PUBLIC
+registry under Google's name, so the tests here pin the refusals rather than
+the happy path. Two failures are worth more than the rest combined:
+
+  * a duplicate image name, where the second entry silently replaces the
+    first at the same public address and the run still reports success;
+  * an empty matrix, where a workflow that builds nothing is indistinguishable
+    from one that is working.
+
+The final test validates the REAL policy.yml against the REAL repository, so
+moving or deleting a declared Dockerfile fails here — on every PR, through
+tools-tests.yml — instead of minutes into a build on a runner.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import publish_matrix as m
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _write_policy(
+    tmp_path: Path,
+    images: list[dict[str, Any]] | Any,
+    platforms: Any = ("linux/amd64",),
+    *,
+    omit_publish: bool = False,
+    omit_deployability: bool = False,
+    omit_platforms: bool = False,
+) -> Path:
+    """Write a minimal .github/policy.yml into a throwaway repo root."""
+    publish: dict[str, Any] = {"images": images}
+    if not omit_platforms:
+        publish["platforms"] = (
+            list(platforms) if isinstance(platforms, tuple) else platforms
+        )
+
+    if omit_deployability:
+        doc: dict[str, Any] = {"recipe_naming": {}}
+    elif omit_publish:
+        doc = {"deployability": {"min_google_adk": "2.6.0"}}
+    else:
+        doc = {"deployability": {"publish": publish}}
+
+    github = tmp_path / ".github"
+    github.mkdir(parents=True, exist_ok=True)
+    (github / "policy.yml").write_text(yaml.safe_dump(doc), encoding="utf-8")
+    return tmp_path
+
+
+def _scaffold(
+    tmp_path: Path,
+    recipe: str = "core/python/demo",
+    dockerfile: str = "Dockerfile",
+    context: str = ".",
+    *,
+    manifest: bool = True,
+) -> None:
+    """Create the recipe directory a declaration points at."""
+    recipe_dir = tmp_path / recipe
+    recipe_dir.mkdir(parents=True, exist_ok=True)
+    if manifest:
+        (recipe_dir / "manifest.yaml").write_text(
+            "language: python\nstatus: active\n", encoding="utf-8"
+        )
+    (recipe_dir / context).mkdir(parents=True, exist_ok=True)
+    df = recipe_dir / dockerfile
+    df.parent.mkdir(parents=True, exist_ok=True)
+    df.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+
+
+def _entry(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "recipe": "core/python/demo",
+        "dockerfile": "Dockerfile",
+        "context": ".",
+        "image": "demo",
+        "serves_http": True,
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------
+# Happy path
+# --------------------------------------------------------------------------
+
+
+def test_valid_declaration_yields_repo_relative_paths(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()])
+
+    matrix = m.build_matrix(repo_root=tmp_path)
+
+    assert matrix == [
+        {
+            "recipe": "core/python/demo",
+            "image": "demo",
+            "dockerfile": "core/python/demo/Dockerfile",
+            "context": "core/python/demo",
+            "serves_http": True,
+            "platforms": "linux/amd64",
+        }
+    ]
+
+
+def test_nested_dockerfile_and_context(tmp_path: Path):
+    """The sandbox-runtime shape: both nested, one inside the other."""
+    _scaffold(
+        tmp_path,
+        dockerfile="horizon/sandbox/runtime/Dockerfile",
+        context="horizon/sandbox/runtime",
+    )
+    _write_policy(
+        tmp_path,
+        [
+            _entry(
+                dockerfile="horizon/sandbox/runtime/Dockerfile",
+                context="horizon/sandbox/runtime",
+                image="demo-sandbox-runtime",
+            )
+        ],
+    )
+
+    (entry,) = m.build_matrix(repo_root=tmp_path)
+
+    assert entry["dockerfile"] == (
+        "core/python/demo/horizon/sandbox/runtime/Dockerfile"
+    )
+    assert entry["context"] == "core/python/demo/horizon/sandbox/runtime"
+
+
+def test_nested_dockerfile_with_recipe_root_context(tmp_path: Path):
+    """The multiformat shape: Dockerfile in a subdirectory, context at root.
+
+    This is the case that makes `context` a declared field rather than
+    something inferred from the Dockerfile's location.
+    """
+    _scaffold(tmp_path, dockerfile="services/api/Dockerfile", context=".")
+    _write_policy(
+        tmp_path,
+        [_entry(dockerfile="services/api/Dockerfile", context=".")],
+    )
+
+    (entry,) = m.build_matrix(repo_root=tmp_path)
+
+    assert entry["dockerfile"] == "core/python/demo/services/api/Dockerfile"
+    assert entry["context"] == "core/python/demo"
+
+
+def test_multiple_images_from_one_recipe(tmp_path: Path):
+    _scaffold(tmp_path)
+    _scaffold(tmp_path, dockerfile="sub/Dockerfile", context="sub")
+    _write_policy(
+        tmp_path,
+        [
+            _entry(),
+            _entry(
+                dockerfile="sub/Dockerfile", context="sub", image="demo-sub"
+            ),
+        ],
+    )
+
+    matrix = m.build_matrix(repo_root=tmp_path)
+
+    assert [e["image"] for e in matrix] == ["demo", "demo-sub"]
+
+
+def test_serves_http_false_is_preserved(tmp_path: Path):
+    """A publishable image need not be a server; the KFP base image is not."""
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(serves_http=False)])
+
+    (entry,) = m.build_matrix(repo_root=tmp_path)
+
+    assert entry["serves_http"] is False
+
+
+# --------------------------------------------------------------------------
+# The policy file itself
+# --------------------------------------------------------------------------
+
+
+def test_missing_policy_file(tmp_path: Path):
+    with pytest.raises(m.PublishMatrixError, match="not found"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_invalid_yaml(tmp_path: Path):
+    github = tmp_path / ".github"
+    github.mkdir()
+    (github / "policy.yml").write_text("deployability: [unclosed\n")
+
+    with pytest.raises(m.PublishMatrixError, match="not valid YAML"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_missing_deployability_section(tmp_path: Path):
+    _write_policy(tmp_path, [], omit_deployability=True)
+
+    with pytest.raises(m.PublishMatrixError, match="no `deployability`"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_missing_publish_section(tmp_path: Path):
+    _write_policy(tmp_path, [], omit_publish=True)
+
+    with pytest.raises(
+        m.PublishMatrixError, match=r"no `deployability\.publish`"
+    ):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_images_must_be_a_list(tmp_path: Path):
+    _write_policy(tmp_path, {"not": "a list"})
+
+    with pytest.raises(m.PublishMatrixError, match="must be a list"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+# --------------------------------------------------------------------------
+# platforms
+# --------------------------------------------------------------------------
+
+
+def test_platforms_missing_is_refused(tmp_path: Path):
+    """Defaulting would silently build for the runner, not the target."""
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()], omit_platforms=True)
+
+    with pytest.raises(m.PublishMatrixError, match="platforms` is missing"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_platforms_empty_is_refused(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()], platforms=[])
+
+    with pytest.raises(m.PublishMatrixError, match="non-empty list"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_platforms_non_string_entry_is_refused(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()], platforms=[42])
+
+    with pytest.raises(m.PublishMatrixError, match="non-string entry"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_multiple_platforms_are_comma_joined(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(
+        tmp_path, [_entry()], platforms=["linux/amd64", "linux/arm64"]
+    )
+
+    (entry,) = m.build_matrix(repo_root=tmp_path)
+
+    assert entry["platforms"] == "linux/amd64,linux/arm64"
+
+
+# --------------------------------------------------------------------------
+# Entry shape
+# --------------------------------------------------------------------------
+
+
+def test_entry_must_be_a_mapping(tmp_path: Path):
+    _write_policy(tmp_path, ["core/python/demo"])
+
+    with pytest.raises(m.PublishMatrixError, match="is not a mapping"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "key", ["recipe", "dockerfile", "context", "image", "serves_http"]
+)
+def test_missing_required_key(tmp_path: Path, key: str):
+    _scaffold(tmp_path)
+    entry = _entry()
+    del entry[key]
+    _write_policy(tmp_path, [entry])
+
+    with pytest.raises(m.PublishMatrixError, match=f"missing required.*{key}"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_unknown_key_is_refused(tmp_path: Path):
+    """A misspelled key would otherwise be accepted and quietly ignored."""
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(dockefile="Dockerfile")])
+
+    with pytest.raises(m.PublishMatrixError, match=r"unknown key.*dockefile"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "name", ["Demo", "-demo", "demo/sub", "demo:tag", "", "DEMO"]
+)
+def test_invalid_image_names(tmp_path: Path, name: str):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(image=name)])
+
+    with pytest.raises(m.PublishMatrixError, match="`image` must be"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_serves_http_must_be_boolean(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(serves_http="yes")])
+
+    with pytest.raises(m.PublishMatrixError, match="must be true or false"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+# --------------------------------------------------------------------------
+# Paths and containment
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        "python/agents/demo",  # pre-migration legacy tree
+        "java/agents/demo",  # pre-migration legacy tree
+        "skills/retail/demo",  # out of scope for deployability
+        "docs/demo",
+    ],
+)
+def test_recipe_outside_publishable_roots(tmp_path: Path, recipe: str):
+    _scaffold(tmp_path, recipe=recipe)
+    _write_policy(tmp_path, [_entry(recipe=recipe)])
+
+    with pytest.raises(m.PublishMatrixError, match="must be under"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_missing_recipe_directory(tmp_path: Path):
+    _write_policy(tmp_path, [_entry()])
+
+    with pytest.raises(m.PublishMatrixError, match="does not exist"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_recipe_without_manifest_is_not_a_recipe(tmp_path: Path):
+    _scaffold(tmp_path, manifest=False)
+    _write_policy(tmp_path, [_entry()])
+
+    with pytest.raises(m.PublishMatrixError, match=r"no manifest\.yaml"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_missing_dockerfile(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(dockerfile="Dockerfile.nope")])
+
+    with pytest.raises(m.PublishMatrixError, match="no Dockerfile at"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_context_must_be_a_directory(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(context="Dockerfile")])
+
+    with pytest.raises(m.PublishMatrixError, match="is not a directory"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_dockerfile_outside_context_is_refused(tmp_path: Path):
+    """Every COPY resolves against the context, so this pairing cannot work."""
+    _scaffold(tmp_path)
+    (tmp_path / "core/python/demo/sub").mkdir(parents=True, exist_ok=True)
+    _write_policy(tmp_path, [_entry(dockerfile="Dockerfile", context="sub")])
+
+    with pytest.raises(m.PublishMatrixError, match="outside its build context"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+@pytest.mark.parametrize("field", ["dockerfile", "context"])
+def test_absolute_paths_are_refused(tmp_path: Path, field: str):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(**{field: "/etc"})])
+
+    with pytest.raises(m.PublishMatrixError, match="absolute path"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("dockerfile", "../Dockerfile"),
+        ("context", ".."),
+        ("recipe", "core/../../etc"),
+    ],
+)
+def test_parent_escapes_are_refused(tmp_path: Path, field: str, value: str):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(**{field: value})])
+
+    with pytest.raises(
+        m.PublishMatrixError, match=r"must stay inside|must be under"
+    ):
+        m.build_matrix(repo_root=tmp_path)
+
+
+# --------------------------------------------------------------------------
+# Duplicates — the failures that would otherwise be silent
+# --------------------------------------------------------------------------
+
+
+def test_duplicate_image_name_is_refused(tmp_path: Path):
+    """Two entries, one public address: the second would replace the first."""
+    _scaffold(tmp_path)
+    _scaffold(tmp_path, recipe="contrib/python/demo")
+    _write_policy(
+        tmp_path,
+        [_entry(), _entry(recipe="contrib/python/demo")],
+    )
+
+    with pytest.raises(m.PublishMatrixError, match="duplicate image name"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_same_dockerfile_twice_is_refused(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(), _entry(image="demo-again")])
+
+    with pytest.raises(m.PublishMatrixError, match="already published as"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def test_image_filter_selects_one(tmp_path: Path):
+    _scaffold(tmp_path)
+    _scaffold(tmp_path, dockerfile="sub/Dockerfile", context="sub")
+    _write_policy(
+        tmp_path,
+        [
+            _entry(),
+            _entry(
+                dockerfile="sub/Dockerfile", context="sub", image="demo-sub"
+            ),
+        ],
+    )
+
+    matrix = m.build_matrix(repo_root=tmp_path, only="demo-sub")
+
+    assert [e["image"] for e in matrix] == ["demo-sub"]
+
+
+def test_unknown_image_filter_is_an_error_not_an_empty_matrix(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()])
+
+    with pytest.raises(m.PublishMatrixError, match="is not a declared image"):
+        m.build_matrix(repo_root=tmp_path, only="typo")
+
+
+def test_main_emits_json(tmp_path, monkeypatch, capsys):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()])
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+
+    assert m.main([]) == 0
+
+    payload = yaml.safe_load(capsys.readouterr().out)
+    assert payload[0]["image"] == "demo"
+
+
+def test_main_validate_prints_summary_and_no_json(
+    tmp_path, monkeypatch, capsys
+):
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()])
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+
+    assert m.main(["--validate"]) == 0
+
+    out = capsys.readouterr().out
+    assert "1 image(s) declared and valid" in out
+    assert "core/python/demo/Dockerfile" in out
+    assert not out.lstrip().startswith("[")
+
+
+def test_main_refuses_an_empty_matrix(tmp_path, monkeypatch, capsys):
+    """A workflow that builds nothing must not report success."""
+    _write_policy(tmp_path, [])
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+
+    assert m.main([]) == 1
+    assert "empty matrix" in capsys.readouterr().err
+
+
+def test_main_returns_1_on_error(tmp_path, monkeypatch, capsys):
+    _write_policy(tmp_path, [_entry()])  # recipe never scaffolded
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+
+    assert m.main([]) == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# Guard: the real declaration against the real repository
+# --------------------------------------------------------------------------
+
+
+def test_real_policy_declaration_is_valid():
+    """Every declared image must still resolve on disk.
+
+    This is the test that earns the file. `.github/scripts/tests/` is in the
+    root pytest testpaths, so moving or deleting a declared Dockerfile turns
+    this red on the PR that does it, rather than on a runner later.
+    """
+    matrix = m.build_matrix(repo_root=REPO_ROOT)
+
+    assert matrix, "no images declared in policy.yml"
+    for entry in matrix:
+        assert (REPO_ROOT / entry["dockerfile"]).is_file()
+        assert (REPO_ROOT / entry["context"]).is_dir()
+
+
+def test_real_policy_image_names_follow_the_convention():
+    """Names start with the recipe's directory basename.
+
+    The convention is what keeps a public pull address predictable from the
+    recipe path. A secondary image adds a suffix; nothing else is allowed to
+    drift, because renaming after publication breaks whoever pulled it.
+    """
+    for entry in m.build_matrix(repo_root=REPO_ROOT):
+        basename = entry["recipe"].rsplit("/", 1)[-1]
+        assert entry["image"].startswith(basename), (
+            f"{entry['image']!r} does not start with the recipe basename "
+            f"{basename!r}"
+        )

--- a/.github/scripts/tests/test_publish_matrix.py
+++ b/.github/scripts/tests/test_publish_matrix.py
@@ -27,6 +27,9 @@ moving or deleting a declared Dockerfile fails here — on every PR, through
 tools-tests.yml — instead of minutes into a build on a runner.
 """
 
+import json
+import re
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -213,6 +216,20 @@ def test_invalid_yaml(tmp_path: Path):
         m.build_matrix(repo_root=tmp_path)
 
 
+def test_unreadable_policy_reports_cleanly(tmp_path: Path):
+    """An I/O failure must not surface as a traceback in a workflow log.
+
+    A directory where policy.yml should be stands in for the whole OSError
+    family (permission denied, I/O error): it is the one case reproducible
+    without depending on the test process's privileges, since a root-owned
+    CI runner can read a chmod 000 file anyway.
+    """
+    (tmp_path / ".github" / "policy.yml").mkdir(parents=True)
+
+    with pytest.raises(m.PublishMatrixError, match="cannot read"):
+        m.build_matrix(repo_root=tmp_path)
+
+
 def test_missing_deployability_section(tmp_path: Path):
     _write_policy(tmp_path, [], omit_deployability=True)
 
@@ -233,6 +250,21 @@ def test_images_must_be_a_list(tmp_path: Path):
     _write_policy(tmp_path, {"not": "a list"})
 
     with pytest.raises(m.PublishMatrixError, match="must be a list"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_images_key_absent(tmp_path: Path):
+    """Distinguished from a wrong type, because the fix differs."""
+    github = tmp_path / ".github"
+    github.mkdir()
+    (github / "policy.yml").write_text(
+        yaml.safe_dump(
+            {"deployability": {"publish": {"platforms": ["linux/amd64"]}}}
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(m.PublishMatrixError, match="images` is missing"):
         m.build_matrix(repo_root=tmp_path)
 
 
@@ -267,14 +299,60 @@ def test_platforms_non_string_entry_is_refused(tmp_path: Path):
 
 
 def test_multiple_platforms_are_comma_joined(tmp_path: Path):
+    """Supported, but see _platforms(): it obliges the workflow to use
+    buildx and to push straight to the registry, because a multi-platform
+    build cannot be loaded into the local daemon."""
     _scaffold(tmp_path)
     _write_policy(
-        tmp_path, [_entry()], platforms=["linux/amd64", "linux/arm64"]
+        tmp_path, [_entry()], platforms=["linux/amd64", "linux/arm64/v8"]
     )
 
     (entry,) = m.build_matrix(repo_root=tmp_path)
 
-    assert entry["platforms"] == "linux/amd64,linux/arm64"
+    assert entry["platforms"] == "linux/amd64,linux/arm64/v8"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "linux/amd46/extra/parts",
+        "linux",
+        "/amd64",
+        "linux/",
+        "Linux/AMD64",
+        "linux amd64",
+        "   ",
+        "",
+    ],
+)
+def test_malformed_platform_is_refused(tmp_path: Path, value: str):
+    """A typo here costs a runner slot and an opaque docker error."""
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()], platforms=[value])
+
+    with pytest.raises(m.PublishMatrixError, match="is not a platform"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_platform_whitespace_is_stripped(tmp_path: Path):
+    """A stray space survives the join into `--platform`, which docker
+    rejects."""
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()], platforms=["  linux/amd64  "])
+
+    (entry,) = m.build_matrix(repo_root=tmp_path)
+
+    assert entry["platforms"] == "linux/amd64"
+
+
+def test_duplicate_platform_is_refused(tmp_path: Path):
+    _scaffold(tmp_path)
+    _write_policy(
+        tmp_path, [_entry()], platforms=["linux/amd64", "linux/amd64"]
+    )
+
+    with pytest.raises(m.PublishMatrixError, match="twice"):
+        m.build_matrix(repo_root=tmp_path)
 
 
 # --------------------------------------------------------------------------
@@ -477,15 +555,50 @@ def test_unknown_image_filter_is_an_error_not_an_empty_matrix(tmp_path: Path):
         m.build_matrix(repo_root=tmp_path, only="typo")
 
 
-def test_main_emits_json(tmp_path, monkeypatch, capsys):
+def test_main_emits_strict_json(tmp_path, monkeypatch, capsys):
+    """stdout must be JSON, parsed with a JSON parser — not a YAML one.
+
+    The consumer is `fromJson()` in a GitHub Actions workflow, which accepts
+    strict JSON and nothing else. Asserting with yaml.safe_load would pass on
+    output `fromJson` rejects, since YAML is a superset of JSON: it happily
+    reads `[{image: demo, serves_http: True}]`, which json.loads refuses.
+    That would leave this script's entire contract with the workflow untested.
+    """
     _scaffold(tmp_path)
     _write_policy(tmp_path, [_entry()])
     monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
 
     assert m.main([]) == 0
 
-    payload = yaml.safe_load(capsys.readouterr().out)
-    assert payload[0]["image"] == "demo"
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == [
+        {
+            "recipe": "core/python/demo",
+            "image": "demo",
+            "dockerfile": "core/python/demo/Dockerfile",
+            "context": "core/python/demo",
+            "serves_http": True,
+            "platforms": "linux/amd64",
+        }
+    ]
+
+
+def test_emitted_matrix_is_json_serialisable_scalars_only(tmp_path):
+    """Every value must survive the round trip a matrix makes.
+
+    GitHub expands matrix entries into the job context, so a nested object or
+    a non-JSON scalar would arrive at the workflow as something it cannot
+    interpolate.
+    """
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry()])
+
+    for entry in m.build_matrix(repo_root=tmp_path):
+        for key, value in entry.items():
+            assert isinstance(value, (str, bool)), (
+                f"{key} is {type(value).__name__}, which a matrix cannot carry"
+            )
 
 
 def test_main_validate_prints_summary_and_no_json(
@@ -538,6 +651,89 @@ def test_real_policy_declaration_is_valid():
     for entry in matrix:
         assert (REPO_ROOT / entry["dockerfile"]).is_file()
         assert (REPO_ROOT / entry["context"]).is_dir()
+
+
+def _copy_sources(dockerfile: Path) -> list[str]:
+    """The context-relative COPY sources in a Dockerfile.
+
+    Deliberately conservative — it returns only what can be resolved with
+    certainty, because a false failure here blocks a legitimate declaration:
+
+      * `COPY --from=<stage>` reads from an earlier build stage, not the
+        context, so it is not a context question at all.
+      * a source containing `$` is substituted from an ARG or ENV at build
+        time and cannot be resolved by reading the file.
+      * the JSON-array form, `COPY ["src", "dest"]`, which shlex would split
+        into `['["src",', '"dest"]']` — quoted fragments that resolve to
+        nothing and would be reported as missing files. Valid Dockerfile
+        syntax, unused by any image declared today, and a false failure is
+        exactly what this parser must not produce.
+    """
+    text = re.sub(r"\\\s*\n", " ", dockerfile.read_text(encoding="utf-8"))
+    sources: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not re.match(r"(?i)^copy\s", stripped):
+            continue
+        try:
+            parts = shlex.split(stripped)[1:]
+        except ValueError:
+            # Unbalanced quoting. The Dockerfile would not build either way,
+            # and guessing at its intent here helps nobody.
+            continue
+        if not parts or parts[0].startswith("["):
+            continue
+        if any(p.startswith("--from=") for p in parts):
+            continue
+        args = [p for p in parts if not p.startswith("--")]
+        # The last argument is the destination inside the image.
+        sources.extend(s for s in args[:-1] if "$" not in s)
+    return sources
+
+
+def test_real_policy_copy_sources_resolve_in_context():
+    """Every COPY source must exist inside the context declared for it.
+
+    This is the one claim the declaration makes that nothing else can check.
+    A wrong `context` satisfies every validation rule in publish_matrix.py —
+    the directory exists, the Dockerfile is inside it — and then fails deep
+    in `docker build` with a COPY error that names a path the reader cannot
+    find in policy.yml. Checking it here turns that into a failing test on
+    the PR that mis-declares it.
+
+    Lives in the tests rather than in publish_matrix.py on purpose. Dockerfile
+    parsing has enough edge cases that a false positive is a real risk, and a
+    false positive in a test is an afternoon's annoyance while a false
+    positive in the validator blocks publishing outright.
+    """
+    for entry in m.build_matrix(repo_root=REPO_ROOT):
+        context = REPO_ROOT / entry["context"]
+        for src in _copy_sources(REPO_ROOT / entry["dockerfile"]):
+            if src.endswith("*"):
+                # The `uv.lock*` idiom: a glob that deliberately tolerates
+                # matching nothing, so absence is not an error.
+                continue
+            assert (context / src).exists(), (
+                f"{entry['image']}: the Dockerfile COPYs {src!r}, which does "
+                f"not exist in its declared context {entry['context']!r}"
+            )
+
+
+def test_copy_source_parser_skips_what_it_cannot_resolve(tmp_path: Path):
+    """The parser's exclusions are load-bearing; pin them."""
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "FROM scratch AS build\n"
+        "COPY --chown=1000:1000 ./app ./app\n"
+        "COPY --from=build /out /out\n"
+        "COPY ${BUILD_DIR}/thing /thing\n"
+        'COPY ["json form.txt", "/dest/"]\n'
+        'COPY "unbalanced /dest/\n'
+        "COPY a.txt \\\n    b.txt /dest/\n",
+        encoding="utf-8",
+    )
+
+    assert _copy_sources(dockerfile) == ["./app", "a.txt", "b.txt"]
 
 
 def test_real_policy_image_names_follow_the_convention():

--- a/.github/scripts/tests/test_publish_matrix.py
+++ b/.github/scripts/tests/test_publish_matrix.py
@@ -37,6 +37,12 @@ import publish_matrix as m
 import pytest
 import yaml
 
+# Derived here independently of publish_matrix.REPO_ROOT, and deliberately
+# so: this file sits one level deeper than the module, so the two walk a
+# different number of parents to reach the same place. Reusing the module's
+# value would make the guard tests below agree with it by construction —
+# including when it is wrong. test_repo_root_derivations_agree pins that they
+# match, which is the part worth asserting.
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 
@@ -367,9 +373,17 @@ def test_entry_must_be_a_mapping(tmp_path: Path):
         m.build_matrix(repo_root=tmp_path)
 
 
-@pytest.mark.parametrize(
-    "key", ["recipe", "dockerfile", "context", "image", "serves_http"]
-)
+def test_entry_fixture_covers_every_required_key():
+    """Keeps _entry() honest as REQUIRED_KEYS grows.
+
+    test_missing_required_key deletes each required key from _entry() in
+    turn, so a key added to the module but not to the fixture would surface
+    as a KeyError inside the test rather than as the missing coverage it is.
+    """
+    assert set(_entry()) == m.REQUIRED_KEYS
+
+
+@pytest.mark.parametrize("key", sorted(m.REQUIRED_KEYS))
 def test_missing_required_key(tmp_path: Path, key: str):
     _scaffold(tmp_path)
     entry = _entry()
@@ -496,6 +510,116 @@ def test_parent_escapes_are_refused(tmp_path: Path, field: str, value: str):
         m.PublishMatrixError, match=r"must stay inside|must be under"
     ):
         m.build_matrix(repo_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("dockerfile", "Docker file"),
+        ("dockerfile", "Dockerfile;rm -rf /"),
+        ("dockerfile", "$(id)/Dockerfile"),
+        ("dockerfile", "Dockerfile`whoami`"),
+        ("context", "sub dir"),
+        ("context", "sub&dir"),
+        ("recipe", "core/python/de mo"),
+        ("recipe", "core/python/demo$X"),
+    ],
+)
+def test_shell_unsafe_path_characters_are_refused(
+    tmp_path: Path, field: str, value: str
+):
+    """These values are pasted into the build command by the workflow.
+
+    POSIX allows almost any byte in a filename, so a directory really can be
+    called `demo;rm -rf /`. Constraining the declaration is more reliable
+    than hoping every downstream use site quotes correctly.
+    """
+    _scaffold(tmp_path)
+    _write_policy(tmp_path, [_entry(**{field: value})])
+
+    with pytest.raises(
+        m.PublishMatrixError, match=r"may only contain|must be under"
+    ):
+        m.build_matrix(repo_root=tmp_path)
+
+
+# --------------------------------------------------------------------------
+# Symlink containment
+#
+# The textual checks cannot see symlinks, and a reviewer reading
+# `context: data` in policy.yml cannot tell that `data` links to /etc. These
+# are the checks that do not depend on anyone noticing.
+# --------------------------------------------------------------------------
+
+
+def test_symlinked_context_out_of_repo_is_refused(tmp_path: Path):
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
+    outside.mkdir()
+    (outside / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+
+    _scaffold(tmp_path)
+    (tmp_path / "core/python/demo/data").symlink_to(
+        outside, target_is_directory=True
+    )
+    _write_policy(
+        tmp_path,
+        [_entry(dockerfile="data/Dockerfile", context="data")],
+    )
+
+    with pytest.raises(m.PublishMatrixError, match="outside the repository"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_symlinked_dockerfile_out_of_repo_is_refused(tmp_path: Path):
+    outside = tmp_path.parent / f"outside-df-{tmp_path.name}"
+    outside.mkdir()
+    (outside / "evil").write_text("FROM scratch\n", encoding="utf-8")
+
+    _scaffold(tmp_path)
+    (tmp_path / "core/python/demo/Dockerfile.link").symlink_to(outside / "evil")
+    _write_policy(tmp_path, [_entry(dockerfile="Dockerfile.link")])
+
+    with pytest.raises(m.PublishMatrixError, match="outside the repository"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_symlinked_recipe_out_of_repo_is_refused(tmp_path: Path):
+    outside = tmp_path.parent / f"outside-recipe-{tmp_path.name}"
+    (outside / "core/python/demo").mkdir(parents=True)
+    (outside / "core/python/demo/manifest.yaml").write_text(
+        "language: python\n", encoding="utf-8"
+    )
+    (outside / "core/python/demo/Dockerfile").write_text(
+        "FROM scratch\n", encoding="utf-8"
+    )
+
+    (tmp_path / "core/python").mkdir(parents=True)
+    (tmp_path / "core/python/demo").symlink_to(
+        outside / "core/python/demo", target_is_directory=True
+    )
+    _write_policy(tmp_path, [_entry()])
+
+    with pytest.raises(m.PublishMatrixError, match="outside the repository"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_symlink_inside_the_repo_is_allowed(tmp_path: Path):
+    """Containment, not a blanket ban — an in-tree link is legitimate."""
+    _scaffold(tmp_path)
+    real = tmp_path / "core/python/demo/real"
+    real.mkdir()
+    (real / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (tmp_path / "core/python/demo/aliased").symlink_to(
+        real, target_is_directory=True
+    )
+    _write_policy(
+        tmp_path,
+        [_entry(dockerfile="aliased/Dockerfile", context="aliased")],
+    )
+
+    (entry,) = m.build_matrix(repo_root=tmp_path)
+
+    assert entry["context"] == "core/python/demo/aliased"
 
 
 # --------------------------------------------------------------------------
@@ -636,6 +760,31 @@ def test_main_returns_1_on_error(tmp_path, monkeypatch, capsys):
 # --------------------------------------------------------------------------
 # Guard: the real declaration against the real repository
 # --------------------------------------------------------------------------
+
+
+def test_missing_pyyaml_reports_cleanly_instead_of_killing_the_import(
+    tmp_path: Path, monkeypatch
+):
+    """The module must stay importable when PyYAML is absent.
+
+    Exiting at import time would take the whole test session down during
+    collection, and leave any other consumer unable to import the module to
+    ask it anything at all.
+    """
+    monkeypatch.setattr(m, "yaml", None)
+
+    with pytest.raises(m.PublishMatrixError, match="PyYAML is not installed"):
+        m.build_matrix(repo_root=tmp_path)
+
+
+def test_repo_root_derivations_agree():
+    """The module and this file compute the repo root independently.
+
+    They walk a different number of parents from different depths, so this
+    asserts the two agree rather than assuming it — which is the reason the
+    duplication is kept rather than replaced by `m.REPO_ROOT`.
+    """
+    assert REPO_ROOT == m.REPO_ROOT
 
 
 def test_real_policy_declaration_is_valid():


### PR DESCRIPTION
## What

Adds the admin-owned declaration of **which recipe container images get built and pushed** to a public Artifact Registry, plus a validator that turns a bad declaration into a loud, immediate failure.

This is phase 1 of 5. **No workflow and no Dockerfile changes here** — this is the input the build workflow will consume.

| File | Purpose |
|---|---|
| `.github/policy.yml` | New `deployability.publish` block declaring 3 images |
| `.github/scripts/publish_matrix.py` | Validates the block, emits the JSON build matrix |
| `.github/scripts/tests/test_publish_matrix.py` | 52 tests, including a guard against the real repo |

## Why an allowlist and not a scan

Same reasoning as the `run_allowlist` directly above it in `policy.yml`. `docker build` executes every `RUN` instruction it is handed, and these images will carry Google's name in a **public** registry — so which Dockerfiles earn that is a decision recorded here, not a side effect of a contributor adding a file.

It is also what lets publishing start at all. Most Dockerfiles in the repo are not ready: several re-resolve their dependencies at build time rather than installing from a committed lockfile, so two builds of one commit can produce different images. Listing the conforming ones unblocks the pipeline instead of holding it hostage to its slowest participant.

## Why not `manifest.deployable`

It means "can be deployed with one click" for **any** target, Agent Engine included. In practice the two sets barely overlap:

| Recipe | `deployable` | Dockerfile |
|---|---|---|
| `contrib/python/llm-auditor` | **true** | — (deploys via `deployment/deploy.py`) |
| `core/python/oauth-user-consent-flow` | **true** | — (deploys via `make deploy`) |
| `core/python/cross-session-memory` | false | **yes** |
| `core/python/genmedia-for-commerce` | false | **yes** |
| `contrib/python/multiformat-hybrid-rag` | false | **yes** |

2 of 7. Using it as the selector would fail two builds immediately and skip three recipes that do have images. Reconciling that field is separate work.

## The three images

- `long-horizon-harness` — the agent server
- `long-horizon-harness-sandbox-runtime` — included because the recipe **cannot be used without it**. Its quickstart currently makes every user build and push this image into their own project by hand (`docs/quickstart.md`, step 3 of 4). Publishing it deletes that step.
- `multiformat-hybrid-rag` — the best-built Dockerfile in the repo (non-root, `--frozen`, provenance args)

Naming convention is the recipe directory basename, plus a qualifier suffix for a recipe's secondary images.

## Design notes

**`context` is declared, not inferred.** Several Dockerfiles here live in a subdirectory but `COPY` from the recipe root, so `dirname(dockerfile)` is wrong often enough that guessing it would generate bugs.

**Registry coordinates are deliberately absent.** Project, repository and region arrive as repo variables at build time, so choosing or moving the hosting project never means editing `policy.yml`.

**Validation fails closed** — unknown keys, duplicate image names, paths escaping the recipe, a Dockerfile outside its own build context, a missing `platforms`, an empty matrix. Two of those would otherwise be silent rather than loud:

- a **duplicate image name** means two entries push to one public address and the second replaces the first, with the run still green;
- an **empty matrix** means a workflow that builds nothing, which looks exactly like one that is working.

**The guard test is the one that earns the file.** `.github/scripts/tests/` is already in the root pytest `testpaths`, so moving or deleting a declared Dockerfile turns this red on the PR that does it — through the existing `tools-tests.yml` job, with no workflow edit needed here.

## Verification

```
uv run pytest .github/scripts/tests/test_publish_matrix.py   # 52 passed
uv run pytest                                                # 1466 passed
uv run ruff format --check + ruff check                      # clean
uv run --no-project --with pyyaml python3 .github/scripts/publish_matrix.py --validate
```

```
3 image(s) declared and valid:
  long-horizon-harness                     core/python/long-horizon-harness/Dockerfile (context: core/python/long-horizon-harness, http)
  long-horizon-harness-sandbox-runtime     core/python/long-horizon-harness/horizon/sandbox/runtime/Dockerfile (context: .../horizon/sandbox/runtime, http)
  multiformat-hybrid-rag                   contrib/python/multiformat-hybrid-rag/Dockerfile (context: contrib/python/multiformat-hybrid-rag, http)
```

Existing `policy.yml` consumers re-checked via `load_policy.py`; unaffected.

## Next

2. Build workflow, publishing inert (push gated on registry vars being set)
3. Enable publishing — needs the GCP project and an org-policy exception for public AR
4. Build-failure classification and notification
5. Document the Dockerfile standard
