### PR TITLE
docs: require an approved recipe proposal before a contrib/ PR

### DIFF
--- a/docs/recipe-checklist.md
+++ b/docs/recipe-checklist.md
@@ -1,4 +1,4 @@
-<!-- word count: 930 (target 900, cap 1200) -->
+<!-- word count: 948 (target 900, cap 1200) -->
 
 # Recipe Checklist
 
@@ -7,12 +7,13 @@ Deep detail lives in [`recipe-handbook/`](./recipe-handbook/README.md).
 
 ---
 
-## Before you start
+## Proposing a new recipe
 
-Open a
+If this is a **new** recipe, open a
 [Propose a New Recipe](https://github.com/google/adk-samples/issues/new?template=propose-a-new-recipe.md)
-issue and wait for approval before adding your recipe to `contrib/`
-and opening a PR.
+issue and wait for approval before adding it to `contrib/` and
+opening a PR. Updating an existing recipe? Skip this and go
+straight to the checklist.
 
 ---
 

--- a/docs/recipe-checklist.md
+++ b/docs/recipe-checklist.md
@@ -1,9 +1,18 @@
-<!-- word count: 906 (target 900, cap 1200) -->
+<!-- word count: 930 (target 900, cap 1200) -->
 
 # Recipe Checklist
 
 Everything you need to submit a `contrib/` recipe, on one page.
 Deep detail lives in [`recipe-handbook/`](./recipe-handbook/README.md).
+
+---
+
+## Before you start
+
+Open a
+[Propose a New Recipe](https://github.com/google/adk-samples/issues/new?template=propose-a-new-recipe.md)
+issue and wait for approval before adding your recipe to `contrib/`
+and opening a PR.
 
 ---
 


### PR DESCRIPTION
## What

Adds a short **Before you start** section at the top of `docs/recipe-checklist.md` pointing contributors at the **Propose a New Recipe** issue template.

## Why

The issue template already exists at `.github/ISSUE_TEMPLATE/propose-a-new-recipe.md`, but nothing in the documented contributor path pointed at it — so contrib/ PRs arrived cold, with no prior signal on whether the recipe idea was wanted. The checklist is the canonical one-page path from empty folder to PR, and this gate happens before step 0, so it goes there as an unnumbered pre-step.

Scoped to `contrib/`; `core/` recipes follow a different process and are unchanged.

## Notes

- 24 words added; the line-1 word-count comment is bumped 906 → 930, still under the file's declared cap.
- Existing section numbering (§0–§5) is untouched.
- Docs-only change.