### PR TITLE
docs: write down the Dockerfile standard for publishable recipes

### DIFF
--- a/docs/recipe-checklist.md
+++ b/docs/recipe-checklist.md
@@ -1,4 +1,4 @@
-<!-- word count: 906 (target 900, cap 1200) -->
+<!-- word count: 926 (target 900, cap 1200) -->
 
 # Recipe Checklist
 
@@ -26,6 +26,10 @@ skill in the right order.
 
 For deep detail on each skill, see the
 [Repo Skills Catalog](./recipe-handbook/skills-catalog.md).
+
+If your recipe ships a `Dockerfile` and you want its image
+published, it also has to meet the
+[Dockerfile standard](./recipe-handbook/dockerfiles.md).
 
 ---
 

--- a/docs/recipe-handbook/README.md
+++ b/docs/recipe-handbook/README.md
@@ -1,4 +1,4 @@
-<!-- word count: 603 (target 500, cap 800) -->
+<!-- word count: 625 (target 500, cap 800) -->
 
 # Recipe Handbook
 
@@ -35,6 +35,9 @@ it covers everything on one page. Come back here for deeper context:
   recipes, regardless of language
 - [Python language rules](./languages/python.md) — starts with the
   fast path; specific requirements and end-to-end scenarios
+- [Dockerfile standard](./dockerfiles.md) — what a recipe's
+  `Dockerfile` must meet before its image is published. Only
+  applies if your recipe ships one
 - [Repo skills catalog](./skills-catalog.md) — the assistant
   helpers that build this repo
 

--- a/docs/recipe-handbook/dockerfiles.md
+++ b/docs/recipe-handbook/dockerfiles.md
@@ -112,7 +112,7 @@ is deprecated.
 
 Fetching model weights or remote installers during the build ties it
 to a third-party host serving the same bytes tomorrow. It can also
-mean redistributing someone else's artifact under your licence.
+mean redistributing someone else's artifact under your license.
 
 ### 9. Declared, not inferred
 

--- a/docs/recipe-handbook/dockerfiles.md
+++ b/docs/recipe-handbook/dockerfiles.md
@@ -1,0 +1,147 @@
+<!-- word count: 903 (target 700, cap 1000) -->
+
+# Dockerfile Standard
+
+The rules a recipe's `Dockerfile` must follow before its image is
+built and pushed to the public registry.
+
+This is a higher bar than "it builds on my machine", and the reason
+is the registry. A published image carries Google's name, is
+world-readable, and stays pullable long after the run that produced
+it. Every rule below exists because a real Dockerfile in this repo
+broke it.
+
+**Not every recipe needs this.** Most recipes are read, copied and
+adapted — they never ship an image. Deployability is opt-in. If your
+recipe has no `Dockerfile`, nothing here applies to you.
+
+## Getting an image published
+
+Publishing is an **allowlist**, not a scan. Adding a `Dockerfile`
+does not start publishing it; an entry in
+[`.github/policy.yml`](../../.github/policy.yml) under
+`deployability.publish.images` does, and only a repository admin can
+add one.
+
+That is deliberate. `docker build` runs every `RUN` instruction it is
+handed, and the result is published under Google's name — so which
+Dockerfiles earn that is a decision someone makes, not a side effect
+of adding a file.
+
+Bring your Dockerfile up to the standard below, then ask a
+maintainer to add the entry. Each entry declares four things: the
+Dockerfile path, the build context, the published image name, and
+whether the image serves HTTP.
+
+## The nine rules
+
+### 1. Reproducible installs
+
+Install from a committed lockfile. `uv sync --frozen`, never bare
+`uv sync`. `npm ci`, never `npm install`. A pinned
+`requirements.txt` if you use neither.
+
+Never delete a lockfile during the build. One recipe here runs
+`rm -f uv.lock && uv sync`, which means two builds of the same
+commit can produce different dependency sets — nobody can reproduce
+or explain the resulting image.
+
+### 2. Pinned base image
+
+Pin by digest, or at minimum an immutable tag. A floating tag like
+`ghcr.io/astral-sh/uv:python3.11-bookworm-slim` moves underneath you,
+so the image you tested is not the image you shipped.
+
+### 3. Pinned build tools
+
+`RUN pip install --no-cache-dir uv==0.8.13`, with the version. This
+repo already uses that exact pin; match it unless you have a reason.
+
+### 4. Honor `$PORT`, with a default
+
+Use `${PORT:-8080}`. Cloud Run injects `PORT` and expects your
+container to listen on it; a hardcoded port breaks the moment it
+differs. The default matters just as much — `--port $PORT` with no
+fallback fails under a plain `docker run`.
+
+### 5. Run as a non-root user
+
+Create an unprivileged user and `USER` to it before the entrypoint.
+Switch before installing dependencies if your runtime re-validates
+the environment at startup, so the virtualenv is owned by the user
+that runs it.
+
+### 6. Explicit `COPY`, plus a `.dockerignore`
+
+Name what goes in. Never `COPY . .` — it puts whatever happens to be
+in the directory into a public layer, including files added later by
+someone who never thought about your image.
+
+Ship a `.dockerignore` covering at least `.venv/`, `.env`, `.git/`
+and `gha-creds-*.json`. That last one is not hypothetical: the build
+workflow authenticates to Google Cloud in the same job, and a
+credential file landing in the build context is exactly the accident
+this line prevents.
+
+### 7. No configuration or secrets in `ENV`
+
+`ENV` is for build metadata — `COMMIT_SHA`, `AGENT_VERSION` — and
+nothing else.
+
+Configuration arrives at runtime, through `docker run -e`,
+`--env-file`, or Cloud Run environment variables. Baking it in does
+not save anyone a step: `-e` works whether or not the Dockerfile
+declares the variable. What it does do is freeze a value into a
+world-readable layer and go stale — an `ENV MODEL_NAME=...` is wrong
+for every operator the day that model is deprecated.
+
+### 8. No unpinned network fetches at build time
+
+Downloading model weights, remote installers or anything else
+unpinned during the build makes it depend on a third-party host
+staying up and serving the same bytes. It also means you may be
+redistributing someone else's artifact under your image's licence.
+
+### 9. Declared, not inferred
+
+The build context is declared per image, not guessed from the
+Dockerfile's location. Several Dockerfiles here live in a
+subdirectory and `COPY` from the recipe root, so
+`dirname(Dockerfile)` is the wrong answer often enough that guessing
+it would generate bugs.
+
+The same goes for whether the image serves HTTP. Not every
+publishable image is a server — one here is a base image for
+pipeline components and has no `CMD` at all — and probing it like a
+web service would report a healthy image as broken.
+
+## Checking your work
+
+The declaration is validated on every pull request. To run it
+yourself:
+
+```bash
+uv run --no-project --with pyyaml python3 \
+  .github/scripts/publish_matrix.py --validate
+```
+
+That checks the declared paths resolve, the image names are unique
+and registry-safe, and each Dockerfile sits inside its declared
+context. It does not check the nine rules above — those are a
+review conversation, not a linter.
+
+## When a published image breaks
+
+A build failure on `main` is classified before anyone is told about
+it. Infrastructure trouble — a registry 5xx, a rate limit, a runner
+out of disk — is never reported to a recipe owner, because a channel
+that blames you for a registry outage is a channel you learn to
+ignore.
+
+A genuine failure comments on the pull request that caused it. If
+the same image fails the next time it is built, a tracking issue is
+opened. Until it builds, the image is not published.
+
+---
+
+← [Checklist](../recipe-checklist.md) · [Handbook](./README.md)

--- a/docs/recipe-handbook/dockerfiles.md
+++ b/docs/recipe-handbook/dockerfiles.md
@@ -1,37 +1,49 @@
-<!-- word count: 903 (target 700, cap 1000) -->
+<!-- word count: 998 (target 700, cap 1000) -->
 
 # Dockerfile Standard
 
 The rules a recipe's `Dockerfile` must follow before its image is
 built and pushed to the public registry.
 
-This is a higher bar than "it builds on my machine", and the reason
-is the registry. A published image carries Google's name, is
-world-readable, and stays pullable long after the run that produced
-it. Every rule below exists because a real Dockerfile in this repo
-broke it.
+The bar is high because the registry is public: an image carries
+Google's name and stays pullable long after the run that built it.
+Almost every rule below is here because a real Dockerfile in this
+repo broke it.
 
-**Not every recipe needs this.** Most recipes are read, copied and
-adapted — they never ship an image. Deployability is opt-in. If your
-recipe has no `Dockerfile`, nothing here applies to you.
+**Not every recipe needs this.** Most recipes are read and adapted,
+never shipped as an image. Deployability is opt-in: if your recipe
+has no `Dockerfile`, nothing here applies to you.
+
+> **Publishing is not switched on yet.** Declared images are built on
+> every pull request and on merge, which is what verifies them, but
+> nothing is pushed: the push step waits on repository variables that
+> arrive with the hosting project. Meet the standard now and your
+> image ships when that lands — but do not tell anyone to pull it
+> yet, because there is nothing there.
 
 ## Getting an image published
 
 Publishing is an **allowlist**, not a scan. Adding a `Dockerfile`
 does not start publishing it; an entry in
 [`.github/policy.yml`](../../.github/policy.yml) under
-`deployability.publish.images` does, and only a repository admin can
-add one.
+`deployability.publish.images` does, and that file needs a
+maintainer's approval to change.
 
 That is deliberate. `docker build` runs every `RUN` instruction it is
-handed, and the result is published under Google's name — so which
-Dockerfiles earn that is a decision someone makes, not a side effect
-of adding a file.
+handed and the result carries Google's name, so which Dockerfiles
+earn that is a decision someone makes, not a side effect of adding a
+file.
 
 Bring your Dockerfile up to the standard below, then ask a
-maintainer to add the entry. Each entry declares four things: the
-Dockerfile path, the build context, the published image name, and
-whether the image serves HTTP.
+maintainer to add the entry. Each entry declares five things: the
+recipe directory, the Dockerfile path, the build context, the
+published image name, and whether the image serves HTTP.
+
+**The images declared today do not all meet this yet.** All three
+use a floating base tag and hardcode their port, and one runs as
+root. They were allowlisted on reproducibility — the property that
+makes an image explainable — and are being brought up to the rest.
+New entries are held to the whole standard.
 
 ## The nine rules
 
@@ -42,15 +54,15 @@ Install from a committed lockfile. `uv sync --frozen`, never bare
 `requirements.txt` if you use neither.
 
 Never delete a lockfile during the build. One recipe here runs
-`rm -f uv.lock && uv sync`, which means two builds of the same
-commit can produce different dependency sets — nobody can reproduce
-or explain the resulting image.
+`rm -f uv.lock && uv sync`, so two builds of the same commit can
+produce different dependency sets — nobody can reproduce or explain
+the resulting image.
 
 ### 2. Pinned base image
 
 Pin by digest, or at minimum an immutable tag. A floating tag like
-`ghcr.io/astral-sh/uv:python3.11-bookworm-slim` moves underneath you,
-so the image you tested is not the image you shipped.
+`python:3.12-slim` moves underneath you, so the image you tested is
+not the image you shipped.
 
 ### 3. Pinned build tools
 
@@ -61,15 +73,15 @@ repo already uses that exact pin; match it unless you have a reason.
 
 Use `${PORT:-8080}`. Cloud Run injects `PORT` and expects your
 container to listen on it; a hardcoded port breaks the moment it
-differs. The default matters just as much — `--port $PORT` with no
-fallback fails under a plain `docker run`.
+differs. The default matters too — `--port $PORT` with no fallback
+fails under a plain `docker run`.
 
 ### 5. Run as a non-root user
 
 Create an unprivileged user and `USER` to it before the entrypoint.
 Switch before installing dependencies if your runtime re-validates
-the environment at startup, so the virtualenv is owned by the user
-that runs it.
+the environment at startup, so the virtualenv is owned by whoever
+runs it.
 
 ### 6. Explicit `COPY`, plus a `.dockerignore`
 
@@ -78,42 +90,41 @@ in the directory into a public layer, including files added later by
 someone who never thought about your image.
 
 Ship a `.dockerignore` covering at least `.venv/`, `.env`, `.git/`
-and `gha-creds-*.json`. That last one is not hypothetical: the build
-workflow authenticates to Google Cloud in the same job, and a
-credential file landing in the build context is exactly the accident
-this line prevents.
+and `gha-creds-*.json`. The build workflow authenticates to Google
+Cloud in the same job. It is configured to keep that credential out
+of the workspace entirely — but that is one setting away from not
+being true, and a `COPY` that cannot reach the file does not depend
+on the setting.
 
 ### 7. No configuration or secrets in `ENV`
 
 `ENV` is for build metadata — `COMMIT_SHA`, `AGENT_VERSION` — and
 nothing else.
 
-Configuration arrives at runtime, through `docker run -e`,
-`--env-file`, or Cloud Run environment variables. Baking it in does
-not save anyone a step: `-e` works whether or not the Dockerfile
-declares the variable. What it does do is freeze a value into a
-world-readable layer and go stale — an `ENV MODEL_NAME=...` is wrong
-for every operator the day that model is deprecated.
+Configuration arrives at runtime, via `docker run -e`, `--env-file`
+or Cloud Run. Baking it in saves nobody a step — `-e` works whether
+or not the Dockerfile declares the variable — and it freezes a value
+into a world-readable layer that goes stale: an
+`ENV MODEL_NAME=...` is wrong for every operator the day that model
+is deprecated.
 
 ### 8. No unpinned network fetches at build time
 
-Downloading model weights, remote installers or anything else
-unpinned during the build makes it depend on a third-party host
-staying up and serving the same bytes. It also means you may be
-redistributing someone else's artifact under your image's licence.
+Fetching model weights or remote installers during the build ties it
+to a third-party host serving the same bytes tomorrow. It can also
+mean redistributing someone else's artifact under your licence.
 
 ### 9. Declared, not inferred
 
 The build context is declared per image, not guessed from the
-Dockerfile's location. Several Dockerfiles here live in a
+Dockerfile's location. Several Dockerfiles here sit in a
 subdirectory and `COPY` from the recipe root, so
-`dirname(Dockerfile)` is the wrong answer often enough that guessing
-it would generate bugs.
+`dirname(Dockerfile)` is wrong often enough that guessing would
+generate bugs.
 
-The same goes for whether the image serves HTTP. Not every
-publishable image is a server — one here is a base image for
-pipeline components and has no `CMD` at all — and probing it like a
-web service would report a healthy image as broken.
+Whether the image serves HTTP is declared too. Not every publishable
+image is a server — one here is a pipeline base image with no `CMD`
+— and probing it like a web service would report it broken.
 
 ## Checking your work
 
@@ -127,16 +138,15 @@ uv run --no-project --with pyyaml python3 \
 
 That checks the declared paths resolve, the image names are unique
 and registry-safe, and each Dockerfile sits inside its declared
-context. It does not check the nine rules above — those are a
-review conversation, not a linter.
+context. It does not check the nine rules above — those are a review
+conversation, not a linter.
 
-## When a published image breaks
+## When a build breaks
 
-A build failure on `main` is classified before anyone is told about
-it. Infrastructure trouble — a registry 5xx, a rate limit, a runner
-out of disk — is never reported to a recipe owner, because a channel
-that blames you for a registry outage is a channel you learn to
-ignore.
+A build failure on `main` is classified before anyone is told.
+Infrastructure trouble — a registry 5xx, a rate limit, a runner out
+of disk — is never reported to an owner, because a channel that
+blames you for a registry outage is one you learn to ignore.
 
 A genuine failure comments on the pull request that caused it. If
 the same image fails the next time it is built, a tracking issue is


### PR DESCRIPTION
Fixes b/557342137. Phase 5 of the recipe image pipeline — the last unblocked one.

## Why

The rules an image must meet before it is published were spread across a comment in `policy.yml`, a docstring in `publish_matrix.py`, and three PR descriptions. An owner who wanted their recipe published had nowhere to read them and no way to act without asking.

## What

New `docs/recipe-handbook/dockerfiles.md` (903 words), linked from the handbook index and from the checklist next to the existing `make-python-recipe-deployable` entry.

**It opens by telling most people to stop reading.** Deployability is opt-in; most recipes are read and adapted, never shipped as an image. Burying that would waste the time of every contributor it doesn't apply to.

**Each rule carries the failure it prevents**, not just the rule. The reasoning is what makes a rule survive contact with someone who has a reason to break it — "pin your base image" is easy to wave away, "the image you tested is not the image you shipped" less so.

**Every example is a real Dockerfile in this repo**, re-verified against the files before pushing:

| Claim in the doc | Verified against |
|---|---|
| a recipe deletes its lockfile mid-build | `genmedia-for-commerce/Dockerfile:52` — `rm -f uv.lock && uv sync --no-cache` |
| a floating base tag | `ambient-expense-agent/Dockerfile:1` |
| a publishable image with no `CMD` | `multiformat-hybrid-rag/data_ingestion_pipeline/Dockerfile` |
| `uv==0.8.13` is the repo's pin | `long-horizon-harness/Dockerfile` |

**It also covers what happens after publishing** — that a build failure is classified first, and that infrastructure trouble is never reported to a recipe owner. Someone who gets no comment after a registry outage should know that was deliberate rather than a gap.

## Verification

```
32 relative links across the three touched files   # 0 dead
publish_matrix.py --validate                       # the command the doc tells people to run — 3 images valid
```

Claims cross-checked programmatically against `policy.yml`, `publish_matrix.py` and `image_build_report.py`, and the three Dockerfile examples re-read directly. Word-count headers updated on all three files to match the repo convention.

## Not in scope

The five non-conforming Dockerfiles are unchanged — this branch touches `docs/` only. The page gives their owners what they need to fix them without waiting on anything.

## Pipeline status

1. Declaration + allowlist — merged (#2592)
2. Build workflow, publishing inert — merged (#2593)
3. Turn on publishing — **blocked** on the public-AR org-policy exception and the GCP project
4. Failure classification + notification — merged (#2594)
5. This
