### PR TITLE
Fix AI issue response extraction, human tone guidelines, and completion closing

### DIFF
--- a/.github/scripts/process_issue_response.py
+++ b/.github/scripts/process_issue_response.py
@@ -5,17 +5,18 @@ Used by .github/workflows/_ai-issue-response-core.yml. Parses the JSON output
 from Antigravity CLI (agy), validates the selected core functional option
 (clarify, simple solution, detailed solution, acknowledge and assign), resolves
 developer assignment based on repository ownership paths when Option 4 is
-selected, and prepares the response comment.
+selected, determines whether to close the issue when a complete solution is
+provided, and prepares the response comment.
 
 Routing rules for Option 4:
   Catch-all (docs, CI workflows, root configs, unmatched): @happyhuman
   /core/python/**      -> @eliasecchig
-  /core/go/**          -> @tklopfenstein
+  /core/go/**          -> @ToniCorinne
   /core/java/**        -> @eliasecchig
   /core/typescript/**  -> @happyhuman
   /core/kotlin/**      -> @happyhuman
   /contrib/python/**   -> @happyhuman
-  /contrib/go/**       -> @tklopfenstein
+  /contrib/go/**       -> @ToniCorinne
   /contrib/java/**     -> @happyhuman
   /contrib/typescript/** -> @happyhuman
   /contrib/kotlin/**   -> @happyhuman
@@ -27,10 +28,11 @@ Usage:
     --issue-number 123 \\
     --comment-out comment.md \\
     --assignee-out assignee.txt \\
+    [--close-out close.txt] \\
     [--github-output "$GITHUB_OUTPUT"]
 
 Exit codes:
-  0  success (comment and optional assignee written)
+  0  success (comment and optional assignee/close flag written)
   2  CI fault (unreadable result or execution crash)
 """
 
@@ -67,13 +69,13 @@ class Option(IntEnum):
 ROUTING_RULES: list[tuple[str, str]] = [
     # Core directory assignments
     ("core/python", "eliasecchig"),
-    ("core/go", "tklopfenstein"),
+    ("core/go", "ToniCorinne"),
     ("core/java", "eliasecchig"),
     ("core/typescript", "happyhuman"),
     ("core/kotlin", "happyhuman"),
     # Contrib directory assignments
     ("contrib/python", "happyhuman"),
-    ("contrib/go", "tklopfenstein"),
+    ("contrib/go", "ToniCorinne"),
     ("contrib/java", "happyhuman"),
     ("contrib/typescript", "happyhuman"),
     ("contrib/kotlin", "happyhuman"),
@@ -84,7 +86,7 @@ ROUTING_RULES: list[tuple[str, str]] = [
 DEFAULT_ASSIGNEE = "happyhuman"
 
 # Known developer usernames (without @ prefix)
-VALID_ASSIGNEES = {"eliasecchig", "tklopfenstein", "happyhuman"}
+VALID_ASSIGNEES = {"eliasecchig", "ToniCorinne", "happyhuman"}
 
 FENCED_JSON = re.compile(
     r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL | re.IGNORECASE
@@ -178,44 +180,170 @@ def parse_option(raw_option: Any) -> Option:
     return Option.ACKNOWLEDGE_AND_ASSIGN
 
 
+def find_json_objects(text: str) -> list[dict[str, Any]]:
+    """Find and parse all valid JSON objects in text, balancing braces."""
+    results: list[dict[str, Any]] = []
+    text_len = len(text)
+    i = 0
+    while i < text_len:
+        if text[i] == "{":
+            depth = 0
+            in_string = False
+            escape = False
+            start_idx = i
+            end_idx = -1
+            for j in range(start_idx, text_len):
+                char = text[j]
+                if escape:
+                    escape = False
+                    continue
+                if char == "\\":
+                    if in_string:
+                        escape = True
+                    continue
+                if char == '"':
+                    in_string = not in_string
+                    continue
+                if not in_string:
+                    if char == "{":
+                        depth += 1
+                    elif char == "}":
+                        depth -= 1
+                        if depth == 0:
+                            end_idx = j
+                            break
+            if end_idx != -1:
+                candidate = text[start_idx : end_idx + 1]
+                try:
+                    parsed = json.loads(candidate)
+                    if isinstance(parsed, dict):
+                        results.append(parsed)
+                except json.JSONDecodeError:
+                    pass
+                i = end_idx + 1
+                continue
+        i += 1
+    return results
+
+
+def _score_decision_candidate(d: dict[str, Any]) -> int:
+    """Score candidate dicts to identify the actual decision payload."""
+    score = 0
+    if "option" in d:
+        score += 10
+    if "response" in d and isinstance(d["response"], str):
+        score += 5
+    if "close_issue" in d or "close" in d:
+        score += 2
+    if "path" in d or "assignee" in d:
+        score += 1
+    if "status" in d:
+        # Penalize outer agy envelopes {"status": "SUCCESS", "response": ...}
+        score -= 20
+    return score
+
+
 def extract_decision_json(raw_text: str) -> dict[str, Any]:
     """Extract and parse the JSON decision from agy output."""
     raw_text = raw_text.strip()
     if not raw_text:
         raise ValueError("Empty output from AI agent.")
 
+    text_to_search = raw_text
+
     # Check if raw_text is the agy envelope JSON: {"status": ..., "response": ...}
     try:
-        parsed = json.loads(raw_text)
-        if isinstance(parsed, dict):
-            if "response" in parsed and isinstance(parsed["response"], str):
-                inner = parsed["response"].strip()
-                # If inner has markdown fences, extract JSON from them
-                match = FENCED_JSON.search(inner)
-                if match:
-                    return json.loads(match.group(1))
-                try:
-                    return json.loads(inner)
-                except json.JSONDecodeError:
-                    pass
-            elif "option" in parsed or "response" in parsed:
-                return parsed
+        envelope = json.loads(raw_text)
+        if isinstance(envelope, dict) and "status" in envelope:
+            if "response" in envelope:
+                if isinstance(envelope["response"], str):
+                    text_to_search = envelope["response"].strip()
+                elif isinstance(envelope["response"], dict):
+                    return envelope["response"]
     except json.JSONDecodeError:
         pass
 
-    # Check for markdown code fence in raw text
-    match = FENCED_JSON.search(raw_text)
-    if match:
-        return json.loads(match.group(1))
+    # Try direct parse of text_to_search first
+    try:
+        parsed = json.loads(text_to_search)
+        if (
+            isinstance(parsed, dict)
+            and ("option" in parsed or "response" in parsed)
+            and "status" not in parsed
+        ):
+            return parsed
+    except json.JSONDecodeError:
+        pass
 
-    # Try direct parse
-    return json.loads(raw_text)
+    # Search for markdown code fences
+    fenced_matches = FENCED_JSON.findall(text_to_search)
+    fenced_candidates: list[dict[str, Any]] = []
+    for match_str in fenced_matches:
+        try:
+            parsed = json.loads(match_str)
+            if isinstance(parsed, dict):
+                fenced_candidates.append(parsed)
+        except json.JSONDecodeError:
+            pass
+
+    if fenced_candidates:
+        fenced_candidates.sort(key=_score_decision_candidate, reverse=True)
+        if _score_decision_candidate(fenced_candidates[0]) > 0:
+            return fenced_candidates[0]
+
+    # Search for balanced JSON objects in text
+    candidates = find_json_objects(text_to_search)
+    if candidates:
+        candidates.sort(key=_score_decision_candidate, reverse=True)
+        if _score_decision_candidate(candidates[0]) > 0:
+            return candidates[0]
+
+    # Fallback to search in raw_text if text_to_search was different
+    if text_to_search != raw_text:
+        raw_candidates = find_json_objects(raw_text)
+        if raw_candidates:
+            raw_candidates.sort(key=_score_decision_candidate, reverse=True)
+            if _score_decision_candidate(raw_candidates[0]) > 0:
+                return raw_candidates[0]
+
+    raise ValueError(
+        f"No valid JSON decision object found in AI output: {text_to_search[:200]}"
+    )
+
+
+def parse_close_issue(decision: dict[str, Any], option: Option) -> bool:
+    """Determine whether to close the issue as completed.
+
+    Only Options 2 and 3 can close an issue when the response provides a complete,
+    definitive solution. Option 1 (clarify) and Option 4 (assign) must never close.
+    """
+    if option in (Option.CLARIFY, Option.ACKNOWLEDGE_AND_ASSIGN):
+        return False
+
+    raw = decision.get("close_issue")
+    if raw is None:
+        raw = decision.get("close")
+
+    if isinstance(raw, bool):
+        return raw
+
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+
+    if isinstance(raw, str):
+        cleaned = raw.strip().lower()
+        if cleaned in ("true", "1", "yes", "close", "closed"):
+            return True
+        if cleaned in ("false", "0", "no", "open", "keep_open"):
+            return False
+
+    return False
 
 
 def process_response(
     decision: dict[str, Any],
-) -> tuple[Option, str, str | None]:
-    """Process decision dict and return (option, response_body, assignee)."""
+) -> tuple[Option, str, str | None, bool]:
+    """Process decision dict and return (option, response_body, assignee, close_issue)."""
     raw_opt = decision.get("option")
     option = parse_option(raw_opt)
 
@@ -232,20 +360,24 @@ def process_response(
 
     raw_assignee = decision.get("assignee")
     if raw_assignee is not None:
-        raw_assignee = str(raw_assignee).strip().lstrip("@").lower()
+        raw_assignee = str(raw_assignee).strip().lstrip("@")
+
+    assignees_ci = {k.lower(): k for k in VALID_ASSIGNEES}
 
     if option == Option.ACKNOWLEDGE_AND_ASSIGN:
         # Determine assignee based on path routing
         if path:
             assignee = resolve_assignee_from_path(path)
-        elif raw_assignee and raw_assignee in VALID_ASSIGNEES:
-            assignee = raw_assignee
+        elif raw_assignee and raw_assignee.lower() in assignees_ci:
+            assignee = assignees_ci[raw_assignee.lower()]
         else:
             assignee = DEFAULT_ASSIGNEE
     else:
         assignee = None
 
-    return option, response_body, assignee
+    close_issue = parse_close_issue(decision, option)
+
+    return option, response_body, assignee, close_issue
 
 
 def _safe_write_text(path: Path, content: str) -> None:
@@ -286,6 +418,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Destination path for assignee text file",
     )
     parser.add_argument(
+        "--close-out",
+        type=Path,
+        default=None,
+        help="Destination path for close issue boolean text file ('true' or 'false')",
+    )
+    parser.add_argument(
         "--github-output",
         type=Path,
         default=None,
@@ -312,11 +450,15 @@ def main() -> int:
             infra_fault(CHECKER, f"failed to parse JSON from agy output: {exc}")
         )
 
-    option, response_body, assignee = process_response(decision)
+    option, response_body, assignee, close_issue = process_response(decision)
 
     try:
         _safe_write_text(args.comment_out, response_body + "\n")
         _safe_write_text(args.assignee_out, (assignee or "") + "\n")
+        if args.close_out:
+            _safe_write_text(
+                args.close_out, ("true" if close_issue else "false") + "\n"
+            )
     except OSError as exc:
         return report_infra_fault(infra_fault(CHECKER, str(exc)))
 
@@ -327,6 +469,9 @@ def main() -> int:
         print(f"Assigned to developer: @{assignee}")
     else:
         print("No assignee specified (Options 1-3).")
+    print(
+        f"Close issue: {'yes (completed)' if close_issue else 'no (keep open)'}"
+    )
 
     if args.github_output:
         outputs = [
@@ -334,6 +479,7 @@ def main() -> int:
             f"option_name={option.name}",
             f"assignee={assignee or ''}",
             f"has_assignee={'true' if assignee else 'false'}",
+            f"close_issue={'true' if close_issue else 'false'}",
         ]
         with args.github_output.open("a", encoding="utf-8") as handle:
             handle.write("\n".join(outputs) + "\n")

--- a/.github/scripts/tests/test_process_issue_response.py
+++ b/.github/scripts/tests/test_process_issue_response.py
@@ -9,7 +9,9 @@ from process_issue_response import (
     ROUTING_RULES,
     Option,
     extract_decision_json,
+    find_json_objects,
     normalize_path,
+    parse_close_issue,
     parse_option,
     process_response,
     resolve_assignee_from_path,
@@ -65,8 +67,8 @@ def test_normalize_path():
         # Core directory assignments
         ("/core/python/my-recipe", "eliasecchig"),
         ("core/python/gemini-live", "eliasecchig"),
-        ("core/go/agent-sample", "tklopfenstein"),
-        ("/core/go/tool-calling", "tklopfenstein"),
+        ("core/go/agent-sample", "ToniCorinne"),
+        ("/core/go/tool-calling", "ToniCorinne"),
         ("core/java/spring-ai", "eliasecchig"),
         ("/core/java/sample", "eliasecchig"),
         ("core/typescript/express-agent", "happyhuman"),
@@ -76,8 +78,8 @@ def test_normalize_path():
         # Contrib directory assignments
         ("contrib/python/custom-tool", "happyhuman"),
         ("/contrib/python/recipe", "happyhuman"),
-        ("contrib/go/rag-search", "tklopfenstein"),
-        ("/contrib/go/sample", "tklopfenstein"),
+        ("contrib/go/rag-search", "ToniCorinne"),
+        ("/contrib/go/sample", "ToniCorinne"),
         ("contrib/java/micronaut", "happyhuman"),
         ("/contrib/java/sample", "happyhuman"),
         ("contrib/typescript/nextjs", "happyhuman"),
@@ -169,8 +171,65 @@ def test_routing_rules_sync_with_codeowners_and_workflow():
 
 
 # ---------------------------------------------------------------------------
+# Close issue parsing tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_close_issue_rules():
+    # Option 1 (clarify): always False
+    assert parse_close_issue({"close_issue": True}, Option.CLARIFY) is False
+
+    # Option 4 (acknowledge and assign): always False
+    assert (
+        parse_close_issue({"close_issue": True}, Option.ACKNOWLEDGE_AND_ASSIGN)
+        is False
+    )
+
+    # Option 2 (simple solution): follows close_issue
+    assert (
+        parse_close_issue({"close_issue": True}, Option.SIMPLE_SOLUTION) is True
+    )
+    assert (
+        parse_close_issue({"close_issue": False}, Option.SIMPLE_SOLUTION)
+        is False
+    )
+    assert (
+        parse_close_issue({"close_issue": "true"}, Option.SIMPLE_SOLUTION)
+        is True
+    )
+    assert parse_close_issue({"close": "yes"}, Option.SIMPLE_SOLUTION) is True
+    assert parse_close_issue({}, Option.SIMPLE_SOLUTION) is False
+
+    # Option 3 (detailed solution): follows close_issue
+    assert (
+        parse_close_issue({"close_issue": True}, Option.DETAILED_SOLUTION)
+        is True
+    )
+    assert (
+        parse_close_issue({"close_issue": False}, Option.DETAILED_SOLUTION)
+        is False
+    )
+    assert (
+        parse_close_issue({"close_issue": "false"}, Option.DETAILED_SOLUTION)
+        is False
+    )
+    assert parse_close_issue({"close": True}, Option.DETAILED_SOLUTION) is True
+
+
+# ---------------------------------------------------------------------------
 # Decision JSON extraction tests
 # ---------------------------------------------------------------------------
+
+
+def test_find_json_objects_multiple_in_text():
+    text = (
+        'Here is item 1: {"a": 1, "nested": {"b": 2}} and '
+        'item 2: {"c": "hello \\"world\\""} trailing.'
+    )
+    objs = find_json_objects(text)
+    assert len(objs) == 2
+    assert objs[0] == {"a": 1, "nested": {"b": 2}}
+    assert objs[1] == {"c": 'hello "world"'}
 
 
 def test_extract_decision_json_from_raw():
@@ -179,11 +238,13 @@ def test_extract_decision_json_from_raw():
             "option": 2,
             "response": "Try setting MODEL_NAME to gemini-3.5-flash.",
             "path": "core/python/sample",
+            "close_issue": True,
         }
     )
     extracted = extract_decision_json(raw)
     assert extracted["option"] == 2
     assert "gemini-3.5-flash" in extracted["response"]
+    assert extracted["close_issue"] is True
 
 
 def test_extract_decision_json_from_fence():
@@ -192,7 +253,8 @@ def test_extract_decision_json_from_fence():
 {
   "option": 1,
   "response": "Could you provide steps to reproduce?",
-  "path": null
+  "path": null,
+  "close_issue": false
 }
 ```
 """
@@ -210,7 +272,7 @@ def test_extract_decision_json_from_agy_envelope():
   "option": 4,
   "response": "We have assigned this to the team.",
   "path": "core/go/sample",
-  "assignee": "tklopfenstein"
+  "assignee": "ToniCorinne"
 }
 ```""",
         }
@@ -218,6 +280,49 @@ def test_extract_decision_json_from_agy_envelope():
     extracted = extract_decision_json(raw)
     assert extracted["option"] == 4
     assert extracted["path"] == "core/go/sample"
+
+
+def test_extract_decision_json_with_thought_preamble():
+    """Reproduces the issue #2604 failure where thought preamble preceded JSON."""
+    raw_thought_text = (
+        "I will search for any relevant files or documentation in the workspace to see "
+        "if there are any specific guidelines on `core` vs `contrib` directories.\n"
+        "{\n"
+        '  "option": 3,\n'
+        '  "path": null,\n'
+        '  "assignee": null,\n'
+        '  "close_issue": true,\n'
+        '  "response": "For new recipes, please place them in contrib/python/your-recipe."\n'
+        "}\n"
+    )
+    envelope = json.dumps({"status": "SUCCESS", "response": raw_thought_text})
+
+    extracted = extract_decision_json(envelope)
+    assert extracted["option"] == 3
+    assert extracted["close_issue"] is True
+    assert (
+        extracted["response"]
+        == "For new recipes, please place them in contrib/python/your-recipe."
+    )
+
+
+def test_extract_decision_json_with_nested_json_in_response():
+    raw = (
+        "Here is the solution:\n"
+        "{\n"
+        '  "option": 2,\n'
+        '  "close_issue": true,\n'
+        '  "response": "You can configure your settings with {\\"timeout\\": 30}."\n'
+        "}"
+    )
+    extracted = extract_decision_json(raw)
+    assert extracted["option"] == 2
+    assert '{"timeout": 30}' in extracted["response"]
+
+
+def test_extract_decision_json_invalid_raises():
+    with pytest.raises(ValueError, match="No valid JSON decision"):
+        extract_decision_json("Just random text with no JSON object at all.")
 
 
 # ---------------------------------------------------------------------------
@@ -231,31 +336,37 @@ def test_process_response_options_1_to_3():
         "option": 1,
         "response": "Please share more information.",
         "path": "core/python/sample",
+        "close_issue": True,  # should be overridden to False for clarify
     }
-    opt, resp, assignee = process_response(d1)
+    opt, resp, assignee, close_issue = process_response(d1)
     assert opt == Option.CLARIFY
     assert resp == "Please share more information."
     assert assignee is None
+    assert close_issue is False
 
     # Option 2: Quick solution
     d2 = {
         "option": 2,
         "response": "Use `uv sync` to install dependencies.",
+        "close_issue": True,
     }
-    opt, resp, assignee = process_response(d2)
+    opt, resp, assignee, close_issue = process_response(d2)
     assert opt == Option.SIMPLE_SOLUTION
     assert "uv sync" in resp
     assert assignee is None
+    assert close_issue is True
 
     # Option 3: Detailed solution
     d3 = {
         "option": 3,
         "response": "Step 1: ... Step 2: ...",
+        "close_issue": True,
     }
-    opt, resp, assignee = process_response(d3)
+    opt, resp, assignee, close_issue = process_response(d3)
     assert opt == Option.DETAILED_SOLUTION
     assert "Step 1" in resp
     assert assignee is None
+    assert close_issue is True
 
 
 def test_process_response_option_4_with_path():
@@ -264,10 +375,12 @@ def test_process_response_option_4_with_path():
         "option": 4,
         "response": "Received. Routing to the Python team.",
         "path": "/core/python/my-recipe",
+        "close_issue": True,  # should be overridden to False for Option 4
     }
-    opt, _resp, assignee = process_response(d4_py)
+    opt, _resp, assignee, close_issue = process_response(d4_py)
     assert opt == Option.ACKNOWLEDGE_AND_ASSIGN
     assert assignee == "eliasecchig"
+    assert close_issue is False
 
     # Option 4: Acknowledge and Assign with core/go path
     d4_go = {
@@ -275,9 +388,10 @@ def test_process_response_option_4_with_path():
         "response": "Received. Routing to Go maintainer.",
         "path": "core/go/search",
     }
-    opt, _resp, assignee = process_response(d4_go)
+    opt, _resp, assignee, close_issue = process_response(d4_go)
     assert opt == Option.ACKNOWLEDGE_AND_ASSIGN
-    assert assignee == "tklopfenstein"
+    assert assignee == "ToniCorinne"
+    assert close_issue is False
 
     # Option 4: Acknowledge and Assign with skills path
     d4_skills = {
@@ -285,21 +399,23 @@ def test_process_response_option_4_with_path():
         "response": "Received. Routing to skills maintainer.",
         "path": "skills/retail/store-ops",
     }
-    opt, _resp, assignee = process_response(d4_skills)
+    opt, _resp, assignee, close_issue = process_response(d4_skills)
     assert opt == Option.ACKNOWLEDGE_AND_ASSIGN
     assert assignee == "happyhuman"
+    assert close_issue is False
 
 
 def test_process_response_option_4_fallback():
-    # Option 4 with no path but valid assignee
+    # Option 4 with no path but valid assignee (case-insensitive)
     d4_raw = {
         "option": 4,
         "response": "Routing ticket.",
-        "assignee": "eliasecchig",
+        "assignee": "tonicorinne",
     }
-    opt, _resp, assignee = process_response(d4_raw)
+    opt, _resp, assignee, close_issue = process_response(d4_raw)
     assert opt == Option.ACKNOWLEDGE_AND_ASSIGN
-    assert assignee == "eliasecchig"
+    assert assignee == "ToniCorinne"
+    assert close_issue is False
 
     # Option 4 with no path and unknown assignee -> catch-all default
     d4_unknown = {
@@ -307,9 +423,10 @@ def test_process_response_option_4_fallback():
         "response": "Routing ticket.",
         "assignee": "some_random_user",
     }
-    opt, _resp, assignee = process_response(d4_unknown)
+    opt, _resp, assignee, close_issue = process_response(d4_unknown)
     assert opt == Option.ACKNOWLEDGE_AND_ASSIGN
     assert assignee == "happyhuman"
+    assert close_issue is False
 
 
 # ---------------------------------------------------------------------------
@@ -339,6 +456,7 @@ def test_cli_execution_option_4(tmp_path):
     )
     comment_out = tmp_path / "comment.md"
     assignee_out = tmp_path / "assignee.txt"
+    close_out = tmp_path / "close.txt"
     github_output = tmp_path / "github_output.txt"
 
     script_path = (
@@ -355,6 +473,8 @@ def test_cli_execution_option_4(tmp_path):
         str(comment_out),
         "--assignee-out",
         str(assignee_out),
+        "--close-out",
+        str(close_out),
         "--github-output",
         str(github_output),
     ]
@@ -367,34 +487,40 @@ def test_cli_execution_option_4(tmp_path):
         "Thank you! Routing this to the Python maintainer."
     )
     assert assignee_out.read_text(encoding="utf-8").strip() == "eliasecchig"
+    assert close_out.read_text(encoding="utf-8").strip() == "false"
 
     output_lines = github_output.read_text(encoding="utf-8").splitlines()
     assert "option=4" in output_lines
     assert "assignee=eliasecchig" in output_lines
     assert "has_assignee=true" in output_lines
+    assert "close_issue=false" in output_lines
 
 
-def test_cli_execution_option_2(tmp_path):
+def test_cli_execution_option_3_with_close(tmp_path):
     import subprocess
     import sys
 
     result_file = tmp_path / "agy_result.json"
+    thought_and_json = (
+        "I will search for any relevant guidelines on core vs contrib.\n"
+        "{\n"
+        '  "option": 3,\n'
+        '  "close_issue": true,\n'
+        '  "response": "Please place your new recipe in `contrib/python/your-recipe`."\n'
+        "}"
+    )
     result_file.write_text(
         json.dumps(
             {
                 "status": "SUCCESS",
-                "response": json.dumps(
-                    {
-                        "option": 2,
-                        "response": "Please use `uv sync` to install dependencies.",
-                    }
-                ),
+                "response": thought_and_json,
             }
         ),
         encoding="utf-8",
     )
     comment_out = tmp_path / "comment.md"
     assignee_out = tmp_path / "assignee.txt"
+    close_out = tmp_path / "close.txt"
     github_output = tmp_path / "github_output.txt"
 
     script_path = (
@@ -406,11 +532,13 @@ def test_cli_execution_option_2(tmp_path):
         "--result",
         str(result_file),
         "--issue-number",
-        "99",
+        "2604",
         "--comment-out",
         str(comment_out),
         "--assignee-out",
         str(assignee_out),
+        "--close-out",
+        str(close_out),
         "--github-output",
         str(github_output),
     ]
@@ -419,10 +547,12 @@ def test_cli_execution_option_2(tmp_path):
     assert res.returncode == 0, res.stderr
 
     assert comment_out.read_text(encoding="utf-8").strip() == (
-        "Please use `uv sync` to install dependencies."
+        "Please place your new recipe in `contrib/python/your-recipe`."
     )
     assert assignee_out.read_text(encoding="utf-8").strip() == ""
+    assert close_out.read_text(encoding="utf-8").strip() == "true"
 
     output_lines = github_output.read_text(encoding="utf-8").splitlines()
-    assert "option=2" in output_lines
+    assert "option=3" in output_lines
     assert "has_assignee=false" in output_lines
+    assert "close_issue=true" in output_lines

--- a/.github/workflows/_ai-issue-response-core.yml
+++ b/.github/workflows/_ai-issue-response-core.yml
@@ -61,6 +61,9 @@ on:
       assignee:
         description: 'Assigned developer username (for Option 4)'
         value: '${{ jobs.respond.outputs.assignee }}'
+      close_issue:
+        description: 'Whether the issue was closed as completed'
+        value: '${{ jobs.respond.outputs.close_issue }}'
 
 permissions:
   contents: 'read'
@@ -74,6 +77,7 @@ jobs:
     outputs:
       option: '${{ steps.process.outputs.option }}'
       assignee: '${{ steps.process.outputs.assignee }}'
+      close_issue: '${{ steps.process.outputs.close_issue }}'
 
     steps:
       - name: 'Checkout repository'
@@ -153,9 +157,14 @@ jobs:
             You are an automated technical support assistant for the adk-samples repository.
             Users open issues reporting errors, asking questions, or requesting help with recipes.
             Your goal is to analyze the issue content against repository guidelines and documentation,
-            and provide an immediate, helpful, clear preliminary response to shorten resolution time.
+            and provide an immediate, helpful, clear, and genuine preliminary response to shorten resolution time.
 
-            The response it generates should be helpful and clear, not overly complicated, and sound like a human.
+            ## Tone & Style Guidelines for Response
+
+            - Sound like a friendly, knowledgeable, genuine repository maintainer / engineer having a conversation on GitHub.
+            - Avoid robotic filler phrases, canned AI clichés, and corporate fluff (e.g. do NOT say "Thanks for reaching out!", "It's great to hear that you are planning to...", "We are thrilled to...", "I hope this helps!", "As an automated assistant...", or "Here is a breakdown to help you...").
+            - Be direct, conversational, natural, and helpful. Get straight to the point and answer the question directly.
+            - Use clear markdown formatting (bold paths, code blocks, bullet points) where appropriate.
 
             ## Core Functional Options
 
@@ -165,17 +174,21 @@ jobs:
             Option 1: Ask for more clarifying questions if not enough information is provided.
             - Choose this when the issue lacks reproduction steps, error logs, environment details, or does not clearly specify which recipe or language is being used.
             - Keep your clarifying questions polite, direct, concise, and easy to answer.
+            - Always set `close_issue: false`.
 
             Option 2: Provide a simple, quick solution for the user to try.
             - Choose this for common, known, or straightforward questions/errors (e.g., outdated model names such as gemini-2.0-flash or gemini-2.5-flash which should be updated to gemini-3.5-flash, missing .env setup from .env.example, installing packages with `uv sync`).
             - Provide a clear, quick 1-3 step fix.
+            - Set `close_issue: true` if this completely and definitively resolves a known question, or `false` if it is a suggestion/workaround the user needs to try.
 
             Option 3: Provide a detailed, step-by-step answer if you can successfully figure out what the solution is.
-            - Choose this when the issue describes a well-defined technical problem, architectural question, or bug where a complete, step-by-step walkthrough or explanation resolves the problem.
+            - Choose this when the issue describes a well-defined technical problem, architectural question, directory placement question (e.g. core vs contrib), or bug where a complete walkthrough or explanation resolves the issue.
+            - Set `close_issue: true` if your response provides a complete, definitive answer that fully resolves the user's question or issue. Set `close_issue: false` if further maintainer action or code changes are still required.
 
             Option 4: Provide an acknowledgement that their message was received along with any partial answer it might be able to provide, and automatically assign the ticket to the designated developer based on file paths and expertise (using the routing logic below).
             - Choose this when the issue requires maintainer investigation, feature changes, complex debugging, or when defaulting to routing.
             - Provide a polite acknowledgement, any preliminary insights or partial guidance you can share, and note that the issue is being routed to the team.
+            - Always set `close_issue: false`.
 
             ## Routing Rules for Ticket Assignment (Option 4)
 
@@ -186,14 +199,14 @@ jobs:
 
             Core Directory Assignments:
             - /core/python/** -> eliasecchig
-            - /core/go/** -> tklopfenstein
+            - /core/go/** -> ToniCorinne
             - /core/java/** -> eliasecchig
             - /core/typescript/** -> happyhuman
             - /core/kotlin/** -> happyhuman
 
             Contrib Directory Assignments:
             - /contrib/python/** -> happyhuman
-            - /contrib/go/** -> tklopfenstein
+            - /contrib/go/** -> ToniCorinne
             - /contrib/java/** -> happyhuman
             - /contrib/typescript/** -> happyhuman
             - /contrib/kotlin/** -> happyhuman
@@ -205,8 +218,8 @@ jobs:
 
             - Terminology: In this repo, all code samples are called **recipes**.
             - Directory layout:
-              - `core/<language>/<recipe-name>`: Curated recipes (python, go, java, typescript, kotlin)
-              - `contrib/<language>/<recipe-name>`: Community-contributed recipes
+              - `core/<language>/<recipe-name>`: Curated reference recipes maintained by the core team.
+              - `contrib/<language>/<recipe-name>`: Community-contributed recipes (default destination for new user contributions).
               - `skills/<vertical>/<solution>`: Vertical skills (e.g. `skills/retail/store-ops/`)
             - Python standards:
               - Minimum Python version: 3.11
@@ -221,19 +234,22 @@ jobs:
 
             ## Output format
 
-            Reply with a single JSON object and nothing else. No prose outside the JSON object:
+            Reply with a single JSON object and nothing else.
+            CRITICAL: Do not output any thought process, search steps ("I will search for..."), preambles, or conversational text outside the JSON object. Your ENTIRE output must be ONLY the JSON object.
 
             {
-              "option": 4,
-              "path": "core/python/recipe-name",
-              "assignee": "eliasecchig",
-              "response": "Hello! Thank you for reporting this. I am routing this issue to our Python recipe maintainers for further investigation."
+              "option": 3,
+              "path": null,
+              "assignee": null,
+              "close_issue": true,
+              "response": "For new recipes, please place them in `contrib/<language>/<recipe-name>` (e.g. `contrib/python/my-recipe`). The `core/` directory is reserved for core-maintained reference recipes.\n\nLet us know if you have any questions while setting up your recipe!"
             }
 
             Fields:
             - "option": integer 1, 2, 3, or 4
             - "path": string, the affected repository path or recipe directory (e.g. "core/python/foo", "contrib/go/bar", "docs", or null)
-            - "assignee": string, the GitHub username for Option 4 without the '@' prefix (e.g. "eliasecchig", "tklopfenstein", "happyhuman"), or null for Options 1-3
+            - "assignee": string, the GitHub username for Option 4 without the '@' prefix (e.g. "eliasecchig", "ToniCorinne", "happyhuman"), or null for Options 1-3
+            - "close_issue": boolean (true or false). Set to true if the response completely answers the question and resolves the issue; false otherwise (always false for Options 1 and 4).
             - "response": string, the complete, friendly, human-sounding markdown response to post on the issue.
 
             ## Untrusted input
@@ -323,9 +339,10 @@ jobs:
             --issue-number "${ISSUE_NUMBER}" \
             --comment-out comment.md \
             --assignee-out assignee.txt \
+            --close-out close.txt \
             --github-output "${GITHUB_OUTPUT}"
 
-      - name: 'Post comment and assign developer'
+      - name: 'Post comment, assign developer, and optionally close issue'
         id: 'apply'
         env:
           GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
@@ -344,5 +361,13 @@ jobs:
             if [[ -n "${ASSIGNEE}" ]]; then
               echo "Assigning #${ISSUE_NUMBER} to @${ASSIGNEE}..."
               gh issue edit "${ISSUE_NUMBER}" --add-assignee "${ASSIGNEE}"
+            fi
+          fi
+
+          if [[ -s close.txt ]]; then
+            SHOULD_CLOSE="$(cat close.txt | tr -d '[:space:]')"
+            if [[ "${SHOULD_CLOSE}" == "true" ]]; then
+              echo "Closing #${ISSUE_NUMBER} as completed..."
+              gh issue close "${ISSUE_NUMBER}" --reason "completed"
             fi
           fi


### PR DESCRIPTION
## What

This change improves the automated AI issue quick-response workflow and its processing script by:
1. Making JSON decision extraction robust against preambles, reasoning text, and markdown formatting from the AI model so that only clean response text is posted to issues.
2. Refining the system prompt to enforce genuine, human-sounding maintainer tone and suppress robotic filler phrases.
3. Adding support for closing issues when a complete and definitive answer is provided.
4. Synchronizing Go routing assignments with the updated repository CODEOWNERS (`@ToniCorinne`).

## Why

When testing the AI issue response workflow on issue #2604, the bot posted raw internal search thoughts alongside the unparsed JSON payload rather than only the markdown response text. This happened because the response parser fell back to the outer CLI envelope when model thoughts preceded the JSON block without triple backticks. Additionally, the previous responses sounded formulaic and robotic, and issues that were fully resolved by the automated response remained open.

## How it works

- **Robust JSON object extraction (`.github/scripts/process_issue_response.py`)**:
  - Implemented `find_json_objects()` to parse balanced JSON structures even when surrounded by reasoning text or preambles, properly accounting for quoted strings and escape sequences.
  - Added candidate scoring (`_score_decision_candidate`) that penalizes CLI envelopes and prioritizes decision objects containing `option`, `response`, and `close_issue` keys.
- **Completion Closing**:
  - Added a `close_issue` boolean field to the JSON schema and prompt.
  - Options 1 (clarify) and 4 (acknowledge & assign) strictly enforce `close_issue = False`.
  - Options 2 and 3 can set `close_issue = True` when the question is fully answered.
  - The workflow executes `gh issue close "${ISSUE_NUMBER}" --reason "completed"` when `close_issue` is true.
- **Tone & Prompt Refinement (`.github/workflows/_ai-issue-response-core.yml`)**:
  - Added concrete tone instructions to avoid robotic phrases (e.g. "Thanks for reaching out!", "It's great to hear that...") and write concise, natural maintainer responses.
  - Explicitly instructed the model that its entire output must be only the JSON object.
- **CODEOWNERS Alignment**:
  - Updated Go routing rules from `@tklopfenstein` to `@ToniCorinne` matching `.github/CODEOWNERS`.

## Testing

```
$ uv run pytest
1312 passed in 15.75s

$ .agent-tmp/bin/actionlint .github/workflows/*.yml
(0 errors)

$ uv run ruff check .github/scripts/
All checks passed!
```

Cannot verify live GitHub Actions execution or WIF credentials locally.

## Notes for the reviewer

- Option 1 (clarify) and Option 4 (acknowledge & assign) are hardcoded in `process_issue_response.py` to never close the issue, regardless of model output.
- Left `@gemini-cli /respond` as the comment trigger prefix in the dispatch condition to match existing triage workflows.
