### PR TITLE
feat(ci): build recipe images on PR and merge, publishing inert

### DIFF
--- a/.github/scripts/publish_matrix.py
+++ b/.github/scripts/publish_matrix.py
@@ -464,6 +464,24 @@ def affected_by(
     # stop every global rebuild rule from ever matching.
     normalised = [c.strip().removeprefix("./") for c in changed if c.strip()]
 
+    # A leading quote means the caller handed us git's C-quoted form, which
+    # git emits for any path containing a non-ASCII byte unless
+    # `core.quotePath=false` is set. Such a path matches no recipe prefix, so
+    # the image owning it would be skipped — silently, which is the one
+    # outcome worth shouting about.
+    #
+    # A warning rather than an error: the other paths in the same list were
+    # still classified correctly, and refusing to build anything would turn a
+    # partial miss into a total one.
+    quoted = [c for c in normalised if c.startswith('"')]
+    if quoted:
+        print(
+            f"WARNING: {len(quoted)} changed path(s) arrived C-quoted, e.g. "
+            f"{quoted[0]}. The caller is missing `-c core.quotePath=false`; "
+            f"images owning those paths will NOT be rebuilt.",
+            file=sys.stderr,
+        )
+
     if any(c in GLOBAL_REBUILD_PATHS for c in normalised):
         return list(entries)
 

--- a/.github/scripts/publish_matrix.py
+++ b/.github/scripts/publish_matrix.py
@@ -118,6 +118,21 @@ IMAGE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 # `os/arch`, optionally `os/arch/variant` — linux/amd64, linux/arm64/v8.
 PLATFORM_RE = re.compile(r"^[a-z0-9]+/[a-z0-9]+(?:/[a-z0-9]+)?$")
 
+# A change to any of these rebuilds EVERY declared image, not just one.
+#
+# The declaration and the code that reads it decide what gets built and how,
+# so a change to either can alter an image without touching the recipe it
+# comes from. The workflow file is here for the same reason: it owns the
+# build arguments. Rebuilding everything is the cheap, obviously-correct
+# answer for a handful of images, and the alternative — reasoning about
+# which policy edit affects which entry — is the kind of cleverness that
+# quietly stops rebuilding something.
+GLOBAL_REBUILD_PATHS = (
+    ".github/policy.yml",
+    ".github/scripts/publish_matrix.py",
+    ".github/workflows/recipe-images.yml",
+)
+
 # The characters a recipe, Dockerfile or context path may contain.
 #
 # Same reasoning as IMAGE_NAME_RE above, and for the same reason: these
@@ -429,6 +444,37 @@ def _validate_entry(
     }
 
 
+def affected_by(
+    entries: list[dict[str, Any]], changed: list[str]
+) -> list[dict[str, Any]]:
+    """The subset of `entries` a set of changed files could have altered.
+
+    An image is affected when a changed file lies inside its recipe. The
+    build context is always inside the recipe (the validator enforces it), so
+    recipe containment is the whole test — no separate context check is
+    needed, and adding one would only invite the two to disagree.
+
+    A change to anything in GLOBAL_REBUILD_PATHS affects every image.
+
+    Order is preserved from the declaration so job names stay stable between
+    runs, which matters for reading a matrix in the Actions UI.
+    """
+    # removeprefix, NOT lstrip("./"): lstrip strips a SET of characters, so
+    # it would turn `.github/policy.yml` into `github/policy.yml` and quietly
+    # stop every global rebuild rule from ever matching.
+    normalised = [c.strip().removeprefix("./") for c in changed if c.strip()]
+
+    if any(c in GLOBAL_REBUILD_PATHS for c in normalised):
+        return list(entries)
+
+    affected = []
+    for entry in entries:
+        prefix = entry["recipe"].rstrip("/") + "/"
+        if any(c.startswith(prefix) for c in normalised):
+            affected.append(entry)
+    return affected
+
+
 def build_matrix(
     repo_root: Path | None = None, only: str | None = None
 ) -> list[dict[str, Any]]:
@@ -505,6 +551,15 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Validate the declaration and print a summary; emit no JSON.",
     )
+    parser.add_argument(
+        "--changed-from",
+        metavar="FILE",
+        help=(
+            "Limit the matrix to images affected by the changed paths listed "
+            "in FILE, one per line. An empty result is legitimate here and "
+            "emits [] with exit 0."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -513,6 +568,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
+    # The whole declaration is validated FIRST, above, and only then filtered.
+    # A broken entry therefore fails the run even when the change under test
+    # does not touch it — which is the point: policy.yml is either valid or it
+    # is not, and letting an unrelated PR sail past a broken entry would leave
+    # it to be discovered by whoever next touches that recipe.
     if not matrix:
         print(
             "error: no images are declared in `deployability.publish.images`."
@@ -522,8 +582,33 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    if args.changed_from is not None:
+        try:
+            text = Path(args.changed_from).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"error: cannot read {args.changed_from}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        changed = text.splitlines()
+        matrix = affected_by(matrix, changed)
+        # Deliberately NOT an error when empty. Unlike an empty declaration,
+        # "this change touched no image" is the normal outcome for most pull
+        # requests. The two are distinguished by exit code: 1 above, 0 here.
+        #
+        # On stderr so it cannot contaminate the JSON on stdout.
+        print(
+            f"{len(matrix)} image(s) affected by "
+            f"{len(changed)} changed path(s)",
+            file=sys.stderr,
+        )
+
     if args.validate:
-        print(f"{len(matrix)} image(s) declared and valid:")
+        if args.changed_from is not None:
+            print(f"{len(matrix)} image(s) affected and valid:")
+        else:
+            print(f"{len(matrix)} image(s) declared and valid:")
         for entry in matrix:
             serves = "http" if entry["serves_http"] else "no-server"
             print(

--- a/.github/scripts/tests/test_publish_matrix.py
+++ b/.github/scripts/tests/test_publish_matrix.py
@@ -649,6 +649,155 @@ def test_same_dockerfile_twice_is_refused(tmp_path: Path):
 
 
 # --------------------------------------------------------------------------
+# Change detection
+# --------------------------------------------------------------------------
+
+
+def _two_images(tmp_path: Path) -> list[dict[str, Any]]:
+    _scaffold(tmp_path)
+    _scaffold(tmp_path, recipe="contrib/python/other")
+    _write_policy(
+        tmp_path,
+        [_entry(), _entry(recipe="contrib/python/other", image="other")],
+    )
+    return m.build_matrix(repo_root=tmp_path)
+
+
+def test_affected_by_selects_only_the_touched_recipe(tmp_path: Path):
+    entries = _two_images(tmp_path)
+
+    affected = m.affected_by(entries, ["core/python/demo/agent.py"])
+
+    assert [e["image"] for e in affected] == ["demo"]
+
+
+def test_affected_by_ignores_unrelated_changes(tmp_path: Path):
+    entries = _two_images(tmp_path)
+
+    assert m.affected_by(entries, ["README.md", "docs/thing.md"]) == []
+
+
+@pytest.mark.parametrize("path", m.GLOBAL_REBUILD_PATHS)
+def test_global_paths_rebuild_everything(tmp_path: Path, path: str):
+    """The declaration and its tooling can change any image."""
+    entries = _two_images(tmp_path)
+
+    affected = m.affected_by(entries, [path])
+
+    assert [e["image"] for e in affected] == ["demo", "other"]
+
+
+def test_affected_by_preserves_declaration_order(tmp_path: Path):
+    """Job names stay stable between runs, which matters when reading a
+    matrix in the Actions UI."""
+    entries = _two_images(tmp_path)
+
+    affected = m.affected_by(
+        entries, ["contrib/python/other/x.py", "core/python/demo/y.py"]
+    )
+
+    assert [e["image"] for e in affected] == ["demo", "other"]
+
+
+def test_affected_by_tolerates_leading_dot_slash_and_blanks(tmp_path: Path):
+    entries = _two_images(tmp_path)
+
+    affected = m.affected_by(
+        entries, ["./core/python/demo/agent.py", "", "   "]
+    )
+
+    assert [e["image"] for e in affected] == ["demo"]
+
+
+def test_a_prefix_match_is_not_a_recipe_match(tmp_path: Path):
+    """`core/python/demo-extra` must not count as a change to `demo`.
+
+    Matching the bare recipe string rather than `recipe + "/"` would make
+    every sibling whose name starts the same way look affected.
+    """
+    entries = _two_images(tmp_path)
+
+    assert m.affected_by(entries, ["core/python/demo-extra/agent.py"]) == []
+
+
+def test_the_recipe_directory_itself_is_not_a_change(tmp_path: Path):
+    entries = _two_images(tmp_path)
+
+    assert m.affected_by(entries, ["core/python/demo"]) == []
+
+
+def test_changed_from_file_filters_the_matrix(tmp_path, monkeypatch, capsys):
+    _two_images(tmp_path)
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    changed = tmp_path / "changed.txt"
+    changed.write_text("core/python/demo/agent.py\n", encoding="utf-8")
+
+    assert m.main(["--changed-from", str(changed)]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [e["image"] for e in payload] == ["demo"]
+
+
+def test_changed_from_empty_result_is_success_not_an_error(
+    tmp_path, monkeypatch, capsys
+):
+    """Nothing affected is the normal outcome for most pull requests.
+
+    It must stay distinguishable from "nothing declared", which is a broken
+    repository — the two are told apart by the exit code.
+    """
+    _two_images(tmp_path)
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    changed = tmp_path / "changed.txt"
+    changed.write_text("README.md\n", encoding="utf-8")
+
+    assert m.main(["--changed-from", str(changed)]) == 0
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == []
+    assert "0 image(s) affected" in captured.err
+
+
+def test_changed_from_still_validates_untouched_entries(
+    tmp_path, monkeypatch, capsys
+):
+    """A broken entry fails the run even when the diff does not touch it.
+
+    policy.yml is either valid or it is not. Letting an unrelated PR sail
+    past a broken entry leaves it for whoever next touches that recipe.
+    """
+    _scaffold(tmp_path)
+    _write_policy(
+        tmp_path,
+        [_entry(), _entry(recipe="contrib/python/ghost", image="ghost")],
+    )
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+    changed = tmp_path / "changed.txt"
+    changed.write_text("README.md\n", encoding="utf-8")
+
+    assert m.main(["--changed-from", str(changed)]) == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_changed_from_missing_file_is_an_error(tmp_path, monkeypatch, capsys):
+    _two_images(tmp_path)
+    monkeypatch.setattr(m, "REPO_ROOT", tmp_path)
+
+    assert m.main(["--changed-from", str(tmp_path / "nope.txt")]) == 1
+    assert "cannot read" in capsys.readouterr().err
+
+
+def test_global_rebuild_paths_exist_in_the_repo():
+    """A stale entry here would silently stop triggering rebuilds.
+
+    Each path is compared literally against `git diff` output, so a renamed
+    file leaves a rule that can never match — and nothing else would notice.
+    """
+    for path in m.GLOBAL_REBUILD_PATHS:
+        assert (REPO_ROOT / path).is_file(), f"{path} no longer exists"
+
+
+# --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
 

--- a/.github/scripts/tests/test_publish_matrix.py
+++ b/.github/scripts/tests/test_publish_matrix.py
@@ -787,6 +787,33 @@ def test_changed_from_missing_file_is_an_error(tmp_path, monkeypatch, capsys):
     assert "cannot read" in capsys.readouterr().err
 
 
+def test_c_quoted_paths_warn_loudly_instead_of_being_skipped_silently(
+    tmp_path: Path, capsys
+):
+    """Git C-quotes non-ASCII paths unless core.quotePath=false is set.
+
+    Such a path matches no recipe prefix. If the workflow ever loses that
+    flag, this warning is what turns an invisible missed rebuild into
+    something a reader can see in the log.
+    """
+    entries = _two_images(tmp_path)
+
+    affected = m.affected_by(entries, ['"core/python/demo/caf\\303\\251.md"'])
+
+    assert affected == []
+    err = capsys.readouterr().err
+    assert "C-quoted" in err
+    assert "core.quotePath=false" in err
+
+
+def test_ordinary_paths_produce_no_quoting_warning(tmp_path: Path, capsys):
+    entries = _two_images(tmp_path)
+
+    m.affected_by(entries, ["core/python/demo/agent.py"])
+
+    assert "C-quoted" not in capsys.readouterr().err
+
+
 def test_global_rebuild_paths_exist_in_the_repo():
     """A stale entry here would silently stop triggering rebuilds.
 

--- a/.github/scripts/tests/test_recipe_images_workflow.py
+++ b/.github/scripts/tests/test_recipe_images_workflow.py
@@ -311,3 +311,129 @@ def test_the_workflow_path_matches_the_scripts_global_rebuild_list():
 
     rel = WORKFLOW.relative_to(REPO_ROOT).as_posix()
     assert rel in publish_matrix.GLOBAL_REBUILD_PATHS
+
+
+def _matches_a_trigger_path(candidate: str, patterns: list[str]) -> bool:
+    """Would `candidate` satisfy one of a trigger's `paths` globs?
+
+    Only the two glob shapes this workflow uses are handled — a literal path
+    and a `dir/**` prefix. Anything else is deliberately not guessed at.
+    """
+    for pattern in patterns:
+        if pattern == candidate:
+            return True
+        if pattern.endswith("/**") and candidate.startswith(pattern[:-2]):
+            return True
+    return False
+
+
+@pytest.mark.parametrize("trigger", ["pull_request", "push"])
+def test_every_global_rebuild_path_also_triggers_the_workflow(
+    triggers: dict, trigger: str
+):
+    """The two lists have to agree or a rebuild rule can never fire.
+
+    GLOBAL_REBUILD_PATHS decides which changes rebuild every image, but it is
+    only consulted once the workflow is already running. A path listed there
+    and absent from these filters is a rule that looks right in the script
+    and never runs — the workflow is not triggered at all, so nothing reports
+    anything, which is the worst shape a failure can take.
+    """
+    import publish_matrix
+
+    patterns = triggers[trigger]["paths"]
+    for path in publish_matrix.GLOBAL_REBUILD_PATHS:
+        assert _matches_a_trigger_path(path, patterns), (
+            f"{path} is in GLOBAL_REBUILD_PATHS but no `on.{trigger}.paths` "
+            f"pattern matches it, so changing it would not start this "
+            f"workflow at all"
+        )
+
+
+@pytest.mark.parametrize("trigger", ["pull_request", "push"])
+def test_every_publishable_root_also_triggers_the_workflow(
+    triggers: dict, trigger: str
+):
+    """Same coupling, for the roots recipes may be published from.
+
+    Add a root to PUBLISHABLE_ROOTS without adding it here and images
+    declared under it are never rebuilt when their recipe changes.
+    """
+    import publish_matrix
+
+    patterns = triggers[trigger]["paths"]
+    for root in publish_matrix.PUBLISHABLE_ROOTS:
+        probe = f"{root}some/recipe/agent.py"
+        assert _matches_a_trigger_path(probe, patterns), (
+            f"{root} is a publishable root but no `on.{trigger}.paths` "
+            f"pattern matches paths under it"
+        )
+
+
+def test_the_two_triggers_filter_on_the_same_paths(triggers: dict):
+    """A path that builds on a PR but not on merge — or the reverse — means
+    the thing verified before merge is not the thing published after it."""
+    assert triggers["pull_request"]["paths"] == triggers["push"]["paths"]
+
+
+def test_dispatch_offers_no_control_that_does_nothing(triggers: dict):
+    """A manual run has no diff base, so it always builds everything.
+
+    A `build_all` input would be a checkbox users could untick to no effect.
+    Asserting its absence rather than the exact input set, so a future input
+    that genuinely does something is not blocked by this test.
+    """
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert "build_all" not in inputs
+    assert "image" in inputs
+
+
+def test_the_diff_does_not_c_quote_non_ascii_paths(doc: dict):
+    """Without core.quotePath=false git emits `"caf\\303\\251.md"`.
+
+    A quoted path matches no recipe prefix, so the image owning it is
+    silently not rebuilt — the exact silent-miss this pipeline exists to
+    avoid. Verified against real git, not assumed.
+    """
+    step = next(s for s in _steps(doc, "detect") if s.get("id") == "detect")
+    diff_lines = [
+        line
+        for line in step["run"].splitlines()
+        if "git " in line
+        and "diff --name-only" in line
+        and not line.strip().startswith("#")
+    ]
+    assert diff_lines, "the diff line moved or changed shape"
+    for line in diff_lines:
+        assert "core.quotePath=false" in line, (
+            f"non-ASCII paths would be C-quoted and silently skipped: {line}"
+        )
+
+
+def test_the_pull_request_diff_fetch_is_not_shallow(doc: dict):
+    """`--depth` here makes the repository shallow and breaks merge-base.
+
+    The checkout already uses fetch-depth: 0, so this fetch only refreshes a
+    ref that is already present. Adding a depth introduces a shallow
+    boundary, after which `git merge-base` and `git diff` against the base
+    can fail — reproduced on a real clone, not theorised.
+    """
+    step = next(s for s in _steps(doc, "detect") if s.get("id") == "detect")
+    fetch_lines = [
+        line
+        for line in step["run"].splitlines()
+        if "git fetch" in line and not line.strip().startswith("#")
+    ]
+    assert fetch_lines, "the PR path no longer fetches its base ref"
+    for line in fetch_lines:
+        assert "--depth" not in line, f"shallow fetch reintroduced: {line}"
+
+
+def test_the_detect_checkout_takes_full_history(doc: dict):
+    """merge-base needs it, and it is what makes the fetch above safe."""
+    checkout = next(
+        s
+        for s in _steps(doc, "detect")
+        if "actions/checkout" in str(s.get("uses", ""))
+    )
+    assert checkout["with"]["fetch-depth"] == 0

--- a/.github/scripts/tests/test_recipe_images_workflow.py
+++ b/.github/scripts/tests/test_recipe_images_workflow.py
@@ -15,9 +15,19 @@
 
 This workflow builds container images from Dockerfiles that community
 contributors write, and is intended to push them to a PUBLIC registry under
-Google's name. Neither actionlint nor zizmor runs in this repository's CI, and
-ruff does not read YAML, so nothing else checks any of the following. Each one
-is a line someone could plausibly "fix" later for a good-sounding local reason.
+Google's name.
+
+What these tests are NOT for: generic GitHub Actions anti-patterns. An
+org-level required workflow runs zizmor over every workflow here — it is not
+a file in this repository, which makes it easy to miss when grepping — and it
+already covers unpinned actions, over-broad permissions and the like.
+
+What they ARE for is the repository-specific properties zizmor cannot know:
+that publishing is gated on three named variables, that the build runs before
+authentication, that the trigger filters agree with publish_matrix.py's path
+constants, that images are tagged by SHA alone. Each is a line someone could
+plausibly "fix" later for a good-sounding local reason, and ruff does not read
+YAML.
 
 The assertions are about PROPERTIES rather than exact text, so ordinary edits
 to the workflow do not trip them.

--- a/.github/scripts/tests/test_recipe_images_workflow.py
+++ b/.github/scripts/tests/test_recipe_images_workflow.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pin the security and correctness properties of recipe-images.yml.
+
+This workflow builds container images from Dockerfiles that community
+contributors write, and is intended to push them to a PUBLIC registry under
+Google's name. Neither actionlint nor zizmor runs in this repository's CI, and
+ruff does not read YAML, so nothing else checks any of the following. Each one
+is a line someone could plausibly "fix" later for a good-sounding local reason.
+
+The assertions are about PROPERTIES rather than exact text, so ordinary edits
+to the workflow do not trip them.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "recipe-images.yml"
+
+
+@pytest.fixture(scope="module")
+def doc() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def triggers(doc: dict) -> dict:
+    # PyYAML parses the unquoted key `on:` as the boolean True, since YAML 1.1
+    # treats `on` as a truthy scalar. Accept whichever key survives so this
+    # does not break if the workflow ever quotes it.
+    return doc.get("on") or doc[True]
+
+
+def _steps(doc: dict, job: str) -> list[dict]:
+    return doc["jobs"][job]["steps"]
+
+
+def _run_blocks(doc: dict) -> list[tuple[str, str]]:
+    out = []
+    for job_name, job in doc["jobs"].items():
+        for step in job.get("steps") or []:
+            if "run" in step:
+                out.append((f"{job_name}:{step.get('name', '?')}", step["run"]))
+    return out
+
+
+def test_the_workflow_parses():
+    assert yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------
+# Fork safety
+# --------------------------------------------------------------------------
+
+
+def test_it_never_uses_pull_request_target(triggers):
+    """pull_request_target runs with repository credentials in scope of code
+    the contributor wrote. For a workflow that builds contributor Dockerfiles
+    it is the single most dangerous trigger available."""
+    assert "pull_request_target" not in triggers
+
+
+def test_it_builds_on_pull_request(triggers):
+    """A first build discovered on main is a build nobody is watching."""
+    assert "pull_request" in triggers
+
+
+def test_push_is_restricted_to_main(triggers):
+    assert triggers["push"]["branches"] == ["main"]
+
+
+# --------------------------------------------------------------------------
+# Publishing is gated
+# --------------------------------------------------------------------------
+
+
+def test_every_push_step_is_gated_on_the_publish_decision(doc):
+    """Nothing may reach the registry unless the mode step said so.
+
+    This is what keeps the workflow inert while the registry variables are
+    unset, and what keeps a pull request — including one from a fork — from
+    publishing anything.
+    """
+    for step in _steps(doc, "build"):
+        run = step.get("run", "")
+        uses = str(step.get("uses", ""))
+        touches_registry = (
+            "docker push" in run
+            or "docker login" in run
+            or "google-github-actions/auth" in uses
+        )
+        if touches_registry:
+            assert "steps.mode.outputs.publish == 'true'" in step.get(
+                "if", ""
+            ), f"unguarded registry step: {step.get('name')}"
+
+
+def test_the_publish_decision_requires_all_three_registry_vars(doc):
+    """A half-configured registry must not half-publish."""
+    mode = next(s for s in _steps(doc, "build") if s.get("id") == "mode")
+    for var in (
+        "RECIPE_IMAGE_REGISTRY",
+        "RECIPE_IMAGE_WIF_PROVIDER",
+        "RECIPE_IMAGE_SA",
+    ):
+        assert var in str(mode.get("env", {})), f"{var} not consulted"
+    assert "PUBLISH=false" in mode["run"]
+
+
+def test_the_publish_decision_requires_a_push_to_main(doc):
+    mode = next(s for s in _steps(doc, "build") if s.get("id") == "mode")
+    assert "refs/heads/main" in mode["run"]
+    assert '"$EVENT_NAME" != "push"' in mode["run"]
+
+
+# --------------------------------------------------------------------------
+# Credential hygiene
+# --------------------------------------------------------------------------
+
+
+def test_the_build_happens_before_authentication(doc):
+    """A credential acquired before the build is a credential the build
+    context could capture. Checkout still comes first, because auth writes
+    into the workspace that a later checkout would clobber."""
+    names = [s.get("name", "") for s in _steps(doc, "build")]
+    order = {n: i for i, n in enumerate(names)}
+    build = next(i for n, i in order.items() if n.startswith("Build image"))
+    auth = next(i for n, i in order.items() if n.startswith("Authenticate"))
+    checkout = next(i for n, i in order.items() if n.startswith("Checkout"))
+    assert checkout < build < auth
+
+
+def test_auth_writes_no_credential_file(doc):
+    """A credential FILE in the workspace can be swept into a layer by a
+    COPY. A short-lived token in the step environment cannot."""
+    auth = next(
+        s
+        for s in _steps(doc, "build")
+        if "google-github-actions/auth" in str(s.get("uses", ""))
+    )
+    assert auth["with"]["create_credentials_file"] is False
+    assert auth["with"]["token_format"] == "access_token"
+
+
+def test_the_registry_token_is_passed_on_stdin(doc):
+    """Not as a `docker login -p` argument, where it would appear in a
+    process listing and in any `set -x` trace."""
+    push = next(
+        s for s in _steps(doc, "build") if "docker push" in s.get("run", "")
+    )
+    assert "--password-stdin" in push["run"]
+    assert "-p " not in push["run"]
+
+
+def test_checkout_never_persists_credentials(doc):
+    for job_name, job in doc["jobs"].items():
+        for step in job.get("steps") or []:
+            if "actions/checkout" in str(step.get("uses", "")):
+                assert (
+                    step.get("with", {}).get("persist-credentials") is False
+                ), f"{job_name} checkout persists credentials"
+
+
+# --------------------------------------------------------------------------
+# Repository conventions
+# --------------------------------------------------------------------------
+
+
+def test_no_github_expression_reaches_a_run_block(doc):
+    """The repo-wide rule: dynamic values arrive through `env:`, so nothing
+    a contributor controls can be substituted into shell source."""
+    for where, run in _run_blocks(doc):
+        assert "${{" not in run, f"{where} interpolates an expression"
+
+
+def test_every_action_is_pinned_to_a_sha(doc):
+    sha = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+    for job in doc["jobs"].values():
+        for step in job.get("steps") or []:
+            uses = step.get("uses")
+            if uses:
+                assert sha.match(uses), f"{uses} is not pinned to a full SHA"
+
+
+def test_workflow_level_permissions_are_empty(doc):
+    """Declared per job instead, so `detect` and `gate` do not inherit the
+    id-token grant that only `build` needs."""
+    assert doc["permissions"] == {}
+
+
+def test_id_token_is_granted_only_to_the_build_job(doc):
+    for name, job in doc["jobs"].items():
+        perms = job.get("permissions") or {}
+        if name == "build":
+            assert perms.get("id-token") == "write"
+        else:
+            assert "id-token" not in perms, f"{name} should not mint tokens"
+
+
+def test_every_job_has_a_timeout(doc):
+    for name, job in doc["jobs"].items():
+        assert job.get("timeout-minutes"), f"{name} has no timeout"
+
+
+def test_the_matrix_does_not_fail_fast(doc):
+    """One broken image must not hide the state of the others."""
+    assert doc["jobs"]["build"]["strategy"]["fail-fast"] is False
+
+
+def test_a_main_build_is_not_cancelled_by_a_later_push(doc):
+    """Cancelling the run that publishes could leave some images pushed and
+    others not. Superseding a PR build is free; superseding this is not."""
+    assert (
+        doc["concurrency"]["cancel-in-progress"]
+        == "${{ github.event_name == 'pull_request' }}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The gate
+# --------------------------------------------------------------------------
+
+
+def test_the_gate_always_runs(doc):
+    """A skipped required check is often treated as passing by branch
+    protection, which is the silent-green failure this guards against."""
+    gate = doc["jobs"]["gate"]
+    assert gate["if"] == "always()"
+    assert set(gate["needs"]) == {"detect", "build"}
+
+
+def test_the_gate_passes_when_no_image_was_affected(doc):
+    """`skipped` on build is the normal outcome for most pull requests."""
+    run = doc["jobs"]["gate"]["steps"][0]["run"]
+    assert "skipped)" in run
+
+
+def test_the_gate_fails_when_detect_fails(doc):
+    """Otherwise an invalid declaration produces a green run that built
+    nothing."""
+    run = doc["jobs"]["gate"]["steps"][0]["run"]
+    assert '"$DETECT_RESULT" != "success"' in run
+    assert "exit 1" in run
+
+
+# --------------------------------------------------------------------------
+# Wiring
+# --------------------------------------------------------------------------
+
+
+def test_the_matrix_comes_from_the_detect_job(doc):
+    build = doc["jobs"]["build"]
+    assert build["needs"] == "detect"
+    assert (
+        build["strategy"]["matrix"]["entry"]
+        == "${{ fromJson(needs.detect.outputs.matrix) }}"
+    )
+    assert build["if"] == "needs.detect.outputs.count != '0'"
+
+
+def test_the_detect_job_declares_the_outputs_build_consumes(doc):
+    outputs = doc["jobs"]["detect"]["outputs"]
+    assert "matrix" in outputs
+    assert "count" in outputs
+
+
+def test_the_build_uses_the_declared_context_and_dockerfile(doc):
+    """The matrix carries these per image; hardcoding either here would
+    silently ignore the declaration."""
+    step = next(
+        s for s in _steps(doc, "build") if "docker build" in s.get("run", "")
+    )
+    env = step["env"]
+    assert env["DOCKERFILE"] == "${{ matrix.entry.dockerfile }}"
+    assert env["CONTEXT"] == "${{ matrix.entry.context }}"
+    assert env["PLATFORMS"] == "${{ matrix.entry.platforms }}"
+
+
+def test_images_are_tagged_by_commit_sha_only(doc):
+    """No moving tag. What a consumer should pin to is still an open
+    question, and a public tag published once is hard to withdraw."""
+    push = next(
+        s for s in _steps(doc, "build") if "docker push" in s.get("run", "")
+    )
+    assert "$COMMIT_SHA" in push["run"]
+    assert ":latest" not in push["run"]
+
+
+def test_the_workflow_path_matches_the_scripts_global_rebuild_list():
+    """publish_matrix.GLOBAL_REBUILD_PATHS names this file literally.
+
+    Rename the workflow without updating that tuple and a change to it stops
+    triggering rebuilds, silently.
+    """
+    import publish_matrix
+
+    rel = WORKFLOW.relative_to(REPO_ROOT).as_posix()
+    assert rel in publish_matrix.GLOBAL_REBUILD_PATHS

--- a/.github/workflows/recipe-images.yml
+++ b/.github/workflows/recipe-images.yml
@@ -1,0 +1,364 @@
+name: 🐳 Recipe Images
+
+# Builds the container image for every recipe declared in
+# `deployability.publish` in .github/policy.yml, and — once the registry is
+# configured — pushes it to a public Artifact Registry on merge to main.
+#
+# PUBLISHING IS INERT UNTIL THE REGISTRY VARS ARE SET
+# ---------------------------------------------------
+# The push half of this workflow is gated on three repository variables
+# (RECIPE_IMAGE_REGISTRY, RECIPE_IMAGE_WIF_PROVIDER, RECIPE_IMAGE_SA). None
+# of them exists yet: the hosting GCP project has not been chosen, and making
+# an Artifact Registry repository public needs an org-policy exception that
+# is still being sought.
+#
+# So this lands and runs green doing the build half only. Turning publishing
+# on later is a repository-settings change, not a code change — which also
+# means the build path is exercised on every PR for weeks before it is first
+# asked to push anything.
+#
+# WHY BUILD ON PR AS WELL AS ON MERGE
+# -----------------------------------
+# If an image were only ever built after merge, every build failure would be
+# discovered on main, by someone who is no longer looking, and the
+# notification path would be the primary way anyone learned of it. Building
+# on the PR makes a merge-time failure rare and almost always
+# infrastructural.
+#
+# FORK PULL REQUESTS ARE SAFE BY CONSTRUCTION
+# -------------------------------------------
+# Nothing is pushed on a `pull_request` event, so no cloud credential is ever
+# requested for one, so a fork PR needs no secrets and can be built like any
+# other. This is `pull_request`, NOT `pull_request_target` — the latter would
+# run with repository credentials in scope of code the contributor wrote, and
+# must never be used here.
+
+on:
+  pull_request:
+    paths:
+      # Recipes live under core/ and contrib/ (skills/ is out of scope for
+      # deployability). Narrower per-recipe filters are pointless: the
+      # detect job below works out which images a change actually affects,
+      # and these paths only decide whether it runs at all.
+      - "core/**"
+      - "contrib/**"
+      - ".github/policy.yml"
+      - ".github/scripts/publish_matrix.py"
+      - ".github/workflows/recipe-images.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "core/**"
+      - "contrib/**"
+      - ".github/policy.yml"
+      - ".github/scripts/publish_matrix.py"
+      - ".github/workflows/recipe-images.yml"
+  workflow_dispatch:
+    inputs:
+      build_all:
+        description: "Build every declared image, ignoring the diff"
+        type: boolean
+        default: true
+      image:
+        description: "Limit to one declared image name"
+        type: string
+        required: false
+
+# Declared per job. At workflow level, `detect` and `gate` would inherit the
+# id-token grant that only `build` needs.
+permissions: {}
+
+concurrency:
+  # Per PR, or per ref for push/dispatch.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Superseding a PR build is free — the next push rebuilds it. Superseding a
+  # main build is not: that is the run that publishes, and cancelling it
+  # halfway could leave some images pushed and others not.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect:
+    name: Detect affected images
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      count: ${{ steps.detect.outputs.count }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          # Full history so the diff below has a base commit to compare with.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # ratchet:astral-sh/setup-uv@v10.0.1
+        with:
+          python-version: "3.11"
+
+      - name: Work out which images this change affects
+        id: detect
+        env:
+          # Through `env:`, never interpolated into the script body. These
+          # particular values are controlled, but the rule that no `${{ }}`
+          # reaches a `run:` block is worth keeping unconditional.
+          EVENT_NAME: ${{ github.event_name }}
+          BUILD_ALL: ${{ github.event.inputs.build_all }}
+          ONLY_IMAGE: ${{ github.event.inputs.image }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # pipefail is load-bearing. Without it a failed `git diff` would
+          # produce an empty change list, which reads as "no images
+          # affected" — a silent green run that built nothing, on exactly
+          # the change that most needed building.
+
+          ARGS=()
+          [ -n "${ONLY_IMAGE:-}" ] && ARGS+=(--image "$ONLY_IMAGE")
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && \
+             [ "${BUILD_ALL:-false}" = "true" ]; then
+            echo "workflow_dispatch with build_all — building everything."
+          else
+            case "$EVENT_NAME" in
+              pull_request)
+                git fetch --no-tags --depth=1 origin "$BASE_REF"
+                BASE="$(git merge-base HEAD "origin/$BASE_REF")"
+                ;;
+              push)
+                # `before` is all-zeros for a branch's first push, and
+                # points at a commit that no longer exists after a force
+                # push. Fall back rather than fail: rebuilding everything
+                # is the safe direction, building nothing is not.
+                if [ -n "${PUSH_BEFORE:-}" ] && \
+                   git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+                  BASE="$PUSH_BEFORE"
+                else
+                  echo "No usable 'before' commit; treating as build-all."
+                  BASE=""
+                fi
+                ;;
+              *)
+                BASE=""
+                ;;
+            esac
+
+            if [ -n "$BASE" ]; then
+              # Into RUNNER_TEMP, not the workspace. Scratch files written
+              # into a checkout have a way of ending up in a build context
+              # later, and this one would land next to the recipes.
+              CHANGED="$RUNNER_TEMP/changed.txt"
+              git diff --name-only "$BASE" HEAD > "$CHANGED"
+              echo "Changed paths:"
+              sed 's/^/  /' "$CHANGED"
+              ARGS+=(--changed-from "$CHANGED")
+            fi
+          fi
+
+          # The declaration is validated in full regardless of which images
+          # the diff selects, so a broken entry fails here even on a PR that
+          # does not touch it.
+          MATRIX="$(uv run --no-project --with pyyaml python3 \
+            .github/scripts/publish_matrix.py "${ARGS[@]}")"
+
+          COUNT="$(printf '%s' "$MATRIX" | python3 -c \
+            'import json,sys; print(len(json.load(sys.stdin)))')"
+
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "$COUNT image(s) to build."
+          printf '%s' "$MATRIX" | python3 -m json.tool
+
+  build:
+    name: "build ${{ matrix.entry.image }}"
+    needs: detect
+    if: needs.detect.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      # For Workload Identity Federation on the publish step. Requested even
+      # when publishing is inert: the grant alone reaches nothing, and a
+      # permissions block that changes when the vars are set would make
+      # turning publishing on a code change, which is what this design
+      # exists to avoid.
+      id-token: write
+    strategy:
+      # One broken image must not hide the state of the others.
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        entry: ${{ fromJson(needs.detect.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Decided here rather than inline on each step, so the build log states
+      # plainly whether this run intends to publish. `vars` is not available
+      # in a job-level `if:`, which is the other reason this is a step.
+      - name: Decide whether this run publishes
+        id: mode
+        env:
+          REGISTRY: ${{ vars.RECIPE_IMAGE_REGISTRY }}
+          WIF_PROVIDER: ${{ vars.RECIPE_IMAGE_WIF_PROVIDER }}
+          SERVICE_ACCOUNT: ${{ vars.RECIPE_IMAGE_SA }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          PUBLISH=false
+          if [ -z "${REGISTRY:-}" ] || [ -z "${WIF_PROVIDER:-}" ] || \
+             [ -z "${SERVICE_ACCOUNT:-}" ]; then
+            echo "Registry variables are not set — build only."
+            echo "  (set RECIPE_IMAGE_REGISTRY, RECIPE_IMAGE_WIF_PROVIDER"
+            echo "   and RECIPE_IMAGE_SA to enable publishing)"
+          elif [ "$EVENT_NAME" != "push" ] || [ "$REF" != "refs/heads/main" ]; then
+            echo "Not a merge to main — build only."
+          else
+            echo "Publishing enabled for this run."
+            PUBLISH=true
+          fi
+          echo "publish=$PUBLISH" >> "$GITHUB_OUTPUT"
+
+      # BUILD BEFORE AUTH, deliberately.
+      #
+      # google-github-actions/auth writes a credential file into the
+      # workspace. Building first means no such file exists on disk while
+      # the build context is being read, so it cannot be captured by a
+      # `COPY` in any Dockerfile. Checkout still comes first because auth
+      # writes into the workspace that checkout would otherwise clobber.
+      - name: Build image
+        env:
+          IMAGE: ${{ matrix.entry.image }}
+          DOCKERFILE: ${{ matrix.entry.dockerfile }}
+          CONTEXT: ${{ matrix.entry.context }}
+          PLATFORMS: ${{ matrix.entry.platforms }}
+          COMMIT_SHA: ${{ github.sha }}
+          SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Tagged with the commit SHA only. A moving tag is deliberately not
+          # produced: what a consumer should pin to is an open question with
+          # Agent Garden, and a tag published once is hard to withdraw.
+          #
+          # COMMIT_SHA is passed to every image. A Dockerfile that does not
+          # declare the ARG gets a warning from docker and nothing else,
+          # which is preferable to maintaining a per-image list of which
+          # build args each one happens to accept.
+          echo "Building $IMAGE for $PLATFORMS"
+          docker build \
+            --platform "$PLATFORMS" \
+            --file "$DOCKERFILE" \
+            --tag "local/$IMAGE:$COMMIT_SHA" \
+            --build-arg "COMMIT_SHA=$COMMIT_SHA" \
+            --label "org.opencontainers.image.source=$SOURCE_URL" \
+            --label "org.opencontainers.image.revision=$COMMIT_SHA" \
+            "$CONTEXT"
+          docker image inspect "local/$IMAGE:$COMMIT_SHA" \
+            --format 'built {{.RepoTags}} — {{.Size}} bytes'
+
+      # `token_format: access_token` rather than the default credential file,
+      # and no setup-gcloud step. Two reasons: the only cloud operation here
+      # is a registry login, which `docker login` does natively with an OAuth
+      # token; and a short-lived token held in the step environment never
+      # becomes a credential FILE sitting in the workspace, where a later
+      # `COPY` could sweep it into a published layer.
+      - name: Authenticate to Google Cloud
+        id: auth
+        if: steps.mode.outputs.publish == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.RECIPE_IMAGE_WIF_PROVIDER }}
+          service_account: ${{ vars.RECIPE_IMAGE_SA }}
+          token_format: access_token
+          create_credentials_file: false
+
+      - name: Push image
+        if: steps.mode.outputs.publish == 'true'
+        env:
+          IMAGE: ${{ matrix.entry.image }}
+          REGISTRY: ${{ vars.RECIPE_IMAGE_REGISTRY }}
+          COMMIT_SHA: ${{ github.sha }}
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: |
+          set -euo pipefail
+          # The registry host is the first path segment of the repository,
+          # e.g. us-central1-docker.pkg.dev from
+          # us-central1-docker.pkg.dev/<project>/<repo>.
+          HOST="${REGISTRY%%/*}"
+          # --password-stdin so the token never appears in a process listing
+          # or in the command echoed by `set -x`.
+          printf '%s' "$ACCESS_TOKEN" | \
+            docker login -u oauth2accesstoken --password-stdin "https://$HOST"
+          docker tag "local/$IMAGE:$COMMIT_SHA" "$REGISTRY/$IMAGE:$COMMIT_SHA"
+          docker push "$REGISTRY/$IMAGE:$COMMIT_SHA"
+          echo "Pushed $REGISTRY/$IMAGE:$COMMIT_SHA"
+
+      - name: Log out of the registry
+        if: always() && steps.mode.outputs.publish == 'true'
+        env:
+          REGISTRY: ${{ vars.RECIPE_IMAGE_REGISTRY }}
+        run: docker logout "https://${REGISTRY%%/*}" || true
+
+      - name: Summary
+        if: always()
+        env:
+          IMAGE: ${{ matrix.entry.image }}
+          DOCKERFILE: ${{ matrix.entry.dockerfile }}
+          PUBLISHED: ${{ steps.mode.outputs.publish }}
+        run: |
+          {
+            echo "### $IMAGE"
+            echo ""
+            echo "- Dockerfile: \`$DOCKERFILE\`"
+            if [ "${PUBLISHED:-false}" = "true" ]; then
+              echo "- Published: yes"
+            else
+              echo "- Published: no (build only)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Branch-protection gate. `if: always()` so the required check still
+  # reports when detect or build was skipped or cancelled — a skipped
+  # required check is often treated as passing, which is the silent-green
+  # failure this guards against.
+  gate:
+    name: Recipe image results
+    needs: [detect, build]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check results
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          COUNT: ${{ needs.detect.outputs.count }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "::error::Could not work out which recipe images this change affects (detect: $DETECT_RESULT), so nothing was built. Either the publish declaration in .github/policy.yml is invalid, or this is a CI tooling failure — the detect job log says which."
+            exit 1
+          fi
+
+          case "$BUILD_RESULT" in
+            success)
+              echo "All $COUNT recipe image(s) built."
+              ;;
+            skipped)
+              echo "No recipe images affected by this change — gate passes."
+              ;;
+            *)
+              echo "::error::One or more recipe images failed to build (build: $BUILD_RESULT). This gate reports the aggregate — open the red 'build <image>' job above for the actual docker output."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/recipe-images.yml
+++ b/.github/workflows/recipe-images.yml
@@ -55,13 +55,12 @@ on:
       - ".github/scripts/publish_matrix.py"
       - ".github/workflows/recipe-images.yml"
   workflow_dispatch:
+    # A manual run builds every declared image. There is no meaningful diff
+    # base for one, so a "use the diff" option would be a control that
+    # silently did nothing — use `image` to narrow it instead.
     inputs:
-      build_all:
-        description: "Build every declared image, ignoring the diff"
-        type: boolean
-        default: true
       image:
-        description: "Limit to one declared image name"
+        description: "Limit to one declared image name (default: all)"
         type: string
         required: false
 
@@ -107,7 +106,6 @@ jobs:
           # particular values are controlled, but the rule that no `${{ }}`
           # reaches a `run:` block is worth keeping unconditional.
           EVENT_NAME: ${{ github.event_name }}
-          BUILD_ALL: ${{ github.event.inputs.build_all }}
           ONLY_IMAGE: ${{ github.event.inputs.image }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           PUSH_BEFORE: ${{ github.event.before }}
@@ -120,45 +118,61 @@ jobs:
           # the change that most needed building.
 
           ARGS=()
-          [ -n "${ONLY_IMAGE:-}" ] && ARGS+=(--image "$ONLY_IMAGE")
+          # An explicit `if`, not `[ -n ... ] && ARGS+=(...)`. Under `set -e`
+          # a failing test in an && list is only exempt from exiting because
+          # it is not the final command — move that line to the end of the
+          # script during some later edit and it silently exits 1 on every
+          # run where the input is empty, which is every PR and every push.
+          if [ -n "${ONLY_IMAGE:-}" ]; then
+            ARGS+=(--image "$ONLY_IMAGE")
+          fi
 
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] && \
-             [ "${BUILD_ALL:-false}" = "true" ]; then
-            echo "workflow_dispatch with build_all — building everything."
-          else
-            case "$EVENT_NAME" in
-              pull_request)
-                git fetch --no-tags --depth=1 origin "$BASE_REF"
-                BASE="$(git merge-base HEAD "origin/$BASE_REF")"
-                ;;
-              push)
-                # `before` is all-zeros for a branch's first push, and
-                # points at a commit that no longer exists after a force
-                # push. Fall back rather than fail: rebuilding everything
-                # is the safe direction, building nothing is not.
-                if [ -n "${PUSH_BEFORE:-}" ] && \
-                   git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
-                  BASE="$PUSH_BEFORE"
-                else
-                  echo "No usable 'before' commit; treating as build-all."
-                  BASE=""
-                fi
-                ;;
-              *)
+          case "$EVENT_NAME" in
+            pull_request)
+              # NO --depth here. The checkout above used fetch-depth: 0, so
+              # every branch is already present and this only refreshes the
+              # ref. Adding --depth=1 would make the repository SHALLOW —
+              # verified, not theorised — and a shallow boundary is exactly
+              # what breaks `git merge-base` and `git diff` against a base
+              # commit that now sits beyond it.
+              git fetch --no-tags origin "$BASE_REF"
+              BASE="$(git merge-base HEAD "origin/$BASE_REF")"
+              ;;
+            push)
+              # `before` is all-zeros for a branch's first push, and points
+              # at a commit that no longer exists after a force push. Fall
+              # back rather than fail: rebuilding everything is the safe
+              # direction, building nothing is not.
+              if [ -n "${PUSH_BEFORE:-}" ] && \
+                 git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+                BASE="$PUSH_BEFORE"
+              else
+                echo "No usable 'before' commit; treating as build-all."
                 BASE=""
-                ;;
-            esac
+              fi
+              ;;
+            *)
+              # workflow_dispatch and anything added later: build everything.
+              echo "$EVENT_NAME — building every declared image."
+              BASE=""
+              ;;
+          esac
 
-            if [ -n "$BASE" ]; then
-              # Into RUNNER_TEMP, not the workspace. Scratch files written
-              # into a checkout have a way of ending up in a build context
-              # later, and this one would land next to the recipes.
-              CHANGED="$RUNNER_TEMP/changed.txt"
-              git diff --name-only "$BASE" HEAD > "$CHANGED"
-              echo "Changed paths:"
-              sed 's/^/  /' "$CHANGED"
-              ARGS+=(--changed-from "$CHANGED")
-            fi
+          if [ -n "$BASE" ]; then
+            # Into RUNNER_TEMP, not the workspace. Scratch files written into
+            # a checkout have a way of ending up in a build context later,
+            # and this one would land next to the recipes.
+            CHANGED="$RUNNER_TEMP/changed.txt"
+            # core.quotePath=false is not cosmetic. By default git C-quotes
+            # any path with a non-ASCII byte — `core/python/x/café.md` comes
+            # out as `"core/python/x/caf\303\251.md"`, complete with the
+            # leading quote, so the prefix match against the recipe fails and
+            # the image is silently NOT rebuilt. Verified against real git.
+            git -c core.quotePath=false diff --name-only "$BASE" HEAD \
+              > "$CHANGED"
+            echo "Changed paths:"
+            sed 's/^/  /' "$CHANGED"
+            ARGS+=(--changed-from "$CHANGED")
           fi
 
           # The declaration is validated in full regardless of which images


### PR DESCRIPTION
## What

Phase 2 of the recipe image pipeline. Builds every declared image on pull requests and on merge to `main`. **The push half is gated on three repository variables that do not exist yet**, so this lands and runs green doing the build half only.

Depends on #2592 (merged).

| File | Purpose |
|---|---|
| `.github/workflows/recipe-images.yml` | New — detect → build (→ push, gated) → gate |
| `.github/scripts/publish_matrix.py` | Adds `--changed-from` and `affected_by()` |
| `.github/scripts/tests/test_recipe_images_workflow.py` | New — 26 property tests over the workflow YAML |
| `.github/scripts/tests/test_publish_matrix.py` | +14 tests for change detection |

## Publishing is inert, on purpose

The push steps are gated on `RECIPE_IMAGE_REGISTRY`, `RECIPE_IMAGE_WIF_PROVIDER` and `RECIPE_IMAGE_SA`. None exists yet — the hosting GCP project isn't chosen, and making an AR repository public needs an org-policy exception still being sought.

Two things this buys: turning publishing on in phase 3 becomes a **repo-settings change rather than a code change**, and the build path gets exercised on every PR for weeks before it is first asked to push anything.

The `id-token: write` grant is requested unconditionally rather than appearing when the vars are set — the grant alone reaches nothing, and a permissions block that changes with configuration would defeat the point.

## Fork PRs are safe by construction

Nothing is pushed on a `pull_request` event, so no cloud credential is ever requested for one, so a fork PR needs no secrets. The trigger is `pull_request`, **never** `pull_request_target` — and a test pins that, because it's the one change that would turn this into a credential-exposure bug.

## Change detection

An image is affected when a changed file lies inside its recipe. Edits to `policy.yml`, `publish_matrix.py` or the workflow rebuild **everything**, since any of the three can alter an image without touching its recipe.

The logic lives in `publish_matrix.py`, not workflow bash, so it can be tested. Verified against real repo paths:

| Changed | Images built |
|---|---|
| `core/python/long-horizon-harness/horizon/agent.py` | `long-horizon-harness`, `long-horizon-harness-sandbox-runtime` |
| `contrib/python/multiformat-hybrid-rag/app/x.py` | `multiformat-hybrid-rag` |
| `README.md` | none |
| `.github/policy.yml` | all 3 |
| `core/python/deep-search/agent.py` | none (not declared) |

Note the first row: one recipe, two images, both correctly rebuilt.

The declaration is validated **in full** before filtering, so a broken entry fails the run even on a PR that doesn't touch it. An empty result is success — "no image affected" is the normal outcome for most PRs — and is distinguished from "nothing declared" by exit code.

## Credential hygiene shaped three choices

- **Build runs before auth.** No credential exists on disk while the build context is read, so no `COPY` can sweep one into a layer. Checkout still comes first, because `auth` writes into the workspace a later checkout would clobber.
- **`token_format: access_token`, `create_credentials_file: false`.** Nothing is written to the workspace at all. This also removes the need for a `setup-gcloud` step.
- **Token reaches docker on stdin**, not as an argument where it would show in a process listing or a `set -x` trace.

## Tests

Neither actionlint nor zizmor runs in this repo's CI, and ruff doesn't read YAML — so nothing would catch a regression in any of the above. `test_recipe_images_workflow.py` adds 26 property assertions: no `pull_request_target`, every registry step gated, build-before-auth ordering, no `${{ }}` inside `run:`, every action pinned to a full SHA, `id-token` only on `build`, SHA-only tags, the gate always running.

One of them cross-checks that the workflow's filename appears in `GLOBAL_REBUILD_PATHS`, so renaming the file can't silently stop it triggering rebuilds.

## Verification

Docker isn't available here, so **no container was built** — that first happens on this PR's own CI run. Everything else was executed:

```
uv run pytest                      # 1536 passed (was 1496)
uv run ruff format --check + check # 27 files clean
```

I extracted the `detect` step's actual shell from the YAML and ran it against real git:

| Scenario | Result |
|---|---|
| `pull_request` vs `main` | 3 images (this PR touches 2 global paths) |
| `push` with valid `before` | 3 images from a 4-path diff |
| `push` with all-zeros `before` | falls back to build-all, doesn't fail |
| `workflow_dispatch` + `build_all` | 3 images |
| `workflow_dispatch` + `image=multiformat-hybrid-rag` | 1 image |
| `workflow_dispatch` + `image=typo` | exits 1 with the known-images list |

Also confirmed `$GITHUB_OUTPUT` receives exactly two lines and the matrix is valid single-line JSON — multi-line output there would break `fromJson` in a way that's awkward to debug.

## Decisions I made rather than asking

- **Affected-only builds on both triggers**, matching `python-tests.yml`. Building 3 containers on every unrelated PR is waste. Worth revisiting in phase 3 if Agent Garden's tag contract needs every image present at every main SHA.
- **`COMMIT_SHA` passed to every image.** Dockerfiles that don't declare the ARG get a docker warning and nothing else, which beats maintaining a per-image list of accepted build args.
- **Main builds are not cancelled by a later push** (`cancel-in-progress` only for PRs) — cancelling the run that publishes could leave some images pushed and others not.

## Next

3. Turn on publishing — **blocked** on the GCP project and the public-AR org-policy exception
4. Build-failure classification + notification
5. Document the Dockerfile standard
