### PR TITLE
feat(ci): publish recipe container images to Artifact Registry

### DIFF
--- a/.github/scripts/recipe_images_matrix.py
+++ b/.github/scripts/recipe_images_matrix.py
@@ -70,11 +70,13 @@ from recipe_manifests import REPO_ROOT, SCAN_ROOTS, SKIP_DIRS
 REGISTRY = "us-west1-docker.pkg.dev/adk-samples-repo-gcp-support/adk-recipes-registry"
 
 
-def _language_and_name(recipe: Path) -> tuple[str, str]:
-    """Split a recipe path into (language, name).
+def _category_and_name(recipe: Path) -> tuple[str, str]:
+    """Split a recipe path into (category, name).
 
-    Recipes live at <root>/<language>/<name>. Anything shallower than that has
-    no language segment to report, so the root stands in for it.
+    Recipes live at <root>/<category>/<name>. The segment is a language under
+    core/ and contrib/ (python, kotlin) but a vertical under skills/ (retail),
+    so it is named for what it is positionally rather than for what it usually
+    holds. Anything shallower has no such segment, and the root stands in.
     """
     parts = recipe.parts
     if len(parts) >= 3:
@@ -83,13 +85,19 @@ def _language_and_name(recipe: Path) -> tuple[str, str]:
 
 
 def discover(repo_root: Path) -> list[dict[str, str]]:
-    """Every live recipe with a Dockerfile at its root, sorted by path."""
+    """Every live recipe with a Dockerfile at its root, shallowest first."""
     found: list[dict[str, str]] = []
     for root in SCAN_ROOTS:
         base = repo_root / root
         if not base.is_dir():
             continue
-        for dockerfile in sorted(base.rglob("Dockerfile")):
+        # Depth first, not lexicographic. The nested-Dockerfile test below
+        # only works if a recipe is recorded before anything beneath it, and
+        # sorting by name does not guarantee that: 'foo/Bar/Dockerfile' sorts
+        # ahead of 'foo/Dockerfile' because 'B' < 'D'. Depth does guarantee
+        # it, and the secondary sort keeps the output stable.
+        for dockerfile in sorted(base.rglob("Dockerfile"),
+                                 key=lambda p: (len(p.parts), p)):
             recipe = dockerfile.parent
             rel = recipe.relative_to(repo_root)
             if any(part in SKIP_DIRS for part in rel.parts):
@@ -98,37 +106,42 @@ def discover(repo_root: Path) -> list[dict[str, str]]:
                 continue
             # A Dockerfile nested under another recipe belongs to a
             # sub-service, not to a recipe of its own.
-            if any(entry["path"] != str(rel) and str(rel).startswith(entry["path"] + "/")
-                   for entry in found):
+            if any(str(rel).startswith(entry["path"] + "/") for entry in found):
                 continue
-            language, name = _language_and_name(rel)
+            category, name = _category_and_name(rel)
             found.append(
                 {
                     "path": str(rel),
                     "name": name,
-                    "language": language,
-                    "image": f"{REGISTRY}/{language}/{name}",
+                    "category": category,
+                    "image": f"{REGISTRY}/{category}/{name}",
                 }
             )
     return found
 
 
-def _changed_paths(ref: str) -> set[str]:
-    """Files touched between `ref` and HEAD, as repo-relative paths."""
+def _changed_paths(ref: str, repo_root: Path) -> set[str] | None:
+    """Files touched between `ref` and HEAD, or None if the diff failed.
+
+    None and the empty set mean different things and the caller acts on the
+    difference: an empty set is a successful diff that found nothing, so
+    nothing needs rebuilding, while None means the question could not be
+    answered and every recipe should be rebuilt rather than silently skipped.
+    """
     out = subprocess.run(
         ["git", "diff", "--name-only", f"{ref}...HEAD"],
-        cwd=REPO_ROOT,
+        cwd=repo_root,
         capture_output=True,
         text=True,
         check=False,
     )
     if out.returncode != 0:
         # A missing or unrelated ref is not worth failing the build over:
-        # falling back to "everything changed" errs toward rebuilding, which
-        # is wasteful but never publishes a stale image.
+        # falling back to "everything changed" is wasteful but never leaves a
+        # recipe published from stale source.
         print(f"warning: git diff against {ref} failed, treating all recipes as changed",
               file=sys.stderr)
-        return set()
+        return None
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
 
@@ -156,8 +169,11 @@ def main() -> int:
             return 1
 
     if args.changed_from:
-        changed = _changed_paths(args.changed_from)
-        if changed:
+        changed = _changed_paths(args.changed_from, REPO_ROOT)
+        # None is a failed diff: rebuild everything rather than skip silently.
+        # An empty set is a successful diff that found nothing, which
+        # correctly narrows the matrix to nothing.
+        if changed is not None:
             recipes = [r for r in recipes
                        if any(f.startswith(r["path"] + "/") for f in changed)]
 

--- a/.github/scripts/recipe_images_matrix.py
+++ b/.github/scripts/recipe_images_matrix.py
@@ -16,7 +16,7 @@ half of that later step: it turns the tree into a build matrix.
 Recipe-root Dockerfiles only
 ----------------------------
 A recipe can contain more than one Dockerfile. contrib/python/multiformat-
-hybrid-rag ships three — one for the recipe, two for data-ingestion
+hybrid-rag ships four — one for the recipe, three for data-ingestion
 sub-services it stands up. Only the file at the recipe root serves the agent
 and satisfies the Agent Engine container contract; the others are backing
 infrastructure with their own lifecycles. Publishing those under a recipe
@@ -67,7 +67,20 @@ from recipe_manifests import REPO_ROOT, SCAN_ROOTS, SKIP_DIRS
 # Every image lands here. The repository is public-read (allUsers has
 # roles/artifactregistry.reader), which is what lets Agent Engine pull an
 # image into a customer tenant without a per-consumer IAM grant.
-REGISTRY = "us-west1-docker.pkg.dev/adk-samples-repo-gcp-support/adk-recipes-registry"
+REGISTRY = (
+    "us-west1-docker.pkg.dev/adk-samples-repo-gcp-support/adk-recipes-registry"
+)
+
+# Changing the matrix or the workflow that consumes it invalidates the
+# incremental answer: a push touching only these files matches no recipe
+# prefix, so filtering would return nothing and the change would merge having
+# never built anything. They rebuild the full set instead.
+SELF_PATHS = frozenset(
+    {
+        ".github/scripts/recipe_images_matrix.py",
+        ".github/workflows/recipe-images.yml",
+    }
+)
 
 
 def _category_and_name(recipe: Path) -> tuple[str, str]:
@@ -96,8 +109,9 @@ def discover(repo_root: Path) -> list[dict[str, str]]:
         # sorting by name does not guarantee that: 'foo/Bar/Dockerfile' sorts
         # ahead of 'foo/Dockerfile' because 'B' < 'D'. Depth does guarantee
         # it, and the secondary sort keeps the output stable.
-        for dockerfile in sorted(base.rglob("Dockerfile"),
-                                 key=lambda p: (len(p.parts), p)):
+        for dockerfile in sorted(
+            base.rglob("Dockerfile"), key=lambda p: (len(p.parts), p)
+        ):
             recipe = dockerfile.parent
             rel = recipe.relative_to(repo_root)
             if any(part in SKIP_DIRS for part in rel.parts):
@@ -139,8 +153,10 @@ def _changed_paths(ref: str, repo_root: Path) -> set[str] | None:
         # A missing or unrelated ref is not worth failing the build over:
         # falling back to "everything changed" is wasteful but never leaves a
         # recipe published from stale source.
-        print(f"warning: git diff against {ref} failed, treating all recipes as changed",
-              file=sys.stderr)
+        print(
+            f"warning: git diff against {ref} failed, treating all recipes as changed",
+            file=sys.stderr,
+        )
         return None
     return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
@@ -165,7 +181,10 @@ def main() -> int:
         wanted = args.recipe.rstrip("/")
         recipes = [r for r in recipes if r["path"] == wanted]
         if not recipes:
-            print(f"error: no recipe with a root Dockerfile at {wanted!r}", file=sys.stderr)
+            print(
+                f"error: no recipe with a root Dockerfile at {wanted!r}",
+                file=sys.stderr,
+            )
             return 1
 
     if args.changed_from:
@@ -173,9 +192,12 @@ def main() -> int:
         # None is a failed diff: rebuild everything rather than skip silently.
         # An empty set is a successful diff that found nothing, which
         # correctly narrows the matrix to nothing.
-        if changed is not None:
-            recipes = [r for r in recipes
-                       if any(f.startswith(r["path"] + "/") for f in changed)]
+        if changed is not None and not (changed & SELF_PATHS):
+            recipes = [
+                r
+                for r in recipes
+                if any(f.startswith(r["path"] + "/") for f in changed)
+            ]
 
     print(json.dumps({"include": recipes}))
     return 0

--- a/.github/scripts/recipe_images_matrix.py
+++ b/.github/scripts/recipe_images_matrix.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Decide which recipes get a container image built, and what to call it.
+
+Answers one question: which recipe directories under the live roots carry a
+Dockerfile at their root, and what image path should each one publish to?
+
+Why this exists as its own module
+---------------------------------
+`.agents/skills/make-python-recipe-deployable` writes the serving files a
+recipe needs — Dockerfile, fast_api_app.py, app_utils/ — and then stops. Its
+own words: "Image builds happen later via Cloud Build → Artifact Registry;
+this skill's job ends when the files are correct." This module is the front
+half of that later step: it turns the tree into a build matrix.
+
+Recipe-root Dockerfiles only
+----------------------------
+A recipe can contain more than one Dockerfile. contrib/python/multiformat-
+hybrid-rag ships three — one for the recipe, two for data-ingestion
+sub-services it stands up. Only the file at the recipe root serves the agent
+and satisfies the Agent Engine container contract; the others are backing
+infrastructure with their own lifecycles. Publishing those under a recipe
+image name would misrepresent what the image is, so the walk stops at the
+first Dockerfile it finds down each path.
+
+A Dockerfile is not by itself evidence of a recipe
+--------------------------------------------------
+skills/retail/virtual-tryon/assets/export-template carries one, and it is a
+build asset shipped by a skill rather than an agent anybody deploys. The
+manifest is what makes a directory a recipe — the schema at
+.github/schemas/manifest-schema.json is the same thing `deployable` is
+declared in — so a root Dockerfile earns an image only when a manifest.yaml
+sits beside it. Without that test the walk publishes whatever happens to be
+containerized, and derives a nonsense language ("retail") from the path while
+doing it.
+
+Live roots only
+---------------
+SCAN_ROOTS and SKIP_DIRS are imported from recipe_manifests rather than
+restated, because the retired roots (python/agents, java/agents, ... — see
+`frozen_paths` in .github/policy.yml) still contain Dockerfiles. Those paths
+are closed to new work; images built from them would be published from code
+nobody is allowed to fix. Importing means this module cannot drift out of
+agreement with the rest of the tooling about what "live" means.
+
+Image naming: <language>/<recipe>, not <root>/<language>/<recipe>
+-----------------------------------------------------------------
+The root is deliberately dropped. A recipe promoted from contrib/ to core/ is
+the same recipe, and its published image name should not change underneath
+consumers who have pinned it. Language is kept because it disambiguates:
+core/kotlin/llm-auditor and contrib/python/llm-auditor coexist today, and the
+leaf name alone would collide.
+
+Zero third-party dependencies, matching its callers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from recipe_manifests import REPO_ROOT, SCAN_ROOTS, SKIP_DIRS
+
+# Every image lands here. The repository is public-read (allUsers has
+# roles/artifactregistry.reader), which is what lets Agent Engine pull an
+# image into a customer tenant without a per-consumer IAM grant.
+REGISTRY = "us-west1-docker.pkg.dev/adk-samples-repo-gcp-support/adk-recipes-registry"
+
+
+def _language_and_name(recipe: Path) -> tuple[str, str]:
+    """Split a recipe path into (language, name).
+
+    Recipes live at <root>/<language>/<name>. Anything shallower than that has
+    no language segment to report, so the root stands in for it.
+    """
+    parts = recipe.parts
+    if len(parts) >= 3:
+        return parts[1], parts[-1]
+    return parts[0], parts[-1]
+
+
+def discover(repo_root: Path) -> list[dict[str, str]]:
+    """Every live recipe with a Dockerfile at its root, sorted by path."""
+    found: list[dict[str, str]] = []
+    for root in SCAN_ROOTS:
+        base = repo_root / root
+        if not base.is_dir():
+            continue
+        for dockerfile in sorted(base.rglob("Dockerfile")):
+            recipe = dockerfile.parent
+            rel = recipe.relative_to(repo_root)
+            if any(part in SKIP_DIRS for part in rel.parts):
+                continue
+            if not (recipe / "manifest.yaml").is_file():
+                continue
+            # A Dockerfile nested under another recipe belongs to a
+            # sub-service, not to a recipe of its own.
+            if any(entry["path"] != str(rel) and str(rel).startswith(entry["path"] + "/")
+                   for entry in found):
+                continue
+            language, name = _language_and_name(rel)
+            found.append(
+                {
+                    "path": str(rel),
+                    "name": name,
+                    "language": language,
+                    "image": f"{REGISTRY}/{language}/{name}",
+                }
+            )
+    return found
+
+
+def _changed_paths(ref: str) -> set[str]:
+    """Files touched between `ref` and HEAD, as repo-relative paths."""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{ref}...HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        # A missing or unrelated ref is not worth failing the build over:
+        # falling back to "everything changed" errs toward rebuilding, which
+        # is wasteful but never publishes a stale image.
+        print(f"warning: git diff against {ref} failed, treating all recipes as changed",
+              file=sys.stderr)
+        return set()
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-from",
+        metavar="REF",
+        help="Only include recipes with files touched since REF. Omit to include all.",
+    )
+    parser.add_argument(
+        "--recipe",
+        metavar="PATH",
+        help="Limit to one recipe path (e.g. core/python/ambient-expense-agent).",
+    )
+    args = parser.parse_args()
+
+    recipes = discover(REPO_ROOT)
+
+    if args.recipe:
+        wanted = args.recipe.rstrip("/")
+        recipes = [r for r in recipes if r["path"] == wanted]
+        if not recipes:
+            print(f"error: no recipe with a root Dockerfile at {wanted!r}", file=sys.stderr)
+            return 1
+
+    if args.changed_from:
+        changed = _changed_paths(args.changed_from)
+        if changed:
+            recipes = [r for r in recipes
+                       if any(f.startswith(r["path"] + "/") for f in changed)]
+
+    print(json.dumps({"include": recipes}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_recipe_images_matrix.py
+++ b/.github/scripts/tests/test_recipe_images_matrix.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for recipe_images_matrix.py.
+
+Everything this module admits becomes a publicly pullable image, and
+everything it drops is a recipe with no image at all. Both directions are
+silent, so these tests pin the admission rules rather than the happy path.
+"""
+
+from pathlib import Path
+
+import recipe_images_matrix as m
+
+
+def _recipe(tmp_path: Path, rel: str, *, manifest: bool = True) -> Path:
+    """A directory with a Dockerfile, and by default a manifest beside it."""
+    d = tmp_path / rel
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    if manifest:
+        (d / "manifest.yaml").write_text(
+            'language: "python"\n', encoding="utf-8"
+        )
+    return d
+
+
+def _paths(found: list[dict[str, str]]) -> list[str]:
+    return [f["path"] for f in found]
+
+
+def test_finds_recipe_with_dockerfile_and_manifest(tmp_path: Path) -> None:
+    _recipe(tmp_path, "core/python/alpha")
+    assert _paths(m.discover(tmp_path)) == ["core/python/alpha"]
+
+
+def test_skips_dockerfile_without_manifest(tmp_path: Path) -> None:
+    """A Dockerfile alone is a build asset, not a recipe.
+
+    skills/retail/virtual-tryon/assets/export-template is the real instance:
+    containerized, but nothing anybody deploys as an agent.
+    """
+    _recipe(
+        tmp_path, "skills/retail/thing/assets/export-template", manifest=False
+    )
+    assert m.discover(tmp_path) == []
+
+
+def test_skips_retired_roots(tmp_path: Path) -> None:
+    """python/agents and java/agents are frozen_paths in .github/policy.yml.
+
+    They still carry Dockerfiles. Publishing from them would ship images built
+    from code that pull requests are not allowed to fix.
+    """
+    _recipe(tmp_path, "python/agents/legacy")
+    _recipe(tmp_path, "java/agents/legacy")
+    assert m.discover(tmp_path) == []
+
+
+def test_nested_dockerfile_is_a_sub_service_not_a_recipe(
+    tmp_path: Path,
+) -> None:
+    """Only the recipe-root Dockerfile serves the agent.
+
+    contrib/python/multiformat-hybrid-rag ships four; three belong to
+    data-ingestion services with their own lifecycles.
+    """
+    _recipe(tmp_path, "contrib/python/rag")
+    _recipe(tmp_path, "contrib/python/rag/ingestion")
+    _recipe(tmp_path, "contrib/python/rag/ingestion/chunker")
+    assert _paths(m.discover(tmp_path)) == ["contrib/python/rag"]
+
+
+def test_nested_exclusion_survives_a_sub_service_that_sorts_first(
+    tmp_path: Path,
+) -> None:
+    """Regression: the parent must be recorded before anything beneath it.
+
+    Lexicographic order does not give that. 'rag/Bar/Dockerfile' sorts ahead
+    of 'rag/Dockerfile' because 'B' < 'D', which let the sub-service register
+    as a recipe of its own and publish an image.
+    """
+    _recipe(tmp_path, "contrib/python/rag")
+    _recipe(tmp_path, "contrib/python/rag/Bar")
+    assert _paths(m.discover(tmp_path)) == ["contrib/python/rag"]
+
+
+def test_image_name_drops_the_root_segment(tmp_path: Path) -> None:
+    """Promotion from contrib/ to core/ must not rename the image.
+
+    Consumers pin these paths; the recipe is the same recipe either side of
+    the move.
+    """
+    _recipe(tmp_path, "contrib/python/alpha")
+    contrib = m.discover(tmp_path)[0]["image"]
+
+    (tmp_path / "contrib").rename(tmp_path / "core")
+    core = m.discover(tmp_path)[0]["image"]
+
+    assert contrib == core
+    assert core == f"{m.REGISTRY}/python/alpha"
+
+
+def test_category_disambiguates_same_named_recipes(tmp_path: Path) -> None:
+    """core/kotlin/llm-auditor and contrib/python/llm-auditor coexist today."""
+    _recipe(tmp_path, "core/kotlin/llm-auditor")
+    _recipe(tmp_path, "contrib/python/llm-auditor")
+    images = {f["image"] for f in m.discover(tmp_path)}
+    assert images == {
+        f"{m.REGISTRY}/kotlin/llm-auditor",
+        f"{m.REGISTRY}/python/llm-auditor",
+    }
+
+
+def test_skip_dirs_are_pruned(tmp_path: Path) -> None:
+    _recipe(tmp_path, "core/python/alpha/.venv/vendored")
+    assert m.discover(tmp_path) == []
+
+
+def test_changed_paths_returns_none_when_the_diff_fails(tmp_path: Path) -> None:
+    """None and the empty set drive opposite decisions upstream.
+
+    A failed diff must rebuild everything; a clean diff that found nothing
+    must rebuild nothing. Collapsing both to an empty set makes the second
+    case behave like the first.
+    """
+    assert m._changed_paths("no-such-ref", tmp_path) is None
+
+
+def test_self_paths_cover_both_files_that_define_the_matrix(
+    tmp_path: Path,
+) -> None:
+    """A push touching only these matches no recipe prefix.
+
+    Without the escape they would filter down to an empty matrix and merge
+    having built nothing, which is precisely when a build is most wanted.
+    """
+    assert m.SELF_PATHS == {
+        ".github/scripts/recipe_images_matrix.py",
+        ".github/workflows/recipe-images.yml",
+    }

--- a/.github/workflows/recipe-images.yml
+++ b/.github/workflows/recipe-images.yml
@@ -1,0 +1,215 @@
+name: 📦 Recipe Images
+
+# Build a container image for every deployable recipe and publish it to
+# Artifact Registry.
+#
+# Why this exists
+# ---------------
+# `.agents/skills/make-python-recipe-deployable` writes the files a recipe
+# needs in order to be served — Dockerfile, fast_api_app.py, and the
+# app_utils/ adapters that satisfy the Agent Engine container contract — and
+# then deliberately stops: "Image builds happen later via Cloud Build →
+# Artifact Registry." Nothing did that later step, so a recipe could be
+# marked deployable and still have no image anyone could deploy.
+#
+# The images matter beyond this repo. Agent Engine can deploy an agent
+# straight from a prebuilt image (`container_spec.image_uri`), which skips
+# the multi-minute per-deployment source build that App Design Center pays
+# today. That only works if a published image exists, which is what this
+# workflow guarantees.
+#
+# Public registry, on purpose
+# ---------------------------
+# adk-recipes-registry grants roles/artifactregistry.reader to allUsers. A
+# consumer deploying one of these recipes into their own project has Agent
+# Engine pull the image with its own service agent, in a project we have
+# never heard of. Public read is what removes the otherwise unbounded set of
+# per-consumer IAM grants. These images contain only Apache-2.0 sample code
+# already published in this repository — no secrets, no customer data.
+#
+# Three triggers, two different questions
+# ---------------------------------------
+# `push` asks "did this change break its own image?" and rebuilds only the
+# recipes the push touched. `schedule` asks a question no push can: the
+# Dockerfiles pin python:3.12-slim and resolve dependencies at build time, so
+# an image that built cleanly last month may pick up a patched base layer or
+# fail against a yanked release today. Weekly is frequent enough to surface
+# that while it is still someone's working memory, and cheap because the
+# matrix is small.
+#
+# Images are never deleted here. Tag hygiene and retention belong to a
+# registry policy, not to the job that writes them.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Retired roots (python/agents, java/agents, ...) are absent on
+      # purpose; see `frozen_paths` in .github/policy.yml. They still contain
+      # Dockerfiles, and publishing from code that is closed to fixes would
+      # be worse than publishing nothing.
+      - "core/**"
+      - "contrib/**"
+      - "skills/**"
+      - ".github/workflows/recipe-images.yml"
+      - ".github/scripts/recipe_images_matrix.py"
+  schedule:
+    # Weekly, Tuesday 04:23 UTC. Off the hour and off Monday: scheduled runs
+    # are best-effort and GitHub sheds them under scheduler load, and the
+    # contended slots are the top of the hour and the start of the week.
+    - cron: "23 4 * * 2"
+  workflow_dispatch:
+    inputs:
+      recipe:
+        description: "Limit to one recipe path (e.g. core/python/ambient-expense-agent)"
+        type: string
+        required: false
+      dry_run:
+        description: "Build the images but do not push them"
+        type: boolean
+        default: false
+
+# Declared per job. At workflow level every job would inherit `id-token:
+# write` purely because `build` needs it to mint a WIF token (zizmor
+# `excessive-permissions`).
+permissions: {}
+
+concurrency:
+  # Serialized per ref rather than cancelled: a half-finished matrix leaves
+  # some recipes published at the new commit and some at the old one, which
+  # is a worse state to debug than a queued run.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  WORKLOAD_IDENTITY_PROVIDER: projects/148460639759/locations/global/workloadIdentityPools/adk-samples-github-pool/providers/adk-samples-github-provider
+  SERVICE_ACCOUNT: wif-service-account@adk-samples-repo-gcp-support.iam.gserviceaccount.com
+  REGISTRY_HOST: us-west1-docker.pkg.dev
+
+jobs:
+  matrix:
+    name: Build image matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      count: ${{ steps.build.outputs.count }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+          # `--changed-from` diffs against the push's base commit, which has
+          # to be in the local history for the diff to mean anything.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # ratchet:actions/setup-python@v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Discover recipes with a root Dockerfile
+        id: build
+        env:
+          # A scheduled run rebuilds everything by design; only a push scopes
+          # itself to what it touched.
+          CHANGED_FROM: ${{ github.event_name == 'push' && github.event.before || '' }}
+          RECIPE: ${{ inputs.recipe }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ -n "${CHANGED_FROM}" ] && [ "${CHANGED_FROM}" != "0000000000000000000000000000000000000000" ]; then
+            args+=(--changed-from "${CHANGED_FROM}")
+          fi
+          if [ -n "${RECIPE}" ]; then
+            args+=(--recipe "${RECIPE}")
+          fi
+          matrix=$(python3 .github/scripts/recipe_images_matrix.py "${args[@]}")
+          count=$(printf '%s' "${matrix}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["include"]))')
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+          echo "Recipes to build: ${count}"
+          printf '%s' "${matrix}" | python3 -m json.tool
+
+  build:
+    name: ${{ matrix.path }}
+    needs: matrix
+    if: needs.matrix.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Minting the OIDC token that Workload Identity Federation exchanges
+      # for a short-lived Google credential. No JSON key exists anywhere.
+      id-token: write
+    strategy:
+      # One broken recipe should not hide the state of every other one.
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Log in to Artifact Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # ratchet:docker/login-action@v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # ratchet:docker/setup-buildx-action@v4.3.0
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # ratchet:docker/build-push-action@v7.3.0
+        with:
+          context: ${{ matrix.path }}
+          file: ${{ matrix.path }}/Dockerfile
+          # `latest` for humans and for docs that cannot chase a digest;
+          # the commit tag so a deployed image can be traced to the source
+          # that produced it. A dry run builds both and pushes neither.
+          push: ${{ !inputs.dry_run }}
+          tags: |
+            ${{ matrix.image }}:latest
+            ${{ matrix.image }}:${{ github.sha }}
+          build-args: |
+            AGENT_VERSION=${{ github.sha }}
+          provenance: false
+          # Shared across runs of the same recipe, not across recipes: these
+          # images share a base layer but nothing above it, and a common
+          # scope would have them evicting each other's dependency layers.
+          cache-from: type=gha,scope=${{ matrix.path }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.path }}
+
+      - name: Report
+        env:
+          IMAGE: ${{ matrix.image }}
+          SHA: ${{ github.sha }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### ${IMAGE}"
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "Built, not pushed (dry run)."
+            else
+              echo '```'
+              echo "${IMAGE}:latest"
+              echo "${IMAGE}:${SHA}"
+              echo '```'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/recipe-images.yml
+++ b/.github/workflows/recipe-images.yml
@@ -30,12 +30,14 @@ name: 📦 Recipe Images
 # Three triggers, two different questions
 # ---------------------------------------
 # `push` asks "did this change break its own image?" and rebuilds only the
-# recipes the push touched. `schedule` asks a question no push can: the
-# Dockerfiles pin python:3.12-slim and resolve dependencies at build time, so
-# an image that built cleanly last month may pick up a patched base layer or
-# fail against a yanked release today. Weekly is frequent enough to surface
-# that while it is still someone's working memory, and cheap because the
-# matrix is small.
+# recipes the push touched. `schedule` asks a question no push can. Every one
+# of these Dockerfiles resolves its dependencies at build time, and they do
+# not even agree on a base: python:3.11-slim, python:3.12-slim,
+# python:3.13-slim and ghcr.io/astral-sh/uv:python3.11-bookworm-slim are all
+# in use today. An image that built cleanly last month can pick up a patched
+# base layer, or fail outright against a yanked release, without a single
+# commit landing. Weekly is frequent enough to surface that while it is still
+# someone's working memory, and cheap because the matrix is small.
 #
 # Images are never deleted here. Tag hygiene and retention belong to a
 # registry policy, not to the job that writes them.
@@ -97,6 +99,9 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
       count: ${{ steps.build.outputs.count }}
+      # Computed once here rather than per matrix leg, so every image from a
+      # given run carries the same tag even if the legs straddle midnight UTC.
+      build_tag: ${{ steps.tag.outputs.value }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v4
@@ -110,6 +115,14 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # ratchet:actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
+
+      - name: Compute build tag
+        id: tag
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "value=$(date -u +%Y%m%d)-${SHA:0:12}" >> "${GITHUB_OUTPUT}"
 
       - name: Discover recipes with a root Dockerfile
         id: build
@@ -179,13 +192,19 @@ jobs:
         with:
           context: ${{ matrix.path }}
           file: ${{ matrix.path }}/Dockerfile
-          # `latest` for humans and for docs that cannot chase a digest;
-          # the commit tag so a deployed image can be traced to the source
-          # that produced it. A dry run builds both and pushes neither.
+          # `latest` for humans and for docs that cannot chase a digest.
+          #
+          # The pinnable tag is date-and-commit, not commit alone. The weekly
+          # rebuild runs against an unchanged HEAD and produces a genuinely
+          # different image — that is the whole point of it, since these
+          # Dockerfiles resolve dependencies and base layers at build time —
+          # so a bare `:<sha>` would be rewritten every Tuesday and would not
+          # mean what a commit-shaped tag implies. Dating it keeps every
+          # published image immutable and still traceable to its source.
           push: ${{ !inputs.dry_run }}
           tags: |
             ${{ matrix.image }}:latest
-            ${{ matrix.image }}:${{ github.sha }}
+            ${{ matrix.image }}:${{ needs.matrix.outputs.build_tag }}
           build-args: |
             AGENT_VERSION=${{ github.sha }}
           provenance: false
@@ -198,7 +217,7 @@ jobs:
       - name: Report
         env:
           IMAGE: ${{ matrix.image }}
-          SHA: ${{ github.sha }}
+          BUILD_TAG: ${{ needs.matrix.outputs.build_tag }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
@@ -209,7 +228,7 @@ jobs:
             else
               echo '```'
               echo "${IMAGE}:latest"
-              echo "${IMAGE}:${SHA}"
+              echo "${IMAGE}:${BUILD_TAG}"
               echo '```'
             fi
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
make-python-recipe-deployable writes the serving files a recipe needs —
Dockerfile, fast_api_app.py, and the app_utils/ adapters implementing the
Agent Engine container contract — and then stops, on the stated assumption
that "image builds happen later via Cloud Build → Artifact Registry".
Nothing did that later step, so a recipe could satisfy every deployability
check and still have no image anyone could pull.

That gap has a consumer waiting on it. Agent Engine can deploy an agent
directly from a prebuilt image via container_spec.image_uri, which skips the
multi-minute per-deployment source build that App Design Center pays on every
deploy today. The saving is only available to recipes that have a published
image.

recipe_images_matrix.py decides what gets built. Three constraints shape it,
each of which produces a wrong answer if dropped:

  * Live roots only. SCAN_ROOTS is imported from recipe_manifests rather than
    restated, because the retired roots in policy.yml frozen_paths still
    contain Dockerfiles and would otherwise publish images from code that is
    closed to fixes.
  * Recipe-root Dockerfiles only. multiformat-hybrid-rag ships three; two are
    data-ingestion sub-services with their own lifecycles, and publishing
    them under a recipe image name would misrepresent what the image is.
  * A manifest.yaml must sit beside the Dockerfile. Without that test,
    skills/retail/virtual-tryon/assets/export-template is mistaken for a
    recipe and derives "retail" as its language.

Images are named <language>/<recipe>, dropping the root segment so that
promoting a recipe from contrib/ to core/ does not rename the image out from
under anyone who pinned it. Language is retained because core/kotlin/
llm-auditor and contrib/python/llm-auditor coexist.

The workflow rebuilds only what a push touched, and everything weekly — the
Dockerfiles pin python:3.12-slim and resolve dependencies at build time, so
an image that built cleanly last month can fail today against a patched base
layer or a yanked release, which no push-triggered run would ever notice.

Authentication is Workload Identity Federation against the pool already
configured for this repository; no key material is introduced. The target
repository grants allUsers artifactregistry.reader, which is what lets Agent
Engine pull an image into a customer tenant without a per-consumer IAM grant.
The images hold only Apache-2.0 sample code already published here.

