### PR TITLE
fix(ci): stop AI review failing on a pull request that changes nothing

### DIFF
--- a/.github/workflows/_ai-pr-review-core.yml
+++ b/.github/workflows/_ai-pr-review-core.yml
@@ -313,6 +313,18 @@ jobs:
             echo "max_diff_files=${MAX_DIFF_FILES}"
           } >> "${GITHUB_OUTPUT}"
 
+          # A PR that changes nothing is a legitimate state, not a fault. It
+          # has to be caught HERE rather than at the diff fetch below, because
+          # that step cannot tell "this PR changes nothing" apart from "the API
+          # returned nothing" — it sees an empty pr_diff.txt either way and
+          # fails the lane. #2600 (a draft opened with 0 changed files) failed
+          # all four lanes that way, mailing the author four times per push.
+          if (( TOTAL_COUNT == 0 )); then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "PR has no changed files; nothing to review."
+            exit 0
+          fi
+
           if (( TOTAL_COUNT > MAX_DIFF_FILES )); then
             echo "skip=true" >> "${GITHUB_OUTPUT}"
             echo "${TOTAL_COUNT} files changed, above the ${MAX_DIFF_FILES}-file diff API limit; skipping."
@@ -1253,8 +1265,12 @@ jobs:
     # Both reasons this job exists, and nothing else. A clean PR that produced
     # no findings is the common case, and spinning a runner up to discover
     # that every step is skipped costs four runners per push across the lanes.
+    # The `total_files != 0` guard keeps an empty PR from spinning four
+    # runners up to say nothing: a 0-file PR also sets `skip`, but it has no
+    # comment to post (see the report step below).
     if: |-
-      needs.review.outputs.skip == 'true' ||
+      (needs.review.outputs.skip == 'true' &&
+       needs.review.outputs.total_files != '0') ||
       needs.review.outputs.has_payload == 'true'
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
@@ -1279,8 +1295,12 @@ jobs:
       # Worked out in `review`, said here, because that job holds no token
       # that can say anything.
       - name: 'Report a PR too large to diff'
+        # `skip` covers two cases and only one of them has anything to say
+        # here. A 0-file PR would otherwise be told it is "above the 300 files
+        # the diff API will serve", which is both false and confusing.
         if: |-
-          needs.review.outputs.skip == 'true'
+          needs.review.outputs.skip == 'true' &&
+          needs.review.outputs.total_files != '0'
         env:
           GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN_SECRET }}'
           # REQUIRED, not tidiness. This job takes no checkout, so there is no


### PR DESCRIPTION
## Problem

A pull request with **zero changed files** is a legitimate state, but the AI reviewer treats it as a fault.

`_ai-pr-review-core.yml` asserts a non-empty `pr_diff.txt` after fetching the diff, on the reasoning recorded in its own comment — *"the new-file-only guard has already run, so a reviewable PR always has a non-empty diff. Empty here means something went wrong."* When that does not hold it exits 1.

It does not hold for an empty PR. #2600, a draft opened with no files, failed **all four lanes** and mailed its author four times per push:

```
##[error]gh pr diff returned an empty diff for PR #2600; refusing to review.
```

## Fix

The assertion is worth keeping. At that point an empty `pr_diff.txt` genuinely is ambiguous — the step cannot tell *"this PR changes nothing"* apart from *"the API returned nothing"*, and the second really is a failure.

So resolve the ambiguity one step earlier, in `diff_size_guard`, where the file count is already in hand for the 300-file check:

```bash
if (( TOTAL_COUNT == 0 )); then
  echo "skip=true" >> "${GITHUB_OUTPUT}"
  echo "PR has no changed files; nothing to review."
  exit 0
fi
```

`skip` already gates all twelve downstream steps, so the lanes go green without reaching the fetch.

## The second half

`skip` now covers two cases, and only one of them has anything to say to the author. Left alone, an empty PR would be told:

> This PR changes **0** files, above the 300 GitHub's diff API will serve, so automated AI review was skipped.

Both false and confusing, four times over. The report step and the `post` job are therefore guarded on `total_files != '0'` — which also stops an empty PR spinning up four runners to reach a step that posts nothing, consistent with the cost note already on that job.

## Verification

- `.github/scripts/tests/` — **416 passed**
- Workflow parses; `post` job condition resolves as intended

## Not included

Investigating this surfaced two unrelated issues, deliberately left out:

- **`CODEOWNERS` has two dead entries.** GitHub's validator reports `Unknown owner` for `@tklopfenstein` on lines 19 and 26 — he holds `read`, and code owners need `write`. `/core/go/**` and `/contrib/go/**` consequently have *no* code owner, since a matching rule assigns nobody and the catch-all does not apply. The fix is an access grant, not a file edit.
- **Dependabot security-update jobs fail by construction.** The blanket `ignore: "*"` in `dependabot.yml` makes every security job exit with `all_versions_ignored` (upstream dependabot-core#9085). Disabling the repository's Dependabot security-updates setting would stop the jobs being created at all; alerts are a separate toggle and would be unaffected.

🤖 Generated with CloudCode — session `ses_e5f792d3ac4ffe1bgYj0AVUA7L`