### PR TITLE
fix(ci): stop a bot comment cancelling the AI review it races

### DIFF
--- a/.github/scripts/tests/test_ai_workflow_hardening.py
+++ b/.github/scripts/tests/test_ai_workflow_hardening.py
@@ -508,3 +508,98 @@ def test_the_diff_is_marked_untrusted_in_the_prompt():
         line for line in script.splitlines() if "Complete unified diff" in line
     )
     assert "UNTRUSTED" in diff_header
+
+
+# --------------------------------------------------------------------------
+# The lane concurrency groups
+#
+# `pull_request_target` and `issue_comment` resolve the PR number to the same
+# value, so the four lanes have to push them apart by hand or every comment on
+# a PR cancels the review that PR's own opening started (#2596, #2577, #2582).
+# GitHub evaluates the group when a run is CREATED, so the job-level `if:`
+# cannot undo it: by the time a comment run skips itself, it has already
+# evicted the real review.
+#
+# What separates them is a trailing segment that must be the exact negation of
+# the `issue_comment` branch of the job's `if:`. Get that wrong in the lax
+# direction — test the `@ai-review` mention but not the association — and any
+# user can put a comment run into the shared group and cancel all four reviews
+# on any open PR at will. Between the `if:` and the group there are eight
+# copies of the gate across the four lanes, and nothing else in CI would
+# notice them drifting apart.
+# --------------------------------------------------------------------------
+
+LANES = sorted(WORKFLOWS.glob("ai-pr-review-*.yml"))
+
+# The operands of the `issue_comment` branch of each lane's `if:`. Written as
+# the substrings that carry the meaning, so reformatting the expression does
+# not trip the test but dropping a check does.
+INVOKE_OPERANDS = (
+    "github.event.issue.pull_request",
+    "contains(github.event.comment.body, '@ai-review')",
+    "github.event.comment.author_association",
+)
+
+
+def _squash(text: str) -> str:
+    return " ".join(str(text).split())
+
+
+def test_the_lane_files_were_all_found():
+    """A glob that matches nothing turns every test below into a pass."""
+    assert len(LANES) == 4, (
+        f"expected 4 review lanes, found {[p.name for p in LANES]}"
+    )
+
+
+@pytest.mark.parametrize("path", LANES, ids=lambda p: p.name)
+def test_a_comment_run_that_cannot_review_cannot_cancel_one(path):
+    """The group's gate must match the job's, operand for operand.
+
+    The failure this prevents is not a broken workflow — it is a working one
+    that an outsider can switch off. A gate testing only for `@ai-review`
+    leaves the association check out, so a comment from anyone at all shares
+    the group with the in-flight review, cancels it, and is then skipped.
+    """
+    workflow = _load(path)
+    group = _squash(workflow["concurrency"]["group"])
+    condition = _squash(workflow["jobs"]["trigger"]["if"])
+
+    for operand in INVOKE_OPERANDS:
+        assert operand in condition, (
+            f"{path.name}: the job's `if:` no longer checks {operand!r}; if the "
+            "invoke gate moved, move the concurrency gate with it"
+        )
+        assert operand in group, (
+            f"{path.name}: the concurrency group does not check {operand!r} but "
+            "the job's `if:` does. A comment failing only that check would land "
+            "in the shared group and cancel the running review."
+        )
+
+
+@pytest.mark.parametrize("path", LANES, ids=lambda p: p.name)
+def test_a_non_reviewing_comment_run_is_keyed_to_itself(path):
+    """`github.run_id`, negated, and only for `issue_comment`.
+
+    Without the negation the gate is inverted and real invokes get the unique
+    key while bot comments keep the shared one — the original bug, silently.
+    """
+    group = _squash(_load(path)["concurrency"]["group"])
+    assert "github.run_id" in group, (
+        "nothing gives a comment run a key of its own"
+    )
+    assert "github.event_name == 'issue_comment'" in group, (
+        "the unique key is not scoped to comments, so a pull_request_target run "
+        "could get one and stop superseding its own earlier run"
+    )
+    assert "&& !(" in group, "the invoke gate is not negated"
+
+
+@pytest.mark.parametrize("path", LANES, ids=lambda p: p.name)
+def test_a_push_still_supersedes_the_review_it_replaces(path):
+    """The PR-number key survives, and in-progress runs are still cancelled."""
+    concurrency = _load(path)["concurrency"]
+    group = _squash(concurrency["group"])
+    assert "github.event.pull_request.number" in group
+    assert "github.event.issue.number" in group
+    assert concurrency["cancel-in-progress"] is True

--- a/.github/workflows/ai-pr-review-correctness.yml
+++ b/.github/workflows/ai-pr-review-correctness.yml
@@ -59,12 +59,27 @@ on: # zizmor: ignore[dangerous-triggers]
 # seconds in, and three of them stayed that way until someone re-ran
 # them by hand. Same shape on #2577 twice and on #2582.
 #
-# So a comment that is NOT an `@ai-review` invoke gets a group of its
-# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# So a comment run that will NOT start a review gets a group of its own,
+# keyed on its run id, where it can cancel nothing. A real invoke keeps
 # the shared group on purpose: re-invoking should supersede a review
-# that is already running.
+# that is already running, as should a synchronize.
+#
+# The condition below MUST stay the exact negation of the `issue_comment`
+# branch of the job's `if:`, all three operands of it. Testing only for
+# `@ai-review` is not a near-enough approximation: the association check
+# is what makes an invoke a maintainer's call, so without it ANY user can
+# put a comment run into the shared group — and cancel all four reviews
+# on any open PR, repeatably, by typing `@ai-review`. That hands an
+# outsider a switch for the Security lane, which is strictly worse than
+# the CLA-bot collision this segment was added to fix.
+#
+# `test_ai_workflow_hardening.py` pins the two conditions together, in
+# all four lanes. Between the `if:` and the group there are eight copies
+# of this gate in the repo, and nothing else would notice them drifting
+# apart.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !(github.event.issue.pull_request && contains(github.event.comment.body, '@ai-review') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) && github.run_id || '' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-correctness.yml
+++ b/.github/workflows/ai-pr-review-correctness.yml
@@ -45,8 +45,26 @@ on: # zizmor: ignore[dangerous-triggers]
         default: true
         type: 'boolean'
 
+# The trailing segment exists because `issue_comment` and
+# `pull_request_target` resolve the PR number to the SAME value, and so
+# without it produce the SAME group — which means ANY comment on a PR
+# cancels the review that the PR's own opening started. GitHub applies
+# `cancel-in-progress` when a run is CREATED, before the job-level `if:`
+# below is evaluated, so a comment run that goes on to skip has already
+# evicted the real one by then.
+#
+# That is not a rare race. `google-cla[bot]` comments on a first-time
+# contributor's PR within ~10 seconds of it opening, well inside the
+# ~90 seconds a review takes: on #2596 all four lanes were cancelled 13
+# seconds in, and three of them stayed that way until someone re-ran
+# them by hand. Same shape on #2577 twice and on #2582.
+#
+# So a comment that is NOT an `@ai-review` invoke gets a group of its
+# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# the shared group on purpose: re-invoking should supersede a review
+# that is already running.
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}'
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-hygiene.yml
+++ b/.github/workflows/ai-pr-review-hygiene.yml
@@ -75,12 +75,27 @@ on: # zizmor: ignore[dangerous-triggers]
 # seconds in, and three of them stayed that way until someone re-ran
 # them by hand. Same shape on #2577 twice and on #2582.
 #
-# So a comment that is NOT an `@ai-review` invoke gets a group of its
-# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# So a comment run that will NOT start a review gets a group of its own,
+# keyed on its run id, where it can cancel nothing. A real invoke keeps
 # the shared group on purpose: re-invoking should supersede a review
-# that is already running.
+# that is already running, as should a synchronize.
+#
+# The condition below MUST stay the exact negation of the `issue_comment`
+# branch of the job's `if:`, all three operands of it. Testing only for
+# `@ai-review` is not a near-enough approximation: the association check
+# is what makes an invoke a maintainer's call, so without it ANY user can
+# put a comment run into the shared group — and cancel all four reviews
+# on any open PR, repeatably, by typing `@ai-review`. That hands an
+# outsider a switch for the Security lane, which is strictly worse than
+# the CLA-bot collision this segment was added to fix.
+#
+# `test_ai_workflow_hardening.py` pins the two conditions together, in
+# all four lanes. Between the `if:` and the group there are eight copies
+# of this gate in the repo, and nothing else would notice them drifting
+# apart.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !(github.event.issue.pull_request && contains(github.event.comment.body, '@ai-review') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) && github.run_id || '' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-hygiene.yml
+++ b/.github/workflows/ai-pr-review-hygiene.yml
@@ -61,8 +61,26 @@ on: # zizmor: ignore[dangerous-triggers]
         default: true
         type: 'boolean'
 
+# The trailing segment exists because `issue_comment` and
+# `pull_request_target` resolve the PR number to the SAME value, and so
+# without it produce the SAME group — which means ANY comment on a PR
+# cancels the review that the PR's own opening started. GitHub applies
+# `cancel-in-progress` when a run is CREATED, before the job-level `if:`
+# below is evaluated, so a comment run that goes on to skip has already
+# evicted the real one by then.
+#
+# That is not a rare race. `google-cla[bot]` comments on a first-time
+# contributor's PR within ~10 seconds of it opening, well inside the
+# ~90 seconds a review takes: on #2596 all four lanes were cancelled 13
+# seconds in, and three of them stayed that way until someone re-ran
+# them by hand. Same shape on #2577 twice and on #2582.
+#
+# So a comment that is NOT an `@ai-review` invoke gets a group of its
+# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# the shared group on purpose: re-invoking should supersede a review
+# that is already running.
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}'
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-maintainability.yml
+++ b/.github/workflows/ai-pr-review-maintainability.yml
@@ -59,12 +59,27 @@ on: # zizmor: ignore[dangerous-triggers]
 # seconds in, and three of them stayed that way until someone re-ran
 # them by hand. Same shape on #2577 twice and on #2582.
 #
-# So a comment that is NOT an `@ai-review` invoke gets a group of its
-# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# So a comment run that will NOT start a review gets a group of its own,
+# keyed on its run id, where it can cancel nothing. A real invoke keeps
 # the shared group on purpose: re-invoking should supersede a review
-# that is already running.
+# that is already running, as should a synchronize.
+#
+# The condition below MUST stay the exact negation of the `issue_comment`
+# branch of the job's `if:`, all three operands of it. Testing only for
+# `@ai-review` is not a near-enough approximation: the association check
+# is what makes an invoke a maintainer's call, so without it ANY user can
+# put a comment run into the shared group — and cancel all four reviews
+# on any open PR, repeatably, by typing `@ai-review`. That hands an
+# outsider a switch for the Security lane, which is strictly worse than
+# the CLA-bot collision this segment was added to fix.
+#
+# `test_ai_workflow_hardening.py` pins the two conditions together, in
+# all four lanes. Between the `if:` and the group there are eight copies
+# of this gate in the repo, and nothing else would notice them drifting
+# apart.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !(github.event.issue.pull_request && contains(github.event.comment.body, '@ai-review') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) && github.run_id || '' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-maintainability.yml
+++ b/.github/workflows/ai-pr-review-maintainability.yml
@@ -45,8 +45,26 @@ on: # zizmor: ignore[dangerous-triggers]
         default: true
         type: 'boolean'
 
+# The trailing segment exists because `issue_comment` and
+# `pull_request_target` resolve the PR number to the SAME value, and so
+# without it produce the SAME group — which means ANY comment on a PR
+# cancels the review that the PR's own opening started. GitHub applies
+# `cancel-in-progress` when a run is CREATED, before the job-level `if:`
+# below is evaluated, so a comment run that goes on to skip has already
+# evicted the real one by then.
+#
+# That is not a rare race. `google-cla[bot]` comments on a first-time
+# contributor's PR within ~10 seconds of it opening, well inside the
+# ~90 seconds a review takes: on #2596 all four lanes were cancelled 13
+# seconds in, and three of them stayed that way until someone re-ran
+# them by hand. Same shape on #2577 twice and on #2582.
+#
+# So a comment that is NOT an `@ai-review` invoke gets a group of its
+# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# the shared group on purpose: re-invoking should supersede a review
+# that is already running.
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}'
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-security.yml
+++ b/.github/workflows/ai-pr-review-security.yml
@@ -59,12 +59,27 @@ on: # zizmor: ignore[dangerous-triggers]
 # seconds in, and three of them stayed that way until someone re-ran
 # them by hand. Same shape on #2577 twice and on #2582.
 #
-# So a comment that is NOT an `@ai-review` invoke gets a group of its
-# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# So a comment run that will NOT start a review gets a group of its own,
+# keyed on its run id, where it can cancel nothing. A real invoke keeps
 # the shared group on purpose: re-invoking should supersede a review
-# that is already running.
+# that is already running, as should a synchronize.
+#
+# The condition below MUST stay the exact negation of the `issue_comment`
+# branch of the job's `if:`, all three operands of it. Testing only for
+# `@ai-review` is not a near-enough approximation: the association check
+# is what makes an invoke a maintainer's call, so without it ANY user can
+# put a comment run into the shared group — and cancel all four reviews
+# on any open PR, repeatably, by typing `@ai-review`. That hands an
+# outsider a switch for the Security lane, which is strictly worse than
+# the CLA-bot collision this segment was added to fix.
+#
+# `test_ai_workflow_hardening.py` pins the two conditions together, in
+# all four lanes. Between the `if:` and the group there are eight copies
+# of this gate in the repo, and nothing else would notice them drifting
+# apart.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !(github.event.issue.pull_request && contains(github.event.comment.body, '@ai-review') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) && github.run_id || '' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ai-pr-review-security.yml
+++ b/.github/workflows/ai-pr-review-security.yml
@@ -45,8 +45,26 @@ on: # zizmor: ignore[dangerous-triggers]
         default: true
         type: 'boolean'
 
+# The trailing segment exists because `issue_comment` and
+# `pull_request_target` resolve the PR number to the SAME value, and so
+# without it produce the SAME group — which means ANY comment on a PR
+# cancels the review that the PR's own opening started. GitHub applies
+# `cancel-in-progress` when a run is CREATED, before the job-level `if:`
+# below is evaluated, so a comment run that goes on to skip has already
+# evicted the real one by then.
+#
+# That is not a rare race. `google-cla[bot]` comments on a first-time
+# contributor's PR within ~10 seconds of it opening, well inside the
+# ~90 seconds a review takes: on #2596 all four lanes were cancelled 13
+# seconds in, and three of them stayed that way until someone re-ran
+# them by hand. Same shape on #2577 twice and on #2582.
+#
+# So a comment that is NOT an `@ai-review` invoke gets a group of its
+# own, keyed on its run id, where it can cancel nothing. An invoke keeps
+# the shared group on purpose: re-invoking should supersede a review
+# that is already running.
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}'
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}-${{ (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@ai-review')) && github.run_id || '' }}"
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
The four AI review lanes are cancelled seconds after they start whenever anything comments on the PR. Most often that is `google-cla[bot]` greeting a first-time external contributor — so the PRs that most need reviewing are the ones reliably left without a review.

## Cause

All four lanes keyed their concurrency group on the PR number alone:

```yaml
group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || ... }}'
cancel-in-progress: true
```

`pull_request_target` resolves that through `pull_request.number` and `issue_comment` through `issue.number` — the same number, so the same group. Every comment therefore evicts the review the PR's own opening started.

The eviction cannot be prevented downstream. GitHub applies `cancel-in-progress` when a run is **created**, before job-level `if:` conditions are evaluated, so the comment run kills the real review and only then skips itself for lacking `@ai-review`. Nothing goes red; the PR is left with no review and nothing to explain why.

## Evidence

PR #2596, all four lanes:

| time | event |
|---|---|
| 17:16:03 | PR opened → 4 `pull_request_target` runs start |
| 17:16:12 | `google-cla[bot]` comments |
| 17:16:15 | 4 `issue_comment` runs created, same group |
| 17:16:16–19 | the 4 review runs cancelled mid-step |

Correctness shows green there only because it was re-run by hand a day later (`run_attempt: 2`). Same shape on #2577 (twice) and #2582 — every `cancelled` run in the lanes' history pairs with an `issue_comment` run seconds behind it.

## Fix

A trailing group segment that gives non-invoking comments a key of their own:

| event | trailing segment | effect |
|---|---|---|
| `pull_request_target` | `''` | shares the group — a synchronize still cancels the prior review |
| `issue_comment`, no `@ai-review` | `github.run_id` | own group; a bot comment can cancel nothing |
| `issue_comment` with `@ai-review` | `''` | shares the group — a re-invoke still supersedes a running review |
| `workflow_dispatch` | `''` | unchanged |

Cancellation semantics are otherwise deliberately unchanged.

The scalar moves from single to double quotes: the expression needs single quotes for `'issue_comment'`, `'@ai-review'` and `''`, which cannot sit unescaped inside a single-quoted YAML scalar.

## Verification

`actionlint` clean on all four lanes and `_ai-pr-review-core.yml`; the group expression parses and resolves as tabled above. zizmor was not run locally — this PR's own Actions Scan covers it.

The real proof is this PR: it is a fork-less branch and will not draw a CLA comment, so watch instead that the four lanes survive a comment posted while they run.
