### PR TITLE
feat(ci): classify recipe image build failures and report the real ones

### DIFF
--- a/.github/scripts/image_build_report.py
+++ b/.github/scripts/image_build_report.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Classify recipe image build failures and report the ones worth reporting.
+
+Two subcommands, used at two points in .github/workflows/recipe-images.yml:
+
+    classify   one per matrix leg: read that image's build log and decide
+               whether the recipe broke or the infrastructure did, writing
+               a small result.json the report job collects.
+
+    report     once per run: collate every result, comment on the merged
+               pull request when a recipe genuinely broke, and open a
+               tracking issue only when the same image fails again.
+
+BLAME THE RECIPE ONLY ON EVIDENCE
+---------------------------------
+Taken verbatim from recipe-canary.yml, which states the reason plainly: the
+cost of the two mistakes is not symmetric. A missed real failure is caught by
+the next run. One failure misfiled against an author for a registry timeout
+teaches everyone that this channel cries wolf, and from then on the real ones
+are ignored too.
+
+So every path that reaches a verdict without a log to read classifies as
+`infra`, and anything matching a known infrastructure signature does too.
+Only a build that failed with output that looks like the Dockerfile's own
+fault is called `fail`.
+
+WHY A PULL REQUEST COMMENT FIRST, AND AN ISSUE ONLY ON A REPEAT
+---------------------------------------------------------------
+For a failure on main the actionable human is whoever merged the change, and
+a comment on their pull request reaches them where the context already is. It
+needs no ownership metadata to be correct, which matters here:
+canary_issues.py records that only 3 of 12 recipes declare an
+`ownership.poc` that can even be assigned, because GitHub silently drops an
+unknown assignee.
+
+An issue is for the failure nobody acted on. Opening one for every failure
+would produce a tracker full of items already fixed by the next commit; a
+second consecutive failure of the same image is evidence the comment was
+missed, and that is worth something more durable.
+
+"Repeated" is read from the workflow's own run history rather than from a
+file or a label, so there is no state to keep in sync and no first run that
+behaves differently because its state does not exist yet.
+
+Usage:
+    image_build_report.py classify --image X --outcome failure \\
+        --log build.log --out result.json
+    image_build_report.py report --results DIR --run-url URL [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "google/adk-samples")
+WORKFLOW_FILE = "recipe-images.yml"
+
+# Who is told when a failure needs a human and no better address exists.
+MAINTAINER = "happyhuman"
+
+TITLE_PREFIX = "Recipe image build failing:"
+LABEL_TRACKING = "recipe-image-build"
+
+# How many log lines to quote back. Enough to show the failing instruction
+# and its error, short enough that a comment stays readable.
+LOG_TAIL_LINES = 25
+
+# Upper bound on issues one run will open. Sized well above routine breakage
+# — three images are declared today — and below "something is systemically
+# wrong". Mirrors DEFAULT_MAX_ISSUES in canary_issues.py, for the same
+# reason: automation that writes to the tracker should refuse a batch whose
+# size implies its own inputs are broken.
+MAX_ISSUES_PER_RUN = 5
+
+# Log signatures that mean the infrastructure failed, not the recipe.
+#
+# Each is a real docker/registry failure mode with a distinctive string. The
+# list is deliberately generous: a false `infra` costs a missed report that
+# the next run catches, while a false `fail` costs the channel's credibility.
+#
+# Matched case-insensitively against the build log.
+INFRA_SIGNATURES: tuple[tuple[str, str], ...] = (
+    # Registry and network.
+    #
+    # Three spellings of "the registry returned an error status". The status
+    # code and the host appear in either order depending on which layer of
+    # docker reports it, and a signature matching only one order would blame
+    # the recipe for the other — which is how the first version of this list
+    # misclassified a real 503 from docker.io.
+    (
+        r"unexpected (?:http )?status:?\s*(?:50\d|429)",
+        "registry returned a server error",
+    ),
+    (
+        r"\b(?:50\d|429)\b[^\n]{0,160}"
+        r"(?:registry|docker\.io|pkg\.dev|ghcr\.io)",
+        "registry returned a server error",
+    ),
+    (
+        r"(?:registry|docker\.io|pkg\.dev|ghcr\.io)[^\n]{0,160}"
+        r"\b(?:50\d|429)\b",
+        "registry returned a server error",
+    ),
+    (r"toomanyrequests|rate limit|too many requests", "registry rate limit"),
+    (
+        r"connection reset by peer|connection refused|broken pipe",
+        "network dropped",
+    ),
+    (
+        r"i/o timeout|timeout awaiting|context deadline exceeded",
+        "network timeout",
+    ),
+    (r"temporary failure in name resolution|no such host|dns", "DNS failure"),
+    (
+        r"tls handshake|x509|certificate (?:has expired|verify failed)",
+        "TLS failure",
+    ),
+    (
+        r"unexpected eof|unexpected status from (?:head|get) request",
+        "truncated registry response",
+    ),
+    # Pulling the base image.
+    (r"failed to resolve source metadata", "base image could not be resolved"),
+    (
+        r"pull access denied|manifest unknown|manifest for .* not found",
+        "base image unavailable",
+    ),
+    (r"error pulling image configuration", "base image layer download failed"),
+    # The runner itself.
+    (r"no space left on device", "the runner ran out of disk"),
+    (
+        r"cannot allocate memory|out of memory|oom-kill",
+        "the runner ran out of memory",
+    ),
+    (
+        r"failed to (?:start|connect to) (?:the )?docker daemon|cannot connect to the docker daemon",
+        "the docker daemon was unavailable",
+    ),
+    # Authentication, which is configuration rather than the recipe.
+    (
+        r"unauthorized: |denied: permission|token.{0,20}expired|invalid_grant",
+        "registry authentication failed",
+    ),
+    (
+        r"workload identity|failed to generate google-github-actions",
+        "cloud authentication failed",
+    ),
+)
+
+_COMPILED = tuple(
+    (re.compile(pattern, re.IGNORECASE), reason)
+    for pattern, reason in INFRA_SIGNATURES
+)
+
+PASS = "pass"
+FAIL = "fail"
+INFRA = "infra"
+
+
+class ReportError(RuntimeError):
+    """The report cannot be produced. Always fatal: a reporter that cannot
+    tell anyone must fail its run rather than report success in silence."""
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify(outcome: str, log: str | None) -> tuple[str, str]:
+    """Decide what a single image's build result means.
+
+    Returns (verdict, detail). `outcome` is the GitHub step outcome for the
+    docker build — "success", "failure", "skipped" or "" if it never ran.
+
+    The order of these branches is the evidence rule made executable: every
+    way of reaching a verdict WITHOUT a log to read lands on `infra`, and the
+    only path to `fail` requires log text that matched no infrastructure
+    signature.
+    """
+    if outcome == "success":
+        return PASS, ""
+
+    if outcome in ("", "skipped", "cancelled"):
+        # The build never ran, so nothing was learned about the recipe.
+        # Checkout, the mode step, or the runner died ahead of it.
+        return (
+            INFRA,
+            f"the build step did not run (outcome: {outcome or 'unset'})",
+        )
+
+    if not log or not log.strip():
+        # docker writes to this file before it starts, so an empty log means
+        # it never got far enough to say anything. No evidence, no blame.
+        return INFRA, "the build failed without producing any output"
+
+    for pattern, reason in _COMPILED:
+        match = pattern.search(log)
+        if match:
+            return INFRA, reason
+
+    return FAIL, _failure_detail(log)
+
+
+def _failure_detail(log: str) -> str:
+    """The most useful line or two from a failing build log.
+
+    Prefers the line naming the instruction that failed, since that is what
+    tells the reader where to look; falls back to the tail.
+    """
+    lines = [line.rstrip() for line in log.splitlines() if line.strip()]
+    for line in reversed(lines):
+        if re.search(
+            r"^ERROR|did not complete successfully|executor failed",
+            line,
+            re.IGNORECASE,
+        ):
+            return line[:300]
+    return lines[-1][:300] if lines else ""
+
+
+def log_tail(log: str, limit: int = LOG_TAIL_LINES) -> str:
+    lines = [line.rstrip() for line in log.splitlines() if line.strip()]
+    return "\n".join(lines[-limit:])
+
+
+# ---------------------------------------------------------------------------
+# gh plumbing
+# ---------------------------------------------------------------------------
+
+
+def gh(*args: str, check: bool = True) -> str:
+    """Run `gh`. Mirrors canary_issues.gh, including never swallowing a
+    failure: a reporter that cannot reach GitHub must fail loudly."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        raise ReportError(
+            f"gh {' '.join(args)} failed ({result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def pull_request_for_commit(sha: str) -> int | None:
+    """The pull request a commit on main came from, or None.
+
+    A squash merge leaves the number in the commit subject, but parsing that
+    breaks on a subject that merely mentions one. The API answers directly.
+    None is a legitimate answer — a direct push to main has no pull request —
+    and the caller falls back to an issue rather than staying silent.
+    """
+    raw = gh(
+        "api",
+        f"repos/{REPO}/commits/{sha}/pulls",
+        "-H",
+        "Accept: application/vnd.github+json",
+        check=False,
+    )
+    try:
+        prs = json.loads(raw or "[]")
+    except json.JSONDecodeError:
+        return None
+    for pr in prs:
+        if isinstance(pr, dict) and pr.get("number"):
+            return int(pr["number"])
+    return None
+
+
+def images_that_failed_in_the_previous_run(current_run_id: str) -> set[str]:
+    """Images whose build job failed in the last completed run before this one.
+
+    The run history IS the state. The alternative — a label, a file, a issue
+    body counter — has to be kept in sync with reality, and the first run
+    after it is introduced behaves differently from every later one because
+    the state does not exist yet.
+
+    Returns an empty set on any difficulty reaching the API. That biases
+    toward commenting without opening an issue, which is the recoverable
+    direction: the next failure opens it.
+    """
+    try:
+        raw = gh(
+            "api",
+            f"repos/{REPO}/actions/workflows/{WORKFLOW_FILE}/runs"
+            "?branch=main&event=push&status=completed&per_page=5",
+            check=False,
+        )
+        parsed = json.loads(raw or "{}")
+        # `.get` on a list is an AttributeError, and the API returns a bare
+        # list on some error shapes. Guarding the TYPE rather than only the
+        # decode is what keeps a bad response from taking the whole report
+        # down after the pull request comment has already been posted.
+        runs = (
+            parsed.get("workflow_runs") or []
+            if isinstance(parsed, dict)
+            else []
+        )
+    except (json.JSONDecodeError, ReportError):
+        return set()
+
+    previous = next(
+        (r for r in runs if str(r.get("id")) != str(current_run_id)), None
+    )
+    if not previous:
+        return set()
+
+    try:
+        raw = gh(
+            "api",
+            f"repos/{REPO}/actions/runs/{previous['id']}/jobs?per_page=100",
+            check=False,
+        )
+        parsed = json.loads(raw or "{}")
+        jobs = parsed.get("jobs") or [] if isinstance(parsed, dict) else []
+    except (json.JSONDecodeError, ReportError):
+        return set()
+
+    failed = set()
+    for job in jobs:
+        name = str(job.get("name") or "")
+        if job.get("conclusion") == "failure" and name.startswith("build "):
+            failed.add(name[len("build ") :].strip())
+    return failed
+
+
+# ---------------------------------------------------------------------------
+# Report bodies
+# ---------------------------------------------------------------------------
+
+
+def comment_body(failures: list[dict], run_url: str, sha: str) -> str:
+    plural = "image" if len(failures) == 1 else "images"
+    lines = [
+        f"### Recipe {plural} failed to build on `main`",
+        "",
+        f"The merge of {sha[:8]} broke the container build for "
+        f"{len(failures)} declared {plural}. Nothing was published.",
+        "",
+    ]
+    for entry in failures:
+        lines += [
+            f"**`{entry['image']}`** — `{entry.get('dockerfile', '?')}`",
+            "",
+            "```",
+            entry.get("tail") or entry.get("detail") or "(no output captured)",
+            "```",
+            "",
+        ]
+    lines += [
+        f"[Full logs]({run_url})",
+        "",
+        "This is the build only — publishing is separate and did not run. "
+        "Reproduce locally with:",
+        "",
+        "```bash",
+        f"docker build -f {failures[0].get('dockerfile', 'Dockerfile')} "
+        f"{failures[0].get('context', '.')}",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def issue_title(image: str) -> str:
+    """Stable across runs — it is the dedupe key, so nothing varying (a SHA,
+    a date, the error text) may appear in it."""
+    return f"{TITLE_PREFIX} {image}"
+
+
+def issue_body(entry: dict, run_url: str, previous_note: str) -> str:
+    return "\n".join(
+        [
+            f"`{entry['image']}` has now failed to build on `main` "
+            f"{previous_note}.",
+            "",
+            f"- Dockerfile: `{entry.get('dockerfile', '?')}`",
+            f"- Build context: `{entry.get('context', '?')}`",
+            "- Declared in: `.github/policy.yml` "
+            "(`deployability.publish.images`)",
+            "",
+            "```",
+            entry.get("tail") or entry.get("detail") or "(no output captured)",
+            "```",
+            "",
+            f"[Latest run]({run_url})",
+            "",
+            "Until this builds, the image is not published. Either fix the "
+            "Dockerfile or remove the entry from `deployability.publish` — "
+            "an image declared and permanently broken is worse than one not "
+            "declared, because the failure is reported every time anything "
+            "in the recipe changes.",
+            "",
+            f"cc @{MAINTAINER}",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_classify(args: argparse.Namespace) -> int:
+    log = ""
+    if args.log:
+        try:
+            log = Path(args.log).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            # Treated as no evidence rather than as an error: the classifier's
+            # whole job is to produce a verdict, and a missing log has one.
+            log = ""
+
+    verdict, detail = classify(args.outcome, log)
+    result = {
+        "image": args.image,
+        "dockerfile": args.dockerfile or "",
+        "context": args.context or "",
+        "outcome": verdict,
+        "detail": detail,
+        "tail": log_tail(log) if verdict == FAIL else "",
+    }
+    Path(args.out).write_text(json.dumps(result), encoding="utf-8")
+    print(f"{args.image}: {verdict}" + (f" — {detail}" if detail else ""))
+    return 0
+
+
+def load_results(results_dir: Path) -> list[dict[str, Any]]:
+    entries = []
+    for path in sorted(results_dir.rglob("result.json")):
+        try:
+            entries.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"WARNING: cannot read {path}: {exc}", file=sys.stderr)
+    return entries
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    entries = load_results(Path(args.results))
+    if not entries:
+        # Distinguished from "everything passed": the build job writes a
+        # result for every leg including the ones that passed, so no results
+        # at all means the collection broke, not that nothing ran.
+        print(
+            "error: no results found. The build jobs did not upload any, "
+            "so this run cannot say whether anything failed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures = [e for e in entries if e.get("outcome") == FAIL]
+    infra = [e for e in entries if e.get("outcome") == INFRA]
+    passed = [e for e in entries if e.get("outcome") == PASS]
+
+    print(
+        f"{len(entries)} image(s): {len(passed)} pass, "
+        f"{len(failures)} fail, {len(infra)} infra"
+    )
+    for entry in entries:
+        print(
+            f"  {entry.get('outcome', '?'):5}  {entry.get('image')}"
+            + (f" — {entry['detail']}" if entry.get("detail") else "")
+        )
+
+    if infra and not failures:
+        # Deliberately silent. Reporting infrastructure noise to an author is
+        # precisely what makes a channel ignorable.
+        print(
+            "\nOnly infrastructure failures; nothing reported to anyone. "
+            "Re-run the workflow."
+        )
+
+    # Recovery is handled BEFORE the early return below, because "no
+    # failures" is exactly the case a recovery looks like. An earlier version
+    # returned first and left every tracking issue open forever — the close
+    # path was unreachable code that read as if it worked.
+    _close_recovered(passed, args)
+
+    if not failures:
+        return 0
+
+    if len(failures) > MAX_ISSUES_PER_RUN:
+        print(
+            f"WARNING: {len(failures)} images failed at once, above the "
+            f"{MAX_ISSUES_PER_RUN} this run will open issues for. Something "
+            f"systemic is more likely than {len(failures)} independent "
+            f"breakages; commenting only.",
+            file=sys.stderr,
+        )
+
+    # --- the pull request comment ------------------------------------------
+    pr = pull_request_for_commit(args.sha) if args.sha else None
+    body = comment_body(failures, args.run_url, args.sha or "")
+    if pr is None:
+        print("\nNo pull request found for this commit (a direct push?).")
+    elif args.dry_run:
+        print(f"\n[dry-run] would comment on #{pr}:\n{body}\n")
+    else:
+        gh("issue", "comment", str(pr), "--repo", REPO, "--body", body)
+        print(f"\nCommented on #{pr}.")
+
+    # --- the issue, only on a repeat ---------------------------------------
+    repeats = images_that_failed_in_the_previous_run(args.run_id or "")
+    opened = 0
+    for entry in failures:
+        image = entry["image"]
+        if image not in repeats:
+            print(f"{image}: first failure — commented, no issue opened.")
+            continue
+        if opened >= MAX_ISSUES_PER_RUN:
+            print(f"{image}: issue cap reached, skipping.")
+            continue
+
+        title = issue_title(image)
+        existing = _find_open_issue(title)
+        note = "twice in a row"
+        if existing:
+            if args.dry_run:
+                print(f"[dry-run] would comment on issue #{existing}")
+            else:
+                gh(
+                    "issue",
+                    "comment",
+                    str(existing),
+                    "--repo",
+                    REPO,
+                    "--body",
+                    f"Still failing as of {args.sha[:8] if args.sha else '?'}"
+                    f" — [run]({args.run_url}).",
+                )
+                print(f"{image}: commented on existing issue #{existing}.")
+            continue
+
+        if args.dry_run:
+            print(f"[dry-run] would open an issue titled {title!r}")
+        else:
+            _ensure_label()
+            gh(
+                "issue",
+                "create",
+                "--repo",
+                REPO,
+                "--title",
+                title,
+                "--label",
+                LABEL_TRACKING,
+                "--body",
+                issue_body(entry, args.run_url, note),
+            )
+            print(f"{image}: opened a tracking issue.")
+        opened += 1
+
+    return 0
+
+
+def _close_recovered(passed: list[dict], args: argparse.Namespace) -> None:
+    """Close the tracking issue of any image that is building again."""
+    for entry in passed:
+        existing = _find_open_issue(issue_title(entry["image"]))
+        if not existing:
+            continue
+        if args.dry_run:
+            print(f"[dry-run] would close issue #{existing}")
+            continue
+        gh(
+            "issue",
+            "close",
+            str(existing),
+            "--repo",
+            REPO,
+            "--comment",
+            f"Building again as of {args.sha[:8] if args.sha else '?'}.",
+        )
+        print(f"{entry['image']}: closed issue #{existing}.")
+
+
+def _find_open_issue(title: str) -> int | None:
+    """Exact title match among open tracking issues.
+
+    Never a prefix match: `demo` must not be handed the issue belonging to
+    `demo-sandbox`, which would report one image's failure on another's
+    thread.
+    """
+    raw = gh(
+        "issue",
+        "list",
+        "--repo",
+        REPO,
+        "--state",
+        "open",
+        "--label",
+        LABEL_TRACKING,
+        "--limit",
+        "100",
+        "--json",
+        "number,title",
+        check=False,
+    )
+    try:
+        for issue in json.loads(raw or "[]"):
+            if issue.get("title") == title:
+                return int(issue["number"])
+    except json.JSONDecodeError:
+        return None
+    return None
+
+
+def _ensure_label() -> None:
+    gh(
+        "label",
+        "create",
+        LABEL_TRACKING,
+        "--repo",
+        REPO,
+        "--description",
+        "A declared recipe image is failing to build",
+        "--color",
+        "B60205",
+        check=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    c = sub.add_parser("classify", help="Classify one image's build result.")
+    c.add_argument("--image", required=True)
+    c.add_argument("--outcome", required=True, help="The build step outcome.")
+    c.add_argument("--log", help="Path to the captured build log.")
+    c.add_argument("--dockerfile", default="")
+    c.add_argument("--context", default="")
+    c.add_argument("--out", required=True, help="Where to write result.json.")
+    c.set_defaults(func=cmd_classify)
+
+    r = sub.add_parser("report", help="Collate results and report failures.")
+    r.add_argument("--results", required=True, help="Directory of results.")
+    r.add_argument("--run-url", default="")
+    r.add_argument("--run-id", default="")
+    r.add_argument("--sha", default="")
+    r.add_argument("--dry-run", action="store_true")
+    r.set_defaults(func=cmd_report)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except ReportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/image_build_report.py
+++ b/.github/scripts/image_build_report.py
@@ -126,6 +126,10 @@ BUILD_JOB_PREFIX = "build "
 # the next run catches, while a false `fail` costs the channel's credibility.
 #
 # Matched case-insensitively against the build log.
+# One reason string shared by the three spellings below, so the wording
+# they report cannot drift apart.
+_REGISTRY_5XX = "registry returned a server error"
+
 INFRA_SIGNATURES: tuple[tuple[str, str], ...] = (
     # Registry and network.
     #
@@ -134,19 +138,16 @@ INFRA_SIGNATURES: tuple[tuple[str, str], ...] = (
     # docker reports it, and a signature matching only one order would blame
     # the recipe for the other — which is how the first version of this list
     # misclassified a real 503 from docker.io.
-    (
-        r"unexpected (?:http )?status:?\s*(?:50\d|429)",
-        "registry returned a server error",
-    ),
+    (r"unexpected (?:http )?status:?\s*(?:50\d|429)", _REGISTRY_5XX),
     (
         r"\b(?:50\d|429)\b[^\n]{0,160}"
         r"(?:registry|docker\.io|pkg\.dev|ghcr\.io)",
-        "registry returned a server error",
+        _REGISTRY_5XX,
     ),
     (
         r"(?:registry|docker\.io|pkg\.dev|ghcr\.io)[^\n]{0,160}"
         r"\b(?:50\d|429)\b",
-        "registry returned a server error",
+        _REGISTRY_5XX,
     ),
     (r"toomanyrequests|rate limit|too many requests", "registry rate limit"),
     (

--- a/.github/scripts/image_build_report.py
+++ b/.github/scripts/image_build_report.py
@@ -73,10 +73,18 @@ import sys
 from pathlib import Path
 from typing import Any
 
-REPO = os.environ.get("GITHUB_REPOSITORY", "google/adk-samples")
+# The default is for reading and for tests. Writing with it is refused —
+# see _require_explicit_repo(). Without that guard, running the report
+# subcommand anywhere GITHUB_REPOSITORY is unset would post comments and
+# open issues on google/adk-samples, which is the wrong repository for
+# everyone who is not CI.
+DEFAULT_REPO = "google/adk-samples"
+REPO = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO)
 WORKFLOW_FILE = "recipe-images.yml"
 
 # Who is told when a failure needs a human and no better address exists.
+# The repository's CODEOWNERS catch-all, and the same value canary_issues.py
+# uses for the same purpose.
 MAINTAINER = "happyhuman"
 
 TITLE_PREFIX = "Recipe image build failing:"
@@ -85,6 +93,11 @@ LABEL_TRACKING = "recipe-image-build"
 # How many log lines to quote back. Enough to show the failing instruction
 # and its error, short enough that a comment stays readable.
 LOG_TAIL_LINES = 25
+
+# How much of the one-line summary to keep. Long enough for a docker error
+# naming the failing instruction, short enough that a result.json stays small
+# and a printed summary line stays on one row.
+MAX_DETAIL_CHARS = 300
 
 # Upper bound on issues one run will open. Sized well above routine breakage
 # — three images are declared today — and below "something is systemically
@@ -249,8 +262,8 @@ def _failure_detail(log: str) -> str:
             line,
             re.IGNORECASE,
         ):
-            return line[:300]
-    return lines[-1][:300] if lines else ""
+            return line[:MAX_DETAIL_CHARS]
+    return lines[-1][:MAX_DETAIL_CHARS] if lines else ""
 
 
 def log_tail(log: str, limit: int = LOG_TAIL_LINES) -> str:
@@ -538,7 +551,29 @@ def load_results(results_dir: Path) -> list[dict[str, Any]]:
     return entries
 
 
+def _require_explicit_repo(dry_run: bool) -> None:
+    """Refuse to write to the fallback repository.
+
+    `REPO` falls back to DEFAULT_REPO so the module imports cleanly and the
+    tests need no environment. That is harmless for reading and for
+    `--dry-run`, and dangerous for anything else: run the report subcommand
+    on a laptop, or in a fork whose workflow forgot the variable, and it
+    would post comments and open issues on google/adk-samples.
+
+    CI always sets GITHUB_REPOSITORY, so this costs the real caller nothing.
+    """
+    if dry_run:
+        return
+    if not os.environ.get("GITHUB_REPOSITORY"):
+        raise ReportError(
+            "GITHUB_REPOSITORY is not set, so the target repository would "
+            f"fall back to {DEFAULT_REPO}. Refusing to comment or open "
+            "issues there. Set it, or pass --dry-run."
+        )
+
+
 def cmd_report(args: argparse.Namespace) -> int:
+    _require_explicit_repo(args.dry_run)
     entries = load_results(Path(args.results))
     if not entries:
         # Distinguished from "everything passed": the build job writes a

--- a/.github/scripts/image_build_report.py
+++ b/.github/scripts/image_build_report.py
@@ -93,6 +93,19 @@ LOG_TAIL_LINES = 25
 # size implies its own inputs are broken.
 MAX_ISSUES_PER_RUN = 5
 
+# How many past runs to walk when asking "did this image fail last time it
+# was built". Deep enough to see through a stretch of merges that touched
+# other recipes, shallow enough to cost a handful of API calls. Beyond this
+# the answer is "no recent evidence", which biases toward not opening an
+# issue — the recoverable direction.
+RUN_HISTORY_DEPTH = 10
+
+# The build job's name is `build <image>`; the matrix leg names come from
+# the workflow's `name:` expression. Parsing them back is the only way to
+# map a historical job to an image, so the two must agree — enforced by
+# test_the_build_job_name_matches_what_the_reporter_parses.
+BUILD_JOB_PREFIX = "build "
+
 # Log signatures that mean the infrastructure failed, not the recipe.
 #
 # Each is a real docker/registry failure mode with a distinctive string. The
@@ -289,23 +302,69 @@ def pull_request_for_commit(sha: str) -> int | None:
     return None
 
 
-def images_that_failed_in_the_previous_run(current_run_id: str) -> set[str]:
-    """Images whose build job failed in the last completed run before this one.
+def images_that_failed_in_the_previous_run(
+    current_run_id: str, wanted: set[str] | None = None
+) -> set[str]:
+    """Images that failed THE LAST TIME EACH WAS BUILT, not merely last run.
 
-    The run history IS the state. The alternative — a label, a file, a issue
-    body counter — has to be kept in sync with reality, and the first run
-    after it is introduced behaves differently from every later one because
-    the state does not exist yet.
+    The distinction is the whole correctness of this function, because builds
+    are affected-only. The realistic sequence is:
 
-    Returns an empty set on any difficulty reaching the API. That biases
+        run A   demo fails
+        run B   a merge touching another recipe; demo is not built at all
+        run C   a merge touching another recipe; demo is not built at all
+        run D   demo fails again
+
+    Asking "did demo fail in the run immediately before D" answers no — run C
+    never built it — so D reads as a first failure, and it reads that way
+    every time. An earlier version did exactly that, which made the issue
+    path unreachable in practice rather than merely rare.
+
+    So this walks back through recent runs and, for each image, takes the
+    verdict from the most recent run that ACTUALLY BUILT it. Runs that
+    skipped an image are transparent to that image and opaque to no other.
+
+    The run history IS the state. The alternative — a label, a file, a
+    counter in an issue body — has to be kept in sync with reality, and the
+    first run after it is introduced behaves differently from every later one
+    because the state does not exist yet.
+
+    Returns an empty set on any difficulty reaching the API: that biases
     toward commenting without opening an issue, which is the recoverable
-    direction: the next failure opens it.
+    direction, since the next failure opens it.
     """
+    runs = _recent_completed_runs()
+    if not runs:
+        return set()
+
+    # image -> conclusion from the most recent run that built it.
+    seen: dict[str, str] = {}
+    for run in runs:
+        if str(run.get("id")) == str(current_run_id):
+            continue
+        for image, conclusion in _build_job_outcomes(run.get("id")).items():
+            # First writer wins: runs arrive newest-first, so the first time
+            # an image appears is the most recent build of it.
+            seen.setdefault(image, conclusion)
+        # Stop once every image the caller asked about has a verdict. Each
+        # extra run costs an API call, and in the common case — the previous
+        # run built the same image — the answer is complete after one.
+        # Without this the walk always cost RUN_HISTORY_DEPTH calls, which is
+        # the n-calls-for-one-question shape canary_issues warns about.
+        if wanted and wanted <= set(seen):
+            break
+
+    return {img for img, concl in seen.items() if concl == "failure"}
+
+
+def _recent_completed_runs() -> list[dict]:
+    """Recent completed push-to-main runs of this workflow, newest first."""
     try:
         raw = gh(
             "api",
             f"repos/{REPO}/actions/workflows/{WORKFLOW_FILE}/runs"
-            "?branch=main&event=push&status=completed&per_page=5",
+            f"?branch=main&event=push&status=completed"
+            f"&per_page={RUN_HISTORY_DEPTH}",
             check=False,
         )
         parsed = json.loads(raw or "{}")
@@ -313,37 +372,42 @@ def images_that_failed_in_the_previous_run(current_run_id: str) -> set[str]:
         # list on some error shapes. Guarding the TYPE rather than only the
         # decode is what keeps a bad response from taking the whole report
         # down after the pull request comment has already been posted.
-        runs = (
-            parsed.get("workflow_runs") or []
-            if isinstance(parsed, dict)
-            else []
-        )
+        if not isinstance(parsed, dict):
+            return []
+        runs = parsed.get("workflow_runs") or []
+        return [r for r in runs if isinstance(r, dict)]
     except (json.JSONDecodeError, ReportError):
-        return set()
+        return []
 
-    previous = next(
-        (r for r in runs if str(r.get("id")) != str(current_run_id)), None
-    )
-    if not previous:
-        return set()
 
+def _build_job_outcomes(run_id: Any) -> dict[str, str]:
+    """image -> job conclusion for the build legs of one run."""
+    if run_id is None:
+        return {}
     try:
         raw = gh(
             "api",
-            f"repos/{REPO}/actions/runs/{previous['id']}/jobs?per_page=100",
+            f"repos/{REPO}/actions/runs/{run_id}/jobs?per_page=100",
             check=False,
         )
         parsed = json.loads(raw or "{}")
-        jobs = parsed.get("jobs") or [] if isinstance(parsed, dict) else []
+        if not isinstance(parsed, dict):
+            return {}
+        jobs = parsed.get("jobs") or []
     except (json.JSONDecodeError, ReportError):
-        return set()
+        return {}
 
-    failed = set()
+    outcomes: dict[str, str] = {}
     for job in jobs:
+        if not isinstance(job, dict):
+            continue
         name = str(job.get("name") or "")
-        if job.get("conclusion") == "failure" and name.startswith("build "):
-            failed.add(name[len("build ") :].strip())
-    return failed
+        if not name.startswith(BUILD_JOB_PREFIX):
+            continue
+        image = name[len(BUILD_JOB_PREFIX) :].strip()
+        if image:
+            outcomes[image] = str(job.get("conclusion") or "")
+    return outcomes
 
 
 # ---------------------------------------------------------------------------
@@ -353,14 +417,21 @@ def images_that_failed_in_the_previous_run(current_run_id: str) -> set[str]:
 
 def comment_body(failures: list[dict], run_url: str, sha: str) -> str:
     plural = "image" if len(failures) == 1 else "images"
+    merge = f"The merge of {sha[:8]}" if sha else "This merge"
     lines = [
         f"### Recipe {plural} failed to build on `main`",
         "",
-        f"The merge of {sha[:8]} broke the container build for "
-        f"{len(failures)} declared {plural}. Nothing was published.",
+        f"{merge} broke the container build for {len(failures)} declared "
+        f"{plural}. Nothing was published — the build and the publish step "
+        f"are separate, and publishing did not run.",
         "",
     ]
     for entry in failures:
+        # The reproduce command goes with EACH image, not once at the end.
+        # An earlier version printed only the first failure's command below
+        # the whole list, which reads as though it covers all of them — so
+        # someone with three broken images would run one build, see it pass
+        # after a fix, and believe they were done.
         lines += [
             f"**`{entry['image']}`** — `{entry.get('dockerfile', '?')}`",
             "",
@@ -368,18 +439,13 @@ def comment_body(failures: list[dict], run_url: str, sha: str) -> str:
             entry.get("tail") or entry.get("detail") or "(no output captured)",
             "```",
             "",
+            "```bash",
+            f"docker build -f {entry.get('dockerfile', 'Dockerfile')} "
+            f"{entry.get('context', '.')}",
+            "```",
+            "",
         ]
-    lines += [
-        f"[Full logs]({run_url})",
-        "",
-        "This is the build only — publishing is separate and did not run. "
-        "Reproduce locally with:",
-        "",
-        "```bash",
-        f"docker build -f {failures[0].get('dockerfile', 'Dockerfile')} "
-        f"{failures[0].get('context', '.')}",
-        "```",
-    ]
+    lines += [f"[Full logs]({run_url})"]
     return "\n".join(lines)
 
 
@@ -447,12 +513,28 @@ def cmd_classify(args: argparse.Namespace) -> int:
 
 
 def load_results(results_dir: Path) -> list[dict[str, Any]]:
+    """Every result.json under `results_dir`, skipping anything unusable.
+
+    Shape is checked, not assumed. A file that is valid JSON but not an
+    object — or an object with no `image` — would otherwise raise deep in the
+    reporting logic, potentially after a comment has already been posted, and
+    the run would look like a reporter bug rather than a corrupt artifact.
+    """
     entries = []
     for path in sorted(results_dir.rglob("result.json")):
         try:
-            entries.append(json.loads(path.read_text(encoding="utf-8")))
+            entry = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             print(f"WARNING: cannot read {path}: {exc}", file=sys.stderr)
+            continue
+        if not isinstance(entry, dict) or not entry.get("image"):
+            print(
+                f"WARNING: {path} is not a usable result (no image); "
+                f"ignoring it",
+                file=sys.stderr,
+            )
+            continue
+        entries.append(entry)
     return entries
 
 
@@ -495,17 +577,33 @@ def cmd_report(args: argparse.Namespace) -> int:
     # failures" is exactly the case a recovery looks like. An earlier version
     # returned first and left every tracking issue open forever — the close
     # path was unreachable code that read as if it worked.
-    _close_recovered(passed, args)
+    # ONE snapshot for the whole run, taken here and passed down.
+    # canary_issues.open_issues_by_title documents why a lookup inside a
+    # loop is wrong: n subprocesses and n chances to hit a rate limit, to
+    # answer a question one call already answers. Taking it twice — once
+    # for recoveries and once for failures — was a smaller version of the
+    # same mistake.
+    open_issues = _open_tracking_issues()
+
+    _close_recovered(passed, args, open_issues)
 
     if not failures:
         return 0
 
-    if len(failures) > MAX_ISSUES_PER_RUN:
+    # Above the cap, comment and open NOTHING. The message used to say
+    # "commenting only" while the loop below went on opening issues up to the
+    # cap anyway — the log said one thing and the tracker showed another.
+    # Refusing outright is also the better behaviour: this many failures at
+    # once is far more likely to be one systemic cause than N independent
+    # breakages, and N issues would each be wrong about what to fix.
+    file_issues = len(failures) <= MAX_ISSUES_PER_RUN
+    if not file_issues:
         print(
             f"WARNING: {len(failures)} images failed at once, above the "
-            f"{MAX_ISSUES_PER_RUN} this run will open issues for. Something "
-            f"systemic is more likely than {len(failures)} independent "
-            f"breakages; commenting only.",
+            f"{MAX_ISSUES_PER_RUN} this run will file for. That is more "
+            f"likely one systemic cause than {len(failures)} independent "
+            f"breakages, so no issues are being opened — the pull request "
+            f"comment is the whole report for this run.",
             file=sys.stderr,
         )
 
@@ -521,20 +619,25 @@ def cmd_report(args: argparse.Namespace) -> int:
         print(f"\nCommented on #{pr}.")
 
     # --- the issue, only on a repeat ---------------------------------------
-    repeats = images_that_failed_in_the_previous_run(args.run_id or "")
-    opened = 0
+    if not file_issues:
+        return 0
+
+    repeats = images_that_failed_in_the_previous_run(
+        args.run_id or "", {e["image"] for e in failures}
+    )
+    # One snapshot for the whole run, not one lookup per image.
+    # canary_issues.open_issues_by_title documents why: a lookup inside the
+    # loop is n subprocesses and n chances to hit a rate limit, to answer a
+    # question one call already answers.
     for entry in failures:
         image = entry["image"]
         if image not in repeats:
             print(f"{image}: first failure — commented, no issue opened.")
             continue
-        if opened >= MAX_ISSUES_PER_RUN:
-            print(f"{image}: issue cap reached, skipping.")
-            continue
 
         title = issue_title(image)
-        existing = _find_open_issue(title)
-        note = "twice in a row"
+        existing = open_issues.get(title)
+        note = "again since it was last built"
         if existing:
             if args.dry_run:
                 print(f"[dry-run] would comment on issue #{existing}")
@@ -569,15 +672,18 @@ def cmd_report(args: argparse.Namespace) -> int:
                 issue_body(entry, args.run_url, note),
             )
             print(f"{image}: opened a tracking issue.")
-        opened += 1
 
     return 0
 
 
-def _close_recovered(passed: list[dict], args: argparse.Namespace) -> None:
+def _close_recovered(
+    passed: list[dict],
+    args: argparse.Namespace,
+    open_issues: dict[str, int],
+) -> None:
     """Close the tracking issue of any image that is building again."""
     for entry in passed:
-        existing = _find_open_issue(issue_title(entry["image"]))
+        existing = open_issues.get(issue_title(entry["image"]))
         if not existing:
             continue
         if args.dry_run:
@@ -595,12 +701,12 @@ def _close_recovered(passed: list[dict], args: argparse.Namespace) -> None:
         print(f"{entry['image']}: closed issue #{existing}.")
 
 
-def _find_open_issue(title: str) -> int | None:
-    """Exact title match among open tracking issues.
+def _open_tracking_issues() -> dict[str, int]:
+    """Open tracking issues indexed by EXACT title. One `gh` call per run.
 
-    Never a prefix match: `demo` must not be handed the issue belonging to
-    `demo-sandbox`, which would report one image's failure on another's
-    thread.
+    Exact keys, never a prefix scan: `demo` must not be handed the issue
+    belonging to `demo-sandbox-runtime`, which would report one image's
+    failure on another image's thread.
     """
     raw = gh(
         "issue",
@@ -618,12 +724,18 @@ def _find_open_issue(title: str) -> int | None:
         check=False,
     )
     try:
-        for issue in json.loads(raw or "[]"):
-            if issue.get("title") == title:
-                return int(issue["number"])
+        parsed = json.loads(raw or "[]")
     except json.JSONDecodeError:
-        return None
-    return None
+        return {}
+    if not isinstance(parsed, list):
+        return {}
+    return {
+        issue["title"]: int(issue["number"])
+        for issue in parsed
+        if isinstance(issue, dict)
+        and issue.get("title")
+        and issue.get("number")
+    }
 
 
 def _ensure_label() -> None:

--- a/.github/scripts/tests/test_image_build_report.py
+++ b/.github/scripts/tests/test_image_build_report.py
@@ -34,6 +34,20 @@ from pathlib import Path
 import image_build_report as m
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def repo_env(monkeypatch):
+    """Run every test as CI does, with GITHUB_REPOSITORY set.
+
+    cmd_report refuses to write when it is absent, because the module-level
+    fallback would otherwise aim comments and issues at google/adk-samples
+    from anyone's laptop. Tests that exercise the writing paths therefore
+    have to supply it; test_writing_without_an_explicit_repo_is_refused
+    covers the opposite case deliberately.
+    """
+    monkeypatch.setenv("GITHUB_REPOSITORY", "google/adk-samples")
+
+
 # --------------------------------------------------------------------------
 # The evidence rule
 # --------------------------------------------------------------------------
@@ -184,7 +198,7 @@ def test_log_tail_is_bounded():
 # --------------------------------------------------------------------------
 
 
-def test_classify_writes_a_result_file(tmp_path: Path, capsys):
+def test_classify_writes_a_result_file(tmp_path: Path):
     log = tmp_path / "build.log"
     log.write_text("no space left on device", encoding="utf-8")
     out = tmp_path / "result.json"
@@ -305,9 +319,7 @@ def no_network(monkeypatch):
     return calls
 
 
-def test_report_says_nothing_when_everything_passed(
-    tmp_path: Path, no_network, capsys
-):
+def test_report_says_nothing_when_everything_passed(tmp_path: Path, no_network):
     _result(tmp_path, 0, outcome="pass")
 
     rc = m.main(["report", "--results", str(tmp_path / "results")])
@@ -330,7 +342,7 @@ def test_report_stays_silent_on_infrastructure_failures(
 
 
 def test_report_comments_on_the_pull_request_for_a_real_failure(
-    tmp_path: Path, no_network, capsys
+    tmp_path: Path, no_network
 ):
     _result(tmp_path, 0, outcome="fail", detail="boom", tail="ERROR: boom")
 
@@ -376,7 +388,7 @@ def test_no_issue_is_opened_on_a_first_failure(
 
 
 def test_an_issue_is_opened_when_the_same_image_fails_again(
-    tmp_path: Path, no_network, monkeypatch, capsys
+    tmp_path: Path, no_network, monkeypatch
 ):
     _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
     monkeypatch.setattr(
@@ -401,7 +413,7 @@ def test_an_issue_is_opened_when_the_same_image_fails_again(
 
 
 def test_a_repeat_with_an_existing_issue_comments_instead_of_duplicating(
-    tmp_path: Path, monkeypatch, capsys
+    tmp_path: Path, monkeypatch
 ):
     _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
     calls: list[tuple[str, ...]] = []
@@ -429,9 +441,7 @@ def test_a_repeat_with_an_existing_issue_comments_instead_of_duplicating(
     assert any(c[:3] == ("issue", "comment", "77") for c in calls)
 
 
-def test_a_recovered_image_closes_its_issue(
-    tmp_path: Path, monkeypatch, capsys
-):
+def test_a_recovered_image_closes_its_issue(tmp_path: Path, monkeypatch):
     _result(tmp_path, 0, outcome="pass")
     calls: list[tuple[str, ...]] = []
 
@@ -517,9 +527,7 @@ def test_dry_run_writes_nothing(tmp_path: Path, no_network, capsys):
     assert "[dry-run]" in capsys.readouterr().out
 
 
-def test_a_mixed_run_reports_only_the_real_failure(
-    tmp_path: Path, no_network, capsys
-):
+def test_a_mixed_run_reports_only_the_real_failure(tmp_path: Path, no_network):
     # Distinctive names on purpose. An earlier version used "ok", which is a
     # substring of "broke" in the comment body, so the assertion failed for a
     # reason that had nothing to do with the code under test.
@@ -732,9 +740,7 @@ def test_a_corrupt_result_file_is_skipped_not_fatal(
     assert "not a usable result" in capsys.readouterr().err
 
 
-def test_the_issue_index_is_fetched_once_per_run(
-    tmp_path: Path, monkeypatch, capsys
-):
+def test_the_issue_index_is_fetched_once_per_run(tmp_path: Path, monkeypatch):
     """canary_issues documents why: a lookup inside the loop is n
     subprocesses and n chances to hit a rate limit, to answer a question one
     call already answers."""
@@ -794,7 +800,7 @@ def test_the_history_walk_keeps_going_until_it_finds_the_image(monkeypatch):
 
 
 def test_an_infra_failure_leaves_an_existing_issue_alone(
-    tmp_path: Path, monkeypatch, capsys
+    tmp_path: Path, monkeypatch
 ):
     """Infrastructure trouble says nothing about the recipe, so it must
     neither open, comment on, nor close a tracking issue."""
@@ -843,3 +849,30 @@ def test_the_issue_index_is_fetched_once_even_with_both_passes_and_failures(
     )
 
     assert len([c for c in calls if c[:2] == ("issue", "list")]) == 1
+
+
+def test_writing_without_an_explicit_repo_is_refused(
+    tmp_path: Path, monkeypatch, capsys
+):
+    """Run this on a laptop with GITHUB_REPOSITORY unset and the fallback
+    would post comments and open issues on google/adk-samples."""
+    _result(tmp_path, 0, outcome="fail", tail="E: boom")
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.setattr(m, "gh", lambda *a, **k: "[]")
+
+    rc = m.main(["report", "--results", str(tmp_path / "results")])
+
+    assert rc == 1
+    assert "GITHUB_REPOSITORY is not set" in capsys.readouterr().err
+
+
+def test_dry_run_needs_no_repo(tmp_path: Path, monkeypatch, capsys):
+    """Reading and previewing are safe without it; only writing is not."""
+    _result(tmp_path, 0, outcome="fail", tail="E: boom")
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.setattr(m, "gh", lambda *a, **k: "[]")
+
+    assert (
+        m.main(["report", "--results", str(tmp_path / "results"), "--dry-run"])
+        == 0
+    )

--- a/.github/scripts/tests/test_image_build_report.py
+++ b/.github/scripts/tests/test_image_build_report.py
@@ -1,0 +1,589 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for image_build_report.py.
+
+The classifier decides whether a human gets told their change broke
+something. Both mistakes it can make are tested here, because they are not
+equally expensive:
+
+  * calling infrastructure trouble a recipe failure blames an author for a
+    registry timeout, and a channel that does that once gets ignored
+    afterwards, including when it is right;
+  * calling a recipe failure infrastructure loses one report, which the next
+    run recovers.
+
+So the bias is deliberate and asserted: every path to a verdict without a log
+to read must land on `infra`, and `fail` must require log text that matched
+no infrastructure signature.
+"""
+
+import json
+from pathlib import Path
+
+import image_build_report as m
+import pytest
+
+# --------------------------------------------------------------------------
+# The evidence rule
+# --------------------------------------------------------------------------
+
+
+def test_a_successful_build_passes():
+    assert m.classify("success", "anything at all")[0] == m.PASS
+
+
+@pytest.mark.parametrize("outcome", ["", "skipped", "cancelled"])
+def test_a_build_that_never_ran_is_never_the_recipes_fault(outcome: str):
+    """Checkout, the mode step or the runner died first. Nothing was learned
+    about the recipe, so nothing may be said about it."""
+    verdict, detail = m.classify(outcome, "")
+
+    assert verdict == m.INFRA
+    assert "did not run" in detail
+
+
+@pytest.mark.parametrize("log", ["", "   \n  \n", None])
+def test_a_failure_with_no_log_is_infra(log):
+    """docker creates the log before it starts, so an empty one means it
+    never got far enough to say anything."""
+    verdict, detail = m.classify("failure", log)
+
+    assert verdict == m.INFRA
+    assert "without producing any output" in detail
+
+
+# --------------------------------------------------------------------------
+# Infrastructure signatures — the failures that must never be blamed
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("log", "expected"),
+    [
+        (
+            "failed to do request: Head https://registry-1.docker.io/v2/: "
+            "received unexpected HTTP status: 503 Service Unavailable",
+            "registry",
+        ),
+        (
+            "toomanyrequests: You have reached your pull rate limit.",
+            "rate limit",
+        ),
+        ("read tcp 10.1.0.4:52134: connection reset by peer", "network"),
+        ("dial tcp: i/o timeout", "network"),
+        (
+            "dial tcp: lookup registry-1.docker.io: no such host",
+            "DNS",
+        ),
+        ("tls handshake timeout", "TLS"),
+        (
+            "ERROR: failed to solve: failed to resolve source metadata for "
+            "docker.io/library/python:3.12-slim",
+            "base image",
+        ),
+        ("pull access denied, repository does not exist", "base image"),
+        ("error pulling image configuration: download failed", "base image"),
+        ("write /var/lib/docker/tmp: no space left on device", "disk"),
+        ("fatal error: runtime: cannot allocate memory", "memory"),
+        (
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+            "docker daemon",
+        ),
+        ("unauthorized: authentication failed", "authentication"),
+        (
+            'denied: Permission "artifactregistry.repositories.uploadArtifacts" denied',
+            "authentication",
+        ),
+    ],
+)
+def test_infrastructure_failures_are_not_blamed_on_the_recipe(
+    log: str, expected: str
+):
+    verdict, detail = m.classify("failure", log)
+
+    assert verdict == m.INFRA, f"{log!r} was blamed on the recipe"
+    assert expected.lower() in detail.lower()
+
+
+# --------------------------------------------------------------------------
+# Genuine recipe failures
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "log",
+    [
+        'ERROR: failed to solve: process "/bin/sh -c uv sync --frozen" '
+        "did not complete successfully: exit code: 1",
+        "COPY failed: file not found in build context: stat app: no such "
+        "file or directory",
+        "Dockerfile:14\n--------------------\nERROR: invalid instruction",
+        "executor failed running [/bin/sh -c pip install -r req.txt]: "
+        "exit code 2",
+    ],
+)
+def test_real_build_failures_are_reported(log: str):
+    verdict, detail = m.classify("failure", log)
+
+    assert verdict == m.FAIL
+    assert detail
+
+
+def test_the_detail_prefers_the_line_naming_the_failure():
+    log = (
+        "#8 [4/6] RUN uv sync --frozen\n"
+        "#8 0.4 error: no lockfile\n"
+        'ERROR: failed to solve: process "/bin/sh -c uv sync --frozen" '
+        "did not complete successfully: exit code: 1\n"
+        "some trailing noise\n"
+    )
+
+    _, detail = m.classify("failure", log)
+
+    assert "did not complete successfully" in detail
+
+
+def test_an_infra_signature_anywhere_in_the_log_wins():
+    """A recipe-looking error preceded by a registry failure is still infra.
+
+    The build fails at the first problem; a later line that looks like the
+    recipe's fault is usually a consequence of the earlier one.
+    """
+    log = (
+        "failed to resolve source metadata for docker.io/library/python\n"
+        'ERROR: failed to solve: process "/bin/sh -c true" did not '
+        "complete successfully: exit code: 1\n"
+    )
+
+    assert m.classify("failure", log)[0] == m.INFRA
+
+
+def test_log_tail_is_bounded():
+    log = "\n".join(f"line {i}" for i in range(500))
+
+    tail = m.log_tail(log)
+
+    assert len(tail.splitlines()) == m.LOG_TAIL_LINES
+    assert "line 499" in tail
+    assert "line 0" not in tail
+
+
+# --------------------------------------------------------------------------
+# The classify subcommand
+# --------------------------------------------------------------------------
+
+
+def test_classify_writes_a_result_file(tmp_path: Path, capsys):
+    log = tmp_path / "build.log"
+    log.write_text("no space left on device", encoding="utf-8")
+    out = tmp_path / "result.json"
+
+    rc = m.main(
+        [
+            "classify",
+            "--image",
+            "demo",
+            "--dockerfile",
+            "core/python/demo/Dockerfile",
+            "--context",
+            "core/python/demo",
+            "--outcome",
+            "failure",
+            "--log",
+            str(log),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(out.read_text())
+    assert result == {
+        "image": "demo",
+        "dockerfile": "core/python/demo/Dockerfile",
+        "context": "core/python/demo",
+        "outcome": "infra",
+        "detail": "the runner ran out of disk",
+        "tail": "",
+    }
+
+
+def test_classify_carries_a_tail_only_for_real_failures(tmp_path: Path):
+    log = tmp_path / "build.log"
+    log.write_text(
+        "ERROR: failed to solve: process did not complete successfully",
+        encoding="utf-8",
+    )
+    out = tmp_path / "result.json"
+
+    m.main(
+        [
+            "classify",
+            "--image",
+            "demo",
+            "--outcome",
+            "failure",
+            "--log",
+            str(log),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert json.loads(out.read_text())["tail"]
+
+
+def test_classify_survives_a_missing_log(tmp_path: Path):
+    """A missing log is evidence of nothing, not a crash."""
+    out = tmp_path / "result.json"
+
+    rc = m.main(
+        [
+            "classify",
+            "--image",
+            "demo",
+            "--outcome",
+            "failure",
+            "--log",
+            str(tmp_path / "nope.log"),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    assert json.loads(out.read_text())["outcome"] == "infra"
+
+
+# --------------------------------------------------------------------------
+# The report subcommand
+# --------------------------------------------------------------------------
+
+
+def _result(tmp_path: Path, index: int, **fields) -> None:
+    entry = {
+        "image": "demo",
+        "dockerfile": "core/python/demo/Dockerfile",
+        "context": "core/python/demo",
+        "outcome": "pass",
+        "detail": "",
+        "tail": "",
+    }
+    entry.update(fields)
+    d = tmp_path / "results" / f"image-result-{index}"
+    d.mkdir(parents=True)
+    (d / "result.json").write_text(json.dumps(entry), encoding="utf-8")
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Every `gh` call recorded, none made."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        if args[:2] == ("issue", "list"):
+            return "[]"
+        if args[0] == "api" and "/pulls" in args[1]:
+            return json.dumps([{"number": 4242}])
+        if args[0] == "api" and "/runs" in args[1] and "jobs" not in args[1]:
+            return json.dumps({"workflow_runs": []})
+        return ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+    return calls
+
+
+def test_report_says_nothing_when_everything_passed(
+    tmp_path: Path, no_network, capsys
+):
+    _result(tmp_path, 0, outcome="pass")
+
+    rc = m.main(["report", "--results", str(tmp_path / "results")])
+
+    assert rc == 0
+    assert not [c for c in no_network if c[:2] == ("issue", "comment")]
+
+
+def test_report_stays_silent_on_infrastructure_failures(
+    tmp_path: Path, no_network, capsys
+):
+    """The whole point. Nobody is told a registry had a bad minute."""
+    _result(tmp_path, 0, outcome="infra", detail="registry rate limit")
+
+    rc = m.main(["report", "--results", str(tmp_path / "results")])
+
+    assert rc == 0
+    assert not [c for c in no_network if c[:2] == ("issue", "comment")]
+    assert "nothing reported to anyone" in capsys.readouterr().out
+
+
+def test_report_comments_on_the_pull_request_for_a_real_failure(
+    tmp_path: Path, no_network, capsys
+):
+    _result(tmp_path, 0, outcome="fail", detail="boom", tail="ERROR: boom")
+
+    rc = m.main(
+        [
+            "report",
+            "--results",
+            str(tmp_path / "results"),
+            "--sha",
+            "abcdef1234567890",
+            "--run-url",
+            "https://run",
+        ]
+    )
+
+    assert rc == 0
+    comments = [c for c in no_network if c[:2] == ("issue", "comment")]
+    assert len(comments) == 1
+    assert comments[0][2] == "4242"
+    body = comments[0][-1]
+    assert "demo" in body and "ERROR: boom" in body
+
+
+def test_no_issue_is_opened_on_a_first_failure(
+    tmp_path: Path, no_network, capsys
+):
+    """One bad merge does not deserve a tracker item — the comment is on the
+    pull request of the person who can fix it."""
+    _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
+
+    m.main(
+        [
+            "report",
+            "--results",
+            str(tmp_path / "results"),
+            "--sha",
+            "abcdef1234567890",
+        ]
+    )
+
+    assert not [c for c in no_network if c[:2] == ("issue", "create")]
+    assert "first failure" in capsys.readouterr().out
+
+
+def test_an_issue_is_opened_when_the_same_image_fails_again(
+    tmp_path: Path, no_network, monkeypatch, capsys
+):
+    _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
+    monkeypatch.setattr(
+        m, "images_that_failed_in_the_previous_run", lambda _run: {"demo"}
+    )
+
+    m.main(
+        [
+            "report",
+            "--results",
+            str(tmp_path / "results"),
+            "--sha",
+            "abcdef1234567890",
+        ]
+    )
+
+    created = [c for c in no_network if c[:2] == ("issue", "create")]
+    assert len(created) == 1
+    assert m.issue_title("demo") in created[0]
+
+
+def test_a_repeat_with_an_existing_issue_comments_instead_of_duplicating(
+    tmp_path: Path, monkeypatch, capsys
+):
+    _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        if args[:2] == ("issue", "list"):
+            return json.dumps([{"number": 77, "title": m.issue_title("demo")}])
+        if args[0] == "api" and "/pulls" in args[1]:
+            return json.dumps([{"number": 1}])
+        return ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+    monkeypatch.setattr(
+        m, "images_that_failed_in_the_previous_run", lambda _run: {"demo"}
+    )
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "a" * 40]
+    )
+
+    assert not [c for c in calls if c[:2] == ("issue", "create")]
+    assert any(c[:3] == ("issue", "comment", "77") for c in calls)
+
+
+def test_a_recovered_image_closes_its_issue(
+    tmp_path: Path, monkeypatch, capsys
+):
+    _result(tmp_path, 0, outcome="pass")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        if args[:2] == ("issue", "list"):
+            return json.dumps([{"number": 88, "title": m.issue_title("demo")}])
+        return ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "b" * 40]
+    )
+
+    assert any(c[:3] == ("issue", "close", "88") for c in calls)
+
+
+def test_an_exact_title_match_is_required(tmp_path: Path, monkeypatch):
+    """`demo` must not be handed the issue belonging to `demo-sandbox`,
+    which would report one image's failure on another's thread."""
+    _result(tmp_path, 0, outcome="pass")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        if args[:2] == ("issue", "list"):
+            return json.dumps(
+                [{"number": 99, "title": m.issue_title("demo-sandbox")}]
+            )
+        return ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "c" * 40]
+    )
+
+    assert not [c for c in calls if c[:2] == ("issue", "close")]
+
+
+def test_no_results_is_an_error_not_a_clean_run(tmp_path: Path, capsys):
+    """Every leg writes a result, including the passing ones, so none at all
+    means collection broke — not that nothing failed."""
+    (tmp_path / "results").mkdir()
+
+    rc = m.main(["report", "--results", str(tmp_path / "results")])
+
+    assert rc == 1
+    assert "no results found" in capsys.readouterr().err
+
+
+def test_a_direct_push_with_no_pull_request_does_not_crash(
+    tmp_path: Path, monkeypatch, capsys
+):
+    _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
+    monkeypatch.setattr(m, "gh", lambda *a, **k: "[]")
+
+    rc = m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "d" * 40]
+    )
+
+    assert rc == 0
+    assert "No pull request found" in capsys.readouterr().out
+
+
+def test_dry_run_writes_nothing(tmp_path: Path, no_network, capsys):
+    _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
+
+    m.main(
+        [
+            "report",
+            "--results",
+            str(tmp_path / "results"),
+            "--sha",
+            "e" * 40,
+            "--dry-run",
+        ]
+    )
+
+    for verb in ("comment", "create", "close"):
+        assert not [c for c in no_network if c[:2] == ("issue", verb)]
+    assert "[dry-run]" in capsys.readouterr().out
+
+
+def test_a_mixed_run_reports_only_the_real_failure(
+    tmp_path: Path, no_network, capsys
+):
+    # Distinctive names on purpose. An earlier version used "ok", which is a
+    # substring of "broke" in the comment body, so the assertion failed for a
+    # reason that had nothing to do with the code under test.
+    _result(tmp_path, 0, image="healthy-one", outcome="pass")
+    _result(tmp_path, 1, image="flaky-one", outcome="infra", detail="DNS")
+    _result(tmp_path, 2, image="broken-one", outcome="fail", tail="E: boom")
+
+    m.main(
+        [
+            "report",
+            "--results",
+            str(tmp_path / "results"),
+            "--sha",
+            "f" * 40,
+        ]
+    )
+
+    body = next(c for c in no_network if c[:2] == ("issue", "comment"))[-1]
+    assert "broken-one" in body
+    assert "flaky-one" not in body
+    assert "healthy-one" not in body
+
+
+# --------------------------------------------------------------------------
+# Previous-run lookup
+# --------------------------------------------------------------------------
+
+
+def test_previous_run_lookup_skips_the_current_run(monkeypatch):
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps({"workflow_runs": [{"id": 100}, {"id": 99}]})
+        return json.dumps(
+            {"jobs": [{"name": "build demo", "conclusion": "failure"}]}
+        )
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("100") == {"demo"}
+
+
+def test_previous_run_lookup_is_empty_when_the_api_is_unreachable(
+    monkeypatch,
+):
+    """Biases toward commenting without opening an issue, which the next
+    failure corrects."""
+
+    def boom(*args: str, check: bool = True) -> str:
+        raise m.ReportError("network down")
+
+    monkeypatch.setattr(m, "gh", boom)
+
+    assert m.images_that_failed_in_the_previous_run("1") == set()
+
+
+def test_previous_run_lookup_ignores_jobs_that_are_not_builds(monkeypatch):
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps({"workflow_runs": [{"id": 1}]})
+        return json.dumps(
+            {
+                "jobs": [
+                    {"name": "Detect affected images", "conclusion": "failure"},
+                    {"name": "build demo", "conclusion": "success"},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("2") == set()

--- a/.github/scripts/tests/test_image_build_report.py
+++ b/.github/scripts/tests/test_image_build_report.py
@@ -380,7 +380,9 @@ def test_an_issue_is_opened_when_the_same_image_fails_again(
 ):
     _result(tmp_path, 0, outcome="fail", tail="ERROR: boom")
     monkeypatch.setattr(
-        m, "images_that_failed_in_the_previous_run", lambda _run: {"demo"}
+        m,
+        "images_that_failed_in_the_previous_run",
+        lambda _run, _wanted=None: {"demo"},
     )
 
     m.main(
@@ -414,7 +416,9 @@ def test_a_repeat_with_an_existing_issue_comments_instead_of_duplicating(
 
     monkeypatch.setattr(m, "gh", fake_gh)
     monkeypatch.setattr(
-        m, "images_that_failed_in_the_previous_run", lambda _run: {"demo"}
+        m,
+        "images_that_failed_in_the_previous_run",
+        lambda _run, _wanted=None: {"demo"},
     )
 
     m.main(
@@ -587,3 +591,255 @@ def test_previous_run_lookup_ignores_jobs_that_are_not_builds(monkeypatch):
     monkeypatch.setattr(m, "gh", fake_gh)
 
     assert m.images_that_failed_in_the_previous_run("2") == set()
+
+
+def test_repeat_looks_back_past_runs_that_did_not_build_the_image(
+    monkeypatch,
+):
+    """The defect that made the issue path unreachable in practice.
+
+    Builds are affected-only, so the common sequence is: the image fails,
+    then several merges touch other recipes and never build it, then it
+    fails again. Asking only about the immediately previous run answers
+    "not failing" every time, so a repeat is never detected and no issue is
+    ever opened.
+    """
+    runs = {"workflow_runs": [{"id": 4}, {"id": 3}, {"id": 2}]}
+    jobs = {
+        # The two most recent runs built a different recipe entirely.
+        4: {"jobs": [{"name": "build other", "conclusion": "success"}]},
+        3: {"jobs": [{"name": "build other", "conclusion": "success"}]},
+        # The last run that actually built `demo` — and it failed.
+        2: {"jobs": [{"name": "build demo", "conclusion": "failure"}]},
+    }
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps(runs)
+        run_id = int(args[1].split("/runs/")[1].split("/")[0])
+        return json.dumps(jobs[run_id])
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("5") == {"demo"}
+
+
+def test_a_later_success_beats_an_earlier_failure(monkeypatch):
+    """Only the MOST RECENT build of an image counts. A failure further back
+    that has since been fixed must not reopen an issue."""
+    runs = {"workflow_runs": [{"id": 9}, {"id": 8}]}
+    jobs = {
+        9: {"jobs": [{"name": "build demo", "conclusion": "success"}]},
+        8: {"jobs": [{"name": "build demo", "conclusion": "failure"}]},
+    }
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps(runs)
+        run_id = int(args[1].split("/runs/")[1].split("/")[0])
+        return json.dumps(jobs[run_id])
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("10") == set()
+
+
+def test_the_current_run_is_never_its_own_evidence(monkeypatch):
+    runs = {"workflow_runs": [{"id": 7}]}
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps(runs)
+        return json.dumps(
+            {"jobs": [{"name": "build demo", "conclusion": "failure"}]}
+        )
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("7") == set()
+
+
+def test_too_many_failures_opens_no_issues_at_all(
+    tmp_path: Path, no_network, monkeypatch, capsys
+):
+    """The message used to say "commenting only" while the loop went on
+    opening issues anyway. This many at once is one systemic cause, and N
+    issues would each be wrong about what to fix."""
+    for i in range(m.MAX_ISSUES_PER_RUN + 1):
+        _result(tmp_path, i, image=f"img{i}", outcome="fail", tail="E: boom")
+    monkeypatch.setattr(
+        m,
+        "images_that_failed_in_the_previous_run",
+        lambda _run, _wanted=None: {
+            f"img{i}" for i in range(m.MAX_ISSUES_PER_RUN + 1)
+        },
+    )
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "a" * 40]
+    )
+
+    assert not [c for c in no_network if c[:2] == ("issue", "create")]
+    assert "no issues are being opened" in capsys.readouterr().err
+
+
+def test_every_failing_image_gets_its_own_reproduce_command(
+    tmp_path: Path, no_network
+):
+    """One command printed under a list of three reads as though it covers
+    all of them, so a reader fixes one image and believes they are done."""
+    _result(
+        tmp_path,
+        0,
+        image="one",
+        outcome="fail",
+        tail="E: 1",
+        dockerfile="core/python/one/Dockerfile",
+        context="core/python/one",
+    )
+    _result(
+        tmp_path,
+        1,
+        image="two",
+        outcome="fail",
+        tail="E: 2",
+        dockerfile="core/python/two/Dockerfile",
+        context="core/python/two",
+    )
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "b" * 40]
+    )
+
+    body = next(c for c in no_network if c[:2] == ("issue", "comment"))[-1]
+    assert "docker build -f core/python/one/Dockerfile core/python/one" in body
+    assert "docker build -f core/python/two/Dockerfile core/python/two" in body
+
+
+def test_a_corrupt_result_file_is_skipped_not_fatal(
+    tmp_path: Path, no_network, capsys
+):
+    """A valid-JSON but wrong-shape artifact must not raise deep in the
+    reporting logic, possibly after a comment has already been posted."""
+    _result(tmp_path, 0, image="good", outcome="pass")
+    bad = tmp_path / "results" / "image-result-9"
+    bad.mkdir(parents=True)
+    (bad / "result.json").write_text("[]", encoding="utf-8")
+
+    rc = m.main(["report", "--results", str(tmp_path / "results")])
+
+    assert rc == 0
+    assert "not a usable result" in capsys.readouterr().err
+
+
+def test_the_issue_index_is_fetched_once_per_run(
+    tmp_path: Path, monkeypatch, capsys
+):
+    """canary_issues documents why: a lookup inside the loop is n
+    subprocesses and n chances to hit a rate limit, to answer a question one
+    call already answers."""
+    for i in range(3):
+        _result(tmp_path, i, image=f"img{i}", outcome="pass")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        return "[]" if args[:2] == ("issue", "list") else ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "c" * 40]
+    )
+
+    assert len([c for c in calls if c[:2] == ("issue", "list")]) == 1
+
+
+def test_the_history_walk_stops_once_every_image_is_answered(monkeypatch):
+    """Each extra run costs an API call. In the common case the previous run
+    built the same image and one call is enough."""
+    runs = {"workflow_runs": [{"id": 3}, {"id": 2}, {"id": 1}]}
+    fetched: list[int] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps(runs)
+        run_id = int(args[1].split("/runs/")[1].split("/")[0])
+        fetched.append(run_id)
+        return json.dumps(
+            {"jobs": [{"name": "build demo", "conclusion": "failure"}]}
+        )
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("9", {"demo"}) == {"demo"}
+    assert fetched == [3], f"walked further than needed: {fetched}"
+
+
+def test_the_history_walk_keeps_going_until_it_finds_the_image(monkeypatch):
+    runs = {"workflow_runs": [{"id": 3}, {"id": 2}]}
+    jobs = {
+        3: {"jobs": [{"name": "build other", "conclusion": "success"}]},
+        2: {"jobs": [{"name": "build demo", "conclusion": "failure"}]},
+    }
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        if "/runs?" in args[1]:
+            return json.dumps(runs)
+        return json.dumps(jobs[int(args[1].split("/runs/")[1].split("/")[0])])
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    assert m.images_that_failed_in_the_previous_run("9", {"demo"}) == {"demo"}
+
+
+def test_an_infra_failure_leaves_an_existing_issue_alone(
+    tmp_path: Path, monkeypatch, capsys
+):
+    """Infrastructure trouble says nothing about the recipe, so it must
+    neither open, comment on, nor close a tracking issue."""
+    _result(tmp_path, 0, image="demo", outcome="infra", detail="DNS failure")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        if args[:2] == ("issue", "list"):
+            return json.dumps([{"number": 5, "title": m.issue_title("demo")}])
+        return ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "d" * 40]
+    )
+
+    for verb in ("create", "comment", "close"):
+        assert not [c for c in calls if c[:2] == ("issue", verb)]
+
+
+def test_the_issue_index_is_fetched_once_even_with_both_passes_and_failures(
+    tmp_path: Path, monkeypatch
+):
+    """The earlier version of this assertion only covered the all-pass case,
+    where just one of the two call sites ran."""
+    _result(tmp_path, 0, image="good", outcome="pass")
+    _result(tmp_path, 1, image="bad", outcome="fail", tail="E: boom")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args: str, check: bool = True) -> str:
+        calls.append(args)
+        if args[:2] == ("issue", "list"):
+            return "[]"
+        if args[0] == "api" and "/pulls" in args[1]:
+            return json.dumps([{"number": 1}])
+        if args[0] == "api" and "/runs?" in args[1]:
+            return json.dumps({"workflow_runs": []})
+        return ""
+
+    monkeypatch.setattr(m, "gh", fake_gh)
+
+    m.main(
+        ["report", "--results", str(tmp_path / "results"), "--sha", "e" * 40]
+    )
+
+    assert len([c for c in calls if c[:2] == ("issue", "list")]) == 1

--- a/.github/scripts/tests/test_recipe_images_workflow.py
+++ b/.github/scripts/tests/test_recipe_images_workflow.py
@@ -546,3 +546,25 @@ def test_the_reporter_does_not_run_when_no_image_was_built(doc: dict):
     reporter goes red on an ordinary healthy merge, and a channel that cries
     wolf gets muted along with its real reports."""
     assert "needs.build.result != 'skipped'" in doc["jobs"]["report"]["if"]
+
+
+def test_the_build_job_name_matches_what_the_reporter_parses(doc: dict):
+    """The job name is the only link between a historical run and an image.
+
+    image_build_report strips BUILD_JOB_PREFIX off each job name to work out
+    which image it built, which is how "did this fail last time it was
+    built" is answered. Rename the job and that parsing silently returns
+    nothing: no repeats are ever detected, and no tracking issue is ever
+    opened again.
+    """
+    import image_build_report
+
+    name = doc["jobs"]["build"]["name"]
+    prefix = image_build_report.BUILD_JOB_PREFIX
+
+    assert name.startswith(prefix), (
+        f"build job is named {name!r} but the reporter strips {prefix!r}"
+    )
+    # What remains must be the image expression, or the parsed value is not
+    # an image name at all.
+    assert name[len(prefix) :].strip() == "${{ matrix.entry.image }}"

--- a/.github/scripts/tests/test_recipe_images_workflow.py
+++ b/.github/scripts/tests/test_recipe_images_workflow.py
@@ -447,3 +447,102 @@ def test_the_detect_checkout_takes_full_history(doc: dict):
         if "actions/checkout" in str(s.get("uses", ""))
     )
     assert checkout["with"]["fetch-depth"] == 0
+
+
+# --------------------------------------------------------------------------
+# Failure reporting
+# --------------------------------------------------------------------------
+
+
+def test_a_failed_build_still_fails_its_job(doc: dict):
+    """`continue-on-error` on the build step exists only so the log can be
+    captured and classified. Without a step restoring the failure, the leg
+    reports success, the gate aggregates three successes, and a required
+    check goes green over an image that did not build."""
+    steps = _steps(doc, "build")
+    build = next(s for s in steps if s.get("id") == "build")
+    assert build["continue-on-error"] is True
+
+    restorer = next(
+        s
+        for s in steps
+        if "steps.build.outcome == 'failure'" in str(s.get("if", ""))
+    )
+    assert "exit 1" in restorer["run"]
+    # After classify and upload, or the evidence is lost before anything
+    # records it.
+    names = [s.get("name", "") for s in steps]
+    assert names.index(restorer["name"]) > names.index("Upload result")
+
+
+def test_every_leg_uploads_a_result_even_when_it_passed(doc: dict):
+    """A recipe absent from the results cannot be told apart from one that
+    passed, which is how a recovery goes unnoticed and its tracking issue
+    stays open forever."""
+    for name in ("Classify the result", "Upload result"):
+        step = next(s for s in _steps(doc, "build") if s.get("name") == name)
+        assert step["if"] == "always()", f"{name} does not always run"
+
+
+def test_the_report_job_only_runs_on_a_merge_to_main(doc: dict):
+    """On a pull request the author is already looking at the failing check;
+    a bot comment repeating it is noise."""
+    condition = doc["jobs"]["report"]["if"]
+    assert "github.event_name == 'push'" in condition
+    assert "refs/heads/main" in condition
+    assert "!cancelled()" in condition
+
+
+def test_the_report_job_is_the_only_writer(doc: dict):
+    """It writes to the tracker and takes no part in building, so nothing a
+    contributor's Dockerfile does happens in a job holding these scopes."""
+    for name, job in doc["jobs"].items():
+        perms = job.get("permissions") or {}
+        writes = {
+            k for k, v in perms.items() if v == "write" and k != "id-token"
+        }
+        if name == "report":
+            assert writes == {"issues", "pull-requests"}
+        else:
+            assert not writes, f"{name} can write {writes}"
+
+
+def test_the_report_job_does_not_build_anything(doc: dict):
+    runs = " ".join(s.get("run", "") for s in _steps(doc, "report"))
+    assert "docker build" not in runs
+    assert "docker push" not in runs
+
+
+def test_the_report_job_reads_the_results_the_build_job_wrote(doc: dict):
+    """The artifact name is the contract between the two jobs; a mismatch
+    means the reporter silently finds nothing and says nothing."""
+    upload = next(
+        s
+        for s in _steps(doc, "build")
+        if "upload-artifact" in str(s.get("uses", ""))
+    )
+    download = next(
+        s
+        for s in _steps(doc, "report")
+        if "download-artifact" in str(s.get("uses", ""))
+    )
+    produced = upload["with"]["name"]
+    pattern = download["with"]["pattern"]
+    assert pattern.endswith("*")
+    assert produced.startswith(pattern[:-1]), (
+        f"upload writes {produced!r}, download looks for {pattern!r}"
+    )
+
+
+def test_the_gate_does_not_depend_on_the_reporter(doc: dict):
+    """Branch protection must not turn red because commenting failed, nor
+    green because it succeeded. The two answer different questions."""
+    assert "report" not in doc["jobs"]["gate"]["needs"]
+
+
+def test_the_reporter_does_not_run_when_no_image_was_built(doc: dict):
+    """Most merges that trigger this workflow affect no declared image, and
+    then `build` is skipped and no artifacts exist. Without this guard the
+    reporter goes red on an ordinary healthy merge, and a channel that cries
+    wolf gets muted along with its real reports."""
+    assert "needs.build.result != 'skipped'" in doc["jobs"]["report"]["if"]

--- a/.github/workflows/recipe-images.yml
+++ b/.github/workflows/recipe-images.yml
@@ -250,6 +250,12 @@ jobs:
       # `COPY` in any Dockerfile. Checkout still comes first because auth
       # writes into the workspace that checkout would otherwise clobber.
       - name: Build image
+        id: build
+        # The job must still go red when this fails — the "Fail the job" step
+        # below restores that. This only keeps the leg alive long enough to
+        # capture the log and classify it, which is the entire input to the
+        # report job.
+        continue-on-error: true
         env:
           IMAGE: ${{ matrix.entry.image }}
           DOCKERFILE: ${{ matrix.entry.dockerfile }}
@@ -258,7 +264,15 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
-          set -euo pipefail
+          # `set +e` is load-bearing — do not drop it. GitHub invokes `run:`
+          # as `bash -e {0}`, so errexit is ALREADY on and `set -uo pipefail`
+          # does not clear it. Without `set +e` a failing docker build kills
+          # the step where it stands, the `tail` below never runs, and the
+          # log tail is lost at exactly the moment it is worth reading. Same
+          # reasoning as the sync step in recipe-canary.yml.
+          set -uo pipefail
+          set +e
+
           # Tagged with the commit SHA only. A moving tag is deliberately not
           # produced: what a consumer should pin to is an open question with
           # Agent Garden, and a tag published once is hard to withdraw.
@@ -275,9 +289,50 @@ jobs:
             --build-arg "COMMIT_SHA=$COMMIT_SHA" \
             --label "org.opencontainers.image.source=$SOURCE_URL" \
             --label "org.opencontainers.image.revision=$COMMIT_SHA" \
-            "$CONTEXT"
-          docker image inspect "local/$IMAGE:$COMMIT_SHA" \
-            --format 'built {{.RepoTags}} — {{.Size}} bytes'
+            "$CONTEXT" > "$RUNNER_TEMP/build.log" 2>&1
+          rc=$?
+
+          # Echo it either way: on success this is the build output a reader
+          # expects to find in the job log, and on failure it is the evidence.
+          tail -80 "$RUNNER_TEMP/build.log"
+
+          if [ $rc -eq 0 ]; then
+            docker image inspect "local/$IMAGE:$COMMIT_SHA" \
+              --format 'built {{.RepoTags}} — {{.Size}} bytes'
+          fi
+          exit $rc
+
+      # Runs even when the build succeeded: the report job needs a result for
+      # every leg, not only the failing ones. A recipe absent from the results
+      # cannot be told apart from one that passed, and that is how a recovery
+      # goes unnoticed and its tracking issue stays open forever.
+      - name: Classify the result
+        if: always()
+        env:
+          IMAGE: ${{ matrix.entry.image }}
+          DOCKERFILE: ${{ matrix.entry.dockerfile }}
+          CONTEXT: ${{ matrix.entry.context }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+        run: |
+          set -euo pipefail
+          # Plain python3, no uv: the classify path is standard library only,
+          # so there is nothing to resolve and nothing to install.
+          python3 .github/scripts/image_build_report.py classify \
+            --image "$IMAGE" \
+            --dockerfile "$DOCKERFILE" \
+            --context "$CONTEXT" \
+            --outcome "$BUILD_OUTCOME" \
+            --log "$RUNNER_TEMP/build.log" \
+            --out "$RUNNER_TEMP/result.json"
+          cat "$RUNNER_TEMP/result.json"
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
+        with:
+          name: image-result-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/result.json
+          retention-days: 7
 
       # `token_format: access_token` rather than the default credential file,
       # and no setup-gcloud step. Two reasons: the only cloud operation here
@@ -339,6 +394,82 @@ jobs:
               echo "- Published: no (build only)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Restores the failure that `continue-on-error` on the build step
+      # suppressed. Without this the leg reports success, the gate aggregates
+      # three successes, and a branch-protection check goes green over an
+      # image that did not build — the exact silent-green this pipeline is
+      # built to prevent. It runs last so the log, the classification and the
+      # artifact are all safely captured first.
+      - name: Fail the job if the build failed
+        if: always() && steps.build.outcome == 'failure'
+        env:
+          IMAGE: ${{ matrix.entry.image }}
+        run: |
+          echo "::error::$IMAGE failed to build. See the 'Build image' step."
+          exit 1
+
+  # Tells a human that a recipe image broke. Separate from the gate because
+  # the two answer different questions: the gate answers "is this branch
+  # healthy" for branch protection, this answers "who needs to know".
+  #
+  # Only on a merge to main. On a pull request the author is already looking
+  # at the failing check, and a bot comment repeating it is noise.
+  report:
+    name: Report build failures
+    needs: [detect, build]
+    # `needs.build.result != 'skipped'` is not redundant with the rest. Most
+    # merges that trigger this workflow affect NO declared image — a change
+    # under core/ to a recipe that publishes nothing is the common case — and
+    # then `build` is skipped, no artifacts exist, and this job would go red
+    # on an ordinary merge for having nothing to read. A reporter that cries
+    # wolf on healthy merges gets muted, taking the real reports with it.
+    if: >-
+      !cancelled()
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.detect.result == 'success'
+      && needs.build.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # To comment on the merged pull request, and to open a tracking issue
+      # when the same image fails twice running. Deliberately the only job
+      # in this workflow that can write anything to the repository, and it
+      # takes no part in building — so nothing a Dockerfile does happens in
+      # a job holding these.
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
+        with:
+          pattern: image-result-*
+          path: ${{ runner.temp }}/results
+          merge-multiple: false
+
+      - name: Report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: >-
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+            github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/image_build_report.py report \
+            --results "$RUNNER_TEMP/results" \
+            --run-url "$RUN_URL" \
+            --run-id "$RUN_ID" \
+            --sha "$COMMIT_SHA"
 
   # Branch-protection gate. `if: always()` so the required check still
   # reports when detect or build was skipped or cancelled — a skipped


### PR DESCRIPTION
Fixes b/557342506. Phase 4 of the recipe image pipeline. Depends on #2593 (merged).

## The problem

A build failure on `main` currently reaches nobody. The job goes red, the run scrolls away, and the next person to touch that recipe discovers it.

## Two halves

**Classify.** Each matrix leg now captures its docker log and decides whether the *recipe* broke or the *infrastructure* did.

The rule is taken verbatim from `recipe-canary.yml`, along with its reasoning: the two mistakes don't cost the same. A missed real failure is caught by the next run; one failure misfiled against an author for a registry timeout teaches everyone the channel cries wolf, and the real ones get ignored too. So **every path that reaches a verdict without a log to read lands on `infra`**, and `fail` requires log text that matched no infrastructure signature.

Recognised as infrastructure: registry 5xx and rate limits, dropped connections, DNS and TLS failures, unresolvable base images, a runner out of disk or memory, an absent docker daemon, authentication failures.

**Report.** A comment on the merged PR when a recipe genuinely broke; a tracking issue only when the same image fails *again*.

The PR comment is first because for a failure on main the actionable human is whoever merged it, and a comment reaches them where the context already is — with no dependence on ownership metadata. That matters: `canary_issues.py` records that only 3 of 12 recipes declare a `poc` that can even be assigned, since GitHub silently drops an unknown assignee.

An issue is for the failure nobody acted on. "Repeated" is read from the workflow's own run history, so there's no state to keep in sync and no first run that behaves differently because its state doesn't exist yet.

Infrastructure failures tell **nobody**. That's the point.

## Workflow changes

`continue-on-error` on the build step so the log survives, then a final step that **restores the failure**. Without it the leg reports success, the gate aggregates three successes, and a required check goes green over an image that didn't build.

Every leg uploads a result **including the passing ones** — a recipe absent from the results can't be told apart from one that passed, which is how a recovery goes unnoticed and its issue stays open forever.

The reporter is the only job here that can write to the repo, and it takes no part in building, so nothing a contributor's Dockerfile does happens in a job holding `issues: write`. The gate doesn't depend on it: branch protection must not go red because commenting failed, nor green because it succeeded.

## Three bugs the tests caught

Worth listing, because each was live in my first draft:

1. The registry 5xx signature only matched when the status code came *before* the hostname. A real docker.io 503 reads `registry-1.docker.io ... 503`, so it was being blamed on the recipe — the exact misfiling this feature exists to prevent.
2. A non-dict API response raised `AttributeError` *after* the PR comment had already been posted.
3. The recovery path sat behind an early `return`, making it unreachable in exactly the no-failures case it exists for. Every tracking issue would have stayed open forever.

## Verification

Docker isn't available locally, so no container was built — that happens on this PR's own CI. Everything else was executed:

```
uv run pytest                          # 1601 passed (was 1547)
uv run ruff format --check + check     # clean
shellcheck, all 10 run: blocks         # 0 failures
```

Classifier run against realistic logs:

| Log | Verdict |
|---|---|
| `uv sync --frozen` exit 2 | `fail` — "did not complete successfully: exit code: 2" |
| `Head https://registry-1.docker.io/...: 503 Service Unavailable` | `infra` — registry returned a server error |
| successful build | `pass` |

Then the reporter end-to-end over those three real result files, and the rendered comment and issue bodies reviewed by eye (both include a `docker build` line to reproduce locally).

Also re-ran the detect step against real git after the edits: 3 images, workspace clean, repo not shallowed.

## One bug I caught before pushing

Most merges that trigger this workflow affect **no** declared image, so `build` is skipped and no artifacts exist. The reporter would have gone red on ordinary healthy merges. Now gated on `needs.build.result != 'skipped'`, with a test.

## Next

5. Document the Dockerfile standard — the last unblocked phase. 3 still waits on the org-policy exception and the GCP project.
