### PR TITLE
fix(ci): name the real Go code owner, who is @ToniCorinne

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,20 +10,28 @@
 #
 # HOW TO CHANGE A LANGUAGE REVIEWER:
 #   Find the relevant line(s) below and replace the username.
+#
+# THE USERNAME IS A LOGIN, NOT A NAME, AND NEEDS WRITE ACCESS:
+#   Use the GitHub login exactly — Toni Klopfenstein is @ToniCorinne, not
+#   @tklopfenstein. A guessed handle can belong to an unrelated account, and
+#   an owner without write access is silently dropped, leaving the path with
+#   NO owner rather than falling back to the catch-all. Both mistakes were
+#   live on the Go lines until #2604. Verify a change with:
+#     gh api repos/google/adk-samples/codeowners/errors
 
 # Catch-all: docs, CI workflows, root configs, anything not matched below
 * @happyhuman
 
 # --- core/ ---
 /core/python/**        @eliasecchig
-/core/go/**            @tklopfenstein
+/core/go/**            @ToniCorinne
 /core/java/**          @eliasecchig
 /core/typescript/**    @happyhuman
 /core/kotlin/**        @happyhuman
 
 # --- contrib/ ---
 /contrib/python/**     @happyhuman
-/contrib/go/**         @tklopfenstein
+/contrib/go/**         @ToniCorinne
 /contrib/java/**       @happyhuman
 /contrib/typescript/** @happyhuman
 /contrib/kotlin/**     @happyhuman

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 #   @tklopfenstein. A guessed handle can belong to an unrelated account, and
 #   an owner without write access is silently dropped, leaving the path with
 #   NO owner rather than falling back to the catch-all. Both mistakes were
-#   live on the Go lines until #2604. Verify a change with:
+#   live on the Go lines until #2605. Verify a change with:
 #     gh api repos/google/adk-samples/codeowners/errors
 
 # Catch-all: docs, CI workflows, root configs, anything not matched below


### PR DESCRIPTION
## Problem

`/core/go/**` and `/contrib/go/**` were assigned to `@tklopfenstein`. That handle looks derived from Toni Klopfenstein's **display name** rather than read off her account — her login is **`@ToniCorinne`**.

`@tklopfenstein` is a real GitHub account, but it belongs to someone unconnected to this repository and holds no access to it.

GitHub has been reporting this the whole time. Nothing surfaced it:

```console
$ gh api repos/google/adk-samples/codeowners/errors
19  Unknown owner  /core/go/**      @tklopfenstein
26  Unknown owner  /contrib/go/**   @tklopfenstein
```

## Why it matters

The Go paths were unowned — and not harmlessly. A matching rule that resolves to nobody **does not fall through to the `*` catch-all**; it assigns no one. So Go changes could be approved by any user with write access, bypassing the review gate this file exists to enforce.

Per GitHub's docs: *"If you specify a user or team that doesn't exist or has insufficient access, a code owner will not be assigned."*

## Fix

Point both lines at `@ToniCorinne`, who holds `maintain` on this repository — sufficient for the code-owner write requirement.

```console
$ gh api repos/google/adk-samples/collaborators/ToniCorinne/permission
{"permission": "write", "role_name": "maintain"}
```

## Verification

Validator run against this branch:

```console
$ gh api "repos/google/adk-samples/codeowners/errors?ref=fix/codeowners-go-owner-username"
NO ERRORS
```

## Header note

The instructions above these lines say *"replace the username"* without mentioning that it must be a **login** rather than a name, or that an owner lacking write access is **dropped silently** rather than erroring. Both traps were live here simultaneously, so both are now documented, along with the one-line command to check.

## Context

Found while investigating a flood of workflow-failure emails. Two related items are **not** in this PR:

- **Recipe-level ownership routing.** 22 `manifest.yaml` files declare `ownership.poc` naming 14 people, but 12 of them hold `read` — so they cannot be code owners today. Routing recipes to their real owners needs access grants first, not a CODEOWNERS edit.
- **The `* @happyhuman` catch-all**, which currently absorbs ~40 legacy recipes, all of `contrib/`, all of `skills/`, all CI, docs and root config. Unchanged here.

🤖 Generated with CloudCode — session `ses_e5f792d3ac4ffe1bgYj0AVUA7L`